### PR TITLE
Fix compilation issues on master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ the same rules and principles. If you're already familiar with the way
 Docker does things, you'll feel right at home.
 
 Otherwise, go read
-[Docker's contributions guidelines](https://github.com/dotcloud/docker/blob/master/CONTRIBUTING.md).
+[Docker's contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
 
 Happy hacking!

--- a/backends/cloud.go
+++ b/backends/cloud.go
@@ -17,12 +17,13 @@ package backends
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dotcloud/docker/engine"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/docker/docker/engine"
 )
 
 // The Cloud interface provides the contract that cloud providers should implement to enable

--- a/backends/dockerclient.go
+++ b/backends/dockerclient.go
@@ -4,10 +4,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/libswarm"
-	"github.com/docker/libswarm/utils"
-	"github.com/dotcloud/docker/engine"
-	dockerutils "github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
 	"net"
@@ -15,6 +11,11 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+
+	"github.com/docker/docker/engine"
+	dockerutils "github.com/docker/docker/utils"
+	"github.com/docker/libswarm"
+	"github.com/docker/libswarm/utils"
 )
 
 type DockerClientConfig struct {

--- a/backends/dockerserver.go
+++ b/backends/dockerserver.go
@@ -3,13 +3,6 @@ package backends
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/docker/libswarm"
-	"github.com/docker/libswarm/utils"
-	"github.com/dotcloud/docker/api"
-	"github.com/dotcloud/docker/pkg/version"
-	dockerContainerConfig "github.com/dotcloud/docker/runconfig"
-	dockerutils "github.com/dotcloud/docker/utils"
-	"github.com/gorilla/mux"
 	"io"
 	"io/ioutil"
 	"net"
@@ -19,6 +12,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/docker/docker/api"
+	"github.com/docker/docker/pkg/version"
+	dockerContainerConfig "github.com/docker/docker/runconfig"
+	dockerutils "github.com/docker/docker/utils"
+	"github.com/docker/libswarm"
+	"github.com/docker/libswarm/utils"
+	"github.com/gorilla/mux"
 )
 
 func DockerServer() libswarm.Sender {

--- a/backends/rax.go
+++ b/backends/rax.go
@@ -31,8 +31,8 @@ import (
 	"time"
 
 	"github.com/codegangsta/cli"
-	"github.com/dotcloud/docker/engine"
-	"github.com/dotcloud/docker/runconfig"
+	"github.com/docker/docker/engine"
+	"github.com/docker/docker/runconfig"
 	"github.com/rackspace/gophercloud"
 )
 

--- a/backends/tutum.go
+++ b/backends/tutum.go
@@ -3,14 +3,15 @@ package backends
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/docker/libswarm"
-	"github.com/dotcloud/docker/engine"
-	"github.com/tutumcloud/go-tutum"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/engine"
+	"github.com/docker/libswarm"
+	"github.com/tutumcloud/go-tutum"
 )
 
 var (

--- a/swarmd/Godeps/Godeps.json
+++ b/swarmd/Godeps/Godeps.json
@@ -41,104 +41,104 @@
 			"Rev": "459978d483ec79a7d8e980ebca00eb950eb64931"
 		},
 		{
-			"ImportPath": "github.com/docker/libcontainer/cgroups",
-			"Comment": "v1.1.0-56-gfb3d909",
-			"Rev": "fb3d909c288ab23f005ddbbdd8bc81c36a1cd701"
+			"ImportPath": "github.com/docker/docker/vendor/src/github.com/docker/libcontainer/cgroups",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/docker/libcontainer/devices",
-			"Comment": "v1.1.0-56-gfb3d909",
-			"Rev": "fb3d909c288ab23f005ddbbdd8bc81c36a1cd701"
+			"ImportPath": "github.com/docker/docker/vendor/src/github.com/docker/libcontainer/devices",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/api",
+			"ImportPath": "github.com/docker/docker/api",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/dockerversion",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/engine",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/nat",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/opts",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/listenbuffer",
 			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/dockerversion",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/mflag",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/engine",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/mount",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/nat",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/sysinfo",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/opts",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/systemd",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/listenbuffer",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/term",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/mflag",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/units",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/mount",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/vendor/src/github.com/docker/libcontainer",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/sysinfo",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/pkg/version",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/systemd",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/registry",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/term",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/runconfig",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/units",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/utils",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/user",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
-		},
-		{
-			"ImportPath": "github.com/dotcloud/docker/pkg/version",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
-		},
-		{
-			"ImportPath": "github.com/dotcloud/docker/registry",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
-		},
-		{
-			"ImportPath": "github.com/dotcloud/docker/runconfig",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
-		},
-		{
-			"ImportPath": "github.com/dotcloud/docker/utils",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
-		},
-		{
-			"ImportPath": "github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar",
-			"Comment": "v0.11.1-466-g77ae37a",
-			"Rev": "77ae37a3836997d215ed3f1750533a9815205695"
+			"ImportPath": "github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar",
+			"Comment": "master 2014-08-13",
+			"Rev": "8c38a3d7321b75b2344dbf3efaf1e93437f9bac0"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-shlex",
@@ -188,6 +188,12 @@
 			"ImportPath": "launchpad.net/goamz/ec2",
 			"Comment": "48",
 			"Rev": "ian.booth@canonical.com-20140708164959-72q70lo1du0e4qki"
+		},
+		{
+			"ImportPath": "github.com/docker/spdystream",
+			"Comment": "master",
+			"Rev": "0e1a22f802ad9bed787cba4ad3d041932958276d"
 		}
 	]
 }
+

--- a/swarmd/swarmd.go
+++ b/swarmd/swarmd.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
-	"github.com/docker/libswarm/backends"
-	"github.com/docker/libswarm"
-	_ "github.com/dotcloud/docker/api/server"
-	"github.com/flynn/go-shlex"
 	"io"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/codegangsta/cli"
+	_ "github.com/docker/docker/api/server"
+	"github.com/docker/libswarm"
+	"github.com/docker/libswarm/backends"
+	"github.com/flynn/go-shlex"
 )
 
 func main() {


### PR DESCRIPTION
s/dotcloud/docker
Had to bump commit versions for stuff in docker repo because of references back to dotcloud/docker within those packages
Using libcontainer from docker/vendor to make things simpler.
Could not use any tagged version for the docker packages since repo changed after last tag.

Also disabled tutum since this appears to be broken and is not compilable.

Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
