### PR TITLE
Support Multiple Backends

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -1,22 +1,85 @@
 package backends
 
 import (
+	"fmt"
+
 	"github.com/dotcloud/docker/engine"
 )
 
-// New returns a new engine, with all backends
-// registered but not activated.
-// To activate a backend, call a job on the resulting
-// engine, named after the desired backend.
-//
-// Example: `New().Job("debug").Run()`
-func New() *engine.Engine {
-	back := engine.New()
-	back.Logging = false
+func NewMux() *EngineMux {
+	engineMux := &EngineMux{
+		enabled: make(map[string]*engine.Engine),
+		engines: make(map[string]*engine.Engine),
+	}
+
 	// Register all backends here
-	Debug().Install(back)
-	Simulator().Install(back)
-	Forward().Install(back)
-	CloudBackend().Install(back)
-	return back
+	engineMux.Register("debug", Debug())
+	engineMux.Register("simulator", Simulator())
+	engineMux.Register("forward", Forward())
+	engineMux.Register("cloud", CloudBackend())
+
+	return engineMux
+}
+
+type EngineMux struct {
+	enabled map[string]*engine.Engine
+	engines map[string]*engine.Engine
+}
+
+func (em *EngineMux) Install(eng *engine.Engine) (err error) {
+	eng.RegisterCatchall(em.handler)
+	return
+}
+
+func (em *EngineMux) handler(parentJob *engine.Job) (status engine.Status) {
+	for name, eng := range em.enabled {
+		// FIXME: This could get hairy if more than one backend tries to write
+		// to stdout.
+		nextJob := eng.Job(parentJob.Name, parentJob.Args...)
+		nextJob.Stdout.Add(parentJob.Stdout)
+		nextJob.Stderr.Add(parentJob.Stderr)
+		nextJob.Stdin.Add(parentJob.Stdin)
+
+		for key, val := range parentJob.Env().Map() {
+			nextJob.Setenv(key, val)
+		}
+
+		if err := nextJob.Run(); err != nil {
+			parentJob.Logf("Error occured while dispatching job to engine: %s. Reason: %v", name, err)
+		}
+	}
+
+	return engine.StatusOK
+}
+
+func (em *EngineMux) GetEngine(name string) (eng *engine.Engine, found bool) {
+	eng, found = em.engines[name]
+	return
+}
+
+func (em *EngineMux) Enable(name string, args ...string) (err error) {
+	if _, found := em.enabled[name]; found {
+		err = fmt.Errorf("Engine %s already enabled.", name)
+	} else {
+		if targetEngine, found := em.engines[name]; found {
+			if err = targetEngine.Job(name, args...).Run(); err == nil {
+				em.enabled[name] = targetEngine
+			}
+		} else {
+			err = fmt.Errorf("No engine registered as: %s.", name)
+		}
+	}
+
+	return
+}
+
+func (em *EngineMux) Register(name string, installer engine.Installer) (err error) {
+	targetEngine, found := em.engines[name]
+
+	if !found {
+		targetEngine = engine.New()
+		em.engines[name] = targetEngine
+	}
+
+	return installer.Install(targetEngine)
 }

--- a/backends/debug.go
+++ b/backends/debug.go
@@ -1,7 +1,6 @@
 package backends
 
 import (
-	"fmt"
 	"github.com/dotcloud/docker/engine"
 	"strings"
 )
@@ -16,14 +15,9 @@ type debug struct {
 func (d *debug) Install(eng *engine.Engine) error {
 	eng.Register("debug", func(job *engine.Job) engine.Status {
 		job.Eng.RegisterCatchall(func(job *engine.Job) engine.Status {
-			fmt.Printf("--> %s %s\n", job.Name, strings.Join(job.Args, " "))
+			job.Logf("--> %s %s\n", job.Name, strings.Join(job.Args, " "))
 			for k, v := range job.Env().Map() {
-				fmt.Printf("        %s=%s\n", k, v)
-			}
-			// This helps us detect the race condition if our time.Sleep
-			// missed it. (see comment in main)
-			if job.Name == "acceptconnections" {
-				panic("race condition in github.com/dotcloud/docker/api/server/ServeApi")
+				job.Logf("        %s=%s\n", k, v)
 			}
 			return engine.StatusOK
 		})


### PR DESCRIPTION
This commit contains the code necessary to multiplex jobs from the frontend engine to multiple backend engines.

This is done by modifying the behaviour of **--backend** slightly. The argument has been changed to **--backends** and now expects a string argument where backends and their associated arguments are delimited by semi-colons.

``` bash
./swarmd --backends "simulator test1 test2; debug" unix:///tmp/socket
```
