### PR TITLE
Correct backend for pass-through is 'forward' not 'dockerclient'

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ of each backend connected to the input of the next, just like unix pipelines.
 This allows for very powerful composition.
 
 ```
-./swarmd 'dockerserver tcp://localhost:4243' 'debug' 'dockerclient unix:///var/run/docker.sock'
+./swarmd 'dockerserver tcp://localhost:4243' 'debug' 'forward unix:///var/run/docker.sock'
 ```
 
 ## Creators


### PR DESCRIPTION
In current HEAD, the correct backend name is `forward` not `dockerclient`. This PR fixes the documentation to match.
