### PR TITLE
Add call to directly get the client

### DIFF
--- a/server.go
+++ b/server.go
@@ -115,3 +115,7 @@ func (s *Server) Close() error {
 func (s *Server) Unwrap() libchan.Sender {
 	return &senderUnwrapper{s}
 }
+
+func (s *Server) Client() *Client {
+	return AsClient(s)
+}


### PR DESCRIPTION
Allows for syntax such as:

``` go
backend := libswarm.NewServer()

backend.Client().Ls()

// Which is a shortcut for:
client := libswarm.AsClient(backend)
client.Ls()
```

Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
