### PR TITLE
DockerClient: Fix client.urlHost always stays dummy.host instead of the real host url

### DIFF
--- a/backends/dockerclient.go
+++ b/backends/dockerclient.go
@@ -299,6 +299,7 @@ func newClient() *client {
 func (c *client) setURL(url string) {
 	parts := strings.SplitN(url, "://", 2)
 	proto, host := parts[0], parts[1]
+	c.urlHost = host
 	c.transport.Dial = func(_, _ string) (net.Conn, error) {
 		return net.Dial(proto, host)
 	}


### PR DESCRIPTION
In setURL the host for transport.Dial is being set but client.urlHost wasn't updated, so it stayed dummy.host :)
Fixed by setting client.urlHost in setURL.
