### PR TITLE
Parse the docker server URL with the net/url Parse() function.

### DIFF
--- a/backends/dockerserver.go
+++ b/backends/dockerserver.go
@@ -48,11 +48,19 @@ func listenAndServe(urlStr string, out beam.Sender) error {
 		return err
 	}
 
-	l, err := net.Listen(parsedUrl.Scheme, parsedUrl.Host)
+	var hostAndPath string
+	// For Unix sockets we need to capture the path as well as the host
+	if parsedUrl.Scheme == "unix" {
+		hostAndPath = "/" + parsedUrl.Host + parsedUrl.Path
+	} else {
+		hostAndPath = parsedUrl.Host
+	}
+
+	l, err := net.Listen(parsedUrl.Scheme, hostAndPath)
 	if err != nil {
 		return err
 	}
-	httpSrv := http.Server{Addr: parsedUrl.Host, Handler: r}
+	httpSrv := http.Server{Addr: hostAndPath, Handler: r}
 	return httpSrv.Serve(l)
 }
 


### PR DESCRIPTION
This is a small fix to the `dockerserver` backend to use the Go stdlib `net/url` `Parse()` function rather than string splitting to parse it. This should be much more robust and return better error messages.

The `net/url` package is already a dependency of other backends.
