### PR TITLE
Added a help wanted note for SkyDNS and SkyDNS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ This service can be used to control a Docker Engine from libswarm services. It t
 
 *Help wanted!*
 
+### SkyDNS
+
+*Help wanted!*
+
+### SkyDNS2
+
+*Help wanted!*
+
 ### Geard
 
 *Clayton Coleman*


### PR DESCRIPTION
SkyDNS and SkyDNS2 are missing and they could be used to replace Consul completely since they support DNS service discovery.
