### PR TITLE
Fixed cluster/node.go:327: too many arguments in call to n.client.PullIm...

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -324,7 +324,7 @@ func (n *Node) Destroy(container *Container, force bool) error {
 }
 
 func (n *Node) Pull(image string) error {
-	if err := n.client.PullImage(image, nil); err != nil {
+	if err := n.client.PullImage(image); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Running go get

```
go get github.com/docker/swarm
```

results in the following error  : 

```
github.com/docker/swarm/cluster/node.go:327: too many arguments in call to n.client.PullImage
```

Removed the extra nil argument from PullImage to get it working.
