### PR TITLE
Improve README first-play experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ $ swarm create
 6856663cdefdec325839a4b7e1de38e8
 
 # on each of your nodes, start the swarm agent
-$ swarm join --token=6856663cdefdec325839a4b7e1de38e8 --addr=<public_node_ip1:2375>
-$ swarm join --token=6856663cdefdec325839a4b7e1de38e8 --addr=<public_node_ip2:2375>
-$ swarm join --token=6856663cdefdec325839a4b7e1de38e8 --addr=<public_node_ip3:2375>
+$ swarm join --token=6856663cdefdec325839a4b7e1de38e8 --addr=<public_node_ip:2375>
 ...
 
 # start the manager on any machine or your laptop


### PR DESCRIPTION
In the course of experimenting with swarm I was confused by the README, and suggest the following improvements:
1. Use the official Docker port of 2375 everywhere.
2. Highlight that the `--addr` argument requires the public IP of the node to advertise.
3. Do not imply running multiple `swarm join` commands on each node.

I am not happy with `public_node_ip`, as it is not necessarily a public IP, just the node's addressable IP. Suggestions are solicited.
