### PR TITLE
WIP: Add libchan client/server transports

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -25,5 +25,7 @@ func New() *libswarm.Client {
 	backends.Bind("shipyard", Shipyard())
 	backends.Bind("ec2", Ec2())
 	backends.Bind("tutum", Tutum())
+	backends.Bind("libchanserver", LibchanServer())
+	backends.Bind("libchanclient", LibchanClient())
 	return libswarm.AsClient(backends)
 }

--- a/backends/libchanclient.go
+++ b/backends/libchanclient.go
@@ -1,0 +1,89 @@
+package backends
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/docker/libchan/http2"
+	"github.com/docker/libswarm"
+)
+
+type libchanClient struct {
+	*libswarm.Server
+	url    string
+	remote libswarm.Sender
+}
+
+func LibchanClient() libswarm.Sender {
+	backend := libswarm.NewServer()
+	backend.OnSpawn(func(cmd ...string) (libswarm.Sender, error) {
+
+		s := &libchanClient{Server: libswarm.NewServer()}
+
+		s.url = "http2://localhost:9000"
+		if len(cmd) > 0 {
+			s.url = cmd[0]
+		}
+
+		s.OnAttach(s.attach)
+		s.OnVerb(libswarm.Start, libswarm.Handler(s.start))
+		s.Catchall(libswarm.Handler(s.catchall))
+		return s.Server, nil
+	})
+	return backend
+}
+
+func (s *libchanClient) attach(name string, ret libswarm.Sender) error {
+	ret.Send(&libswarm.Message{Verb: libswarm.Ack, Ret: s})
+	<-make(chan struct{})
+	return nil
+}
+
+func (s *libchanClient) start(msg *libswarm.Message) error {
+	remote, err := s.dial()
+	if err != nil {
+		return err
+	}
+	forwardedMsg := msg
+	remote.Send(forwardedMsg)
+
+	return nil
+}
+
+func (s *libchanClient) catchall(msg *libswarm.Message) (err error) {
+	forwardedMsg := msg
+	s.remote.Send(forwardedMsg)
+
+	return nil
+}
+
+func (s *libchanClient) dial() (libswarm.Sender, error) {
+	parsedUrl, err := url.Parse(s.url)
+	if err != nil {
+		return nil, err
+	}
+
+	switch parsedUrl.Scheme {
+	case "http2":
+		return s.dialHttp2(parsedUrl.Host)
+	default:
+		return nil, fmt.Errorf("libchanClient: Protocol not implemented - %s", parsedUrl.Scheme)
+	}
+}
+
+func (s *libchanClient) dialHttp2(host string) (libswarm.Sender, error) {
+	conn, err := net.Dial("tcp", host)
+	if err != nil {
+		return nil, fmt.Errorf("libchanClient http2: Error dialing %v - %v", host, err)
+	}
+
+	session, err := http2.NewStreamSession(conn)
+	if err != nil {
+		return nil, fmt.Errorf("libchanClient http2: Error establishing spdy stream to %v - %v", host, err)
+	}
+
+	sender, err := session.NewSender()
+	return libswarm.WrapSender(sender), err
+
+}

--- a/backends/libchanserver.go
+++ b/backends/libchanserver.go
@@ -1,0 +1,155 @@
+package backends
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+
+	"github.com/docker/libchan/http2"
+	"github.com/docker/libswarm"
+	"github.com/docker/libswarm/utils"
+)
+
+type libchanServer struct {
+	out libswarm.Sender
+	*libswarm.Server
+}
+
+type libchanHttp2Server struct {
+	*libchanServer
+}
+
+func LibchanServer() libswarm.Sender {
+	backend := libswarm.NewServer()
+	backend.OnVerb(libswarm.Spawn, libswarm.Handler(func(ctx *libswarm.Message) error {
+		s := &libchanServer{Server: libswarm.NewServer()}
+		instance := utils.Task(func(in libswarm.Receiver, out libswarm.Sender) {
+
+			s.out = out
+
+			url := "http2://localhost:9000"
+			if len(ctx.Args) > 0 {
+				url = ctx.Args[0]
+			}
+			s.Catchall(libswarm.Handler(s.catchall))
+
+			err := s.listenAndServe(url)
+			if err != nil {
+				fmt.Printf("libchanserver: %v", err)
+			}
+		})
+
+		_, err := ctx.Ret.Send(&libswarm.Message{Verb: libswarm.Ack, Ret: instance})
+		return err
+	}))
+	return backend
+}
+
+func (s *libchanServer) catchall(msg *libswarm.Message) error {
+	forwardedMsg := msg
+	//forwardedMsg.Ret = libswarm.RetPipe
+	_, err := s.out.Send(forwardedMsg)
+	if err != nil {
+		return err
+	}
+
+	//if inbound, err := s.out.Send(forwardedMsg); err != nil {
+	//	return fmt.Errorf("libchanserver: Failed to forward msg. Reason: %v\n", err)
+	//} else if inbound == nil {
+	//	return fmt.Errorf("libchanserver: Inbound channel nil.\n")
+	//} else {
+	//	for {
+	//		// Relay all messages returned until the inbound channel is empty (EOF)
+	//		var reply *libswarm.Message
+	//		if reply, err = inbound.Receive(0); err != nil {
+	//			if err == io.EOF {
+	//				// EOF is expected
+	//				err = nil
+	//			}
+	//			break
+	//		}
+
+	//		// Forward the message back downstream
+	//		if _, err = msg.Ret.Send(reply); err != nil {
+	//			return fmt.Errorf("libchanserver: Failed to forward msg. Reason: %v\n", err)
+	//		}
+	//	}
+	//}
+	return nil
+}
+
+func (s *libchanServer) listenAndServe(urlStr string) error {
+	parsedUrl, err := url.Parse(urlStr)
+	if err != nil {
+		return err
+	}
+
+	switch parsedUrl.Scheme {
+	case "http2":
+		http2srv := &libchanHttp2Server{s}
+		return http2srv.listenAndServe(parsedUrl.Host)
+	default:
+		return fmt.Errorf("libchanserver: Protocol not implemented - %s", parsedUrl.Scheme)
+	}
+}
+
+func (s *libchanHttp2Server) listenAndServe(host string) error {
+	listener, err := net.Listen("tcp", host)
+	if err != nil {
+		return err
+	}
+
+	session, err := http2.NewListenSession(listener, s.auth)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		session.Close()
+	}()
+	for {
+		stream, err := session.AcceptSession()
+
+		if err != nil {
+			return err
+		}
+		go s.handleConn(stream)
+	}
+}
+
+func (s *libchanHttp2Server) handleConn(stream *http2.StreamSession) {
+	defer func() {
+		stream.Close()
+	}()
+	r, err := stream.ReceiverWait()
+	if err != nil {
+		fmt.Errorf("libchanserver http2: %v", err)
+		return
+	}
+	remote := libswarm.WrapReceiver(r)
+	if err = s.Copy(remote); err != nil {
+		fmt.Errorf("libchanserver http2: %v", err)
+	}
+}
+
+func (s *libchanServer) Copy(src libswarm.Receiver) error {
+	for {
+		msg, err := src.Receive(0)
+		if err == io.EOF {
+			err = nil
+		}
+		if err != nil {
+			return fmt.Errorf("libchanserver http2: %v", err)
+		}
+		if err = s.catchall(msg); err != nil {
+			return fmt.Errorf("libchanserver http2: %v", err)
+		}
+	}
+	return nil
+}
+
+func (s *libchanHttp2Server) auth(conn net.Conn) error {
+	fmt.Printf("Verifying credentials...")
+	fmt.Println("Much secure!")
+	return nil
+}


### PR DESCRIPTION
This is not ready yet.

Adds transports for libchan client/server so, for instance,
backends can communite over libchan/http2

Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
