### PR TITLE
Support Post docker hostconfig.

### DIFF
--- a/backends/aggregate.go
+++ b/backends/aggregate.go
@@ -90,9 +90,9 @@ func (a *aggregator) attach(name string, ret libswarm.Sender) error {
 	return nil
 }
 
-func (a *aggregator) start() error {
+func (a *aggregator) start(config string) error {
 	for _, b := range a.backends {
-		err := b.Start()
+		err := b.Start(config)
 		if err != nil {
 			return err
 		}

--- a/backends/dockerclient.go
+++ b/backends/dockerclient.go
@@ -82,7 +82,7 @@ func (b *dockerClientBackend) attach(name string, ret libswarm.Sender) error {
 	return nil
 }
 
-func (b *dockerClientBackend) start() error {
+func (b *dockerClientBackend) start(config string) error {
 	return nil
 }
 
@@ -232,9 +232,12 @@ func (c *container) attach(name string, ret libswarm.Sender) error {
 	return nil
 }
 
-func (c *container) start() error {
+func (c *container) start(config string) error {
+	if config == "" {
+		config = "{}"
+	}
 	path := fmt.Sprintf("/containers/%s/start", c.id)
-	resp, err := c.backend.client.call("POST", path, "{}")
+	resp, err := c.backend.client.call("POST", path, config)
 	if err != nil {
 		return err
 	}
@@ -316,6 +319,12 @@ func (c *client) call(method, path, body string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	} else if method == "POST" {
+		req.Header.Set("Content-Type", "plain/text")
+	}
+
 	httpClient := &http.Client{Transport: c.transport}
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/backends/dockerclient_test.go
+++ b/backends/dockerclient_test.go
@@ -33,7 +33,7 @@ func TestAttachAndStart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = i.Start()
+	err = i.Start("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,6 +137,30 @@ func TestGetChild(t *testing.T) {
 
 func TestStartChild(t *testing.T) {
 	name := "foo"
+	config := "{\"PortBindings\":{\"4000/tcp\":[{\"HostIp\":\"\",\"HostPort\":\"80\"}]}}"
+	server := makeServer(t, &requestStub{
+		reqMethod: "GET",
+		reqPath:   fmt.Sprintf("/containers/%s/json", name),
+
+		resBody: "{}",
+	}, &requestStub{
+		reqMethod: "POST",
+		reqPath:   fmt.Sprintf("/containers/%s/start", name),
+		reqBody:   config,
+
+		resStatus: 204,
+	})
+	i := instance(t, server)
+	c := child(t, server, i, name)
+	err := c.Start(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Check()
+}
+
+func TestStartEmptyConfig(t *testing.T) {
+	name := "foo"
 	server := makeServer(t, &requestStub{
 		reqMethod: "GET",
 		reqPath:   fmt.Sprintf("/containers/%s/json", name),
@@ -151,7 +175,7 @@ func TestStartChild(t *testing.T) {
 	})
 	i := instance(t, server)
 	c := child(t, server, i, name)
-	err := c.Start()
+	err := c.Start("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backends/dockerserver.go
+++ b/backends/dockerserver.go
@@ -260,7 +260,10 @@ func postContainersStart(out libswarm.Sender, version version.Version, w http.Re
 		return fmt.Errorf("Missing parameter")
 	}
 
-	// TODO: r.Body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
 
 	name := vars["name"]
 	_, containerOut, err := libswarm.AsClient(out).Attach(name)
@@ -268,7 +271,7 @@ func postContainersStart(out libswarm.Sender, version version.Version, w http.Re
 	if err != nil {
 		return err
 	}
-	if err := container.Start(); err != nil {
+	if err := container.Start(string(body)); err != nil {
 		return err
 	}
 

--- a/client.go
+++ b/client.go
@@ -171,8 +171,8 @@ func (c *Client) Watch() (Receiver, error) {
 	return nil, fmt.Errorf("unexpected verb %v", msg.Verb)
 }
 
-func (c *Client) Start() error {
-	ret, err := c.Send(&Message{Verb: Start, Ret: RetPipe})
+func (c *Client) Start(config string) error {
+	ret, err := c.Send(&Message{Verb: Start, Args: []string{config}, Ret: RetPipe})
 	msg, err := ret.Receive(0)
 	if err == io.EOF {
 		return fmt.Errorf("unexpected EOF")

--- a/server.go
+++ b/server.go
@@ -78,9 +78,13 @@ func (s *Server) OnGet(h func() (string, error)) *Server {
 	}))
 }
 
-func (s *Server) OnStart(h func() error) *Server {
+func (s *Server) OnStart(h func(string) error) *Server {
 	return s.OnVerb(Start, Handler(func(msg *Message) error {
-		if err := h(); err != nil {
+		config := ""
+		if len(msg.Args) > 0 {
+			config = msg.Args[0]
+		}
+		if err := h(config); err != nil {
 			return err
 		}
 		_, err := msg.Ret.Send(&Message{Verb: Ack})

--- a/swarmd/swarmd.go
+++ b/swarmd/swarmd.go
@@ -67,7 +67,7 @@ func cmdDaemon(c *cli.Context) {
 			}
 			w.Close()
 		}(previousInstanceR, instanceW, idx)
-		if err := instance.Start(); err != nil {
+		if err := instance.Start(""); err != nil {
 			Fatalf("start: %v", err)
 		}
 		previousInstanceR = instanceR


### PR DESCRIPTION
Libswarm dockerclient does not support call start API with hostconfig.
Therefore, I add to "StartWithConfig" method.
(Change client.Start method too hard ...)

Docker-DCO-1.1-Signed-off-by: Yutaka Matsubara yutaka.matsubara@gmail.com (github: mopemope)
