### PR TITLE
Cluster: Fix empty name container lookup.

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -70,6 +70,10 @@ func (c *Cluster) Containers() []*Container {
 
 // Container returns the container with ID in the cluster
 func (c *Cluster) Container(IdOrName string) *Container {
+	// Abort immediately if the name is empty.
+	if len(IdOrName) == 0 {
+		return nil
+	}
 	for _, container := range c.Containers() {
 		// Match ID prefix.
 		if strings.HasPrefix(container.Id, IdOrName) {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -9,14 +9,19 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func createNode(t *testing.T, ID string) *Node {
+func createNode(t *testing.T, ID string, containers ...dockerclient.Container) *Node {
 	node := NewNode(ID)
+	node.Name = ID
 
 	assert.False(t, node.IsConnected())
 
 	client := mockclient.NewMockClient()
 	client.On("Info").Return(mockInfo, nil)
-	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
+	client.On("ListContainers", true, false, "").Return(containers, nil)
+	client.On("InspectContainer", mock.Anything).Return(
+		&dockerclient.ContainerInfo{
+			Config: &dockerclient.ContainerConfig{CpuShares: 100},
+		}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, node.connectClient(client))
@@ -30,13 +35,42 @@ func TestAddNode(t *testing.T) {
 	c := NewCluster()
 
 	assert.Equal(t, len(c.Nodes()), 0)
+	assert.Nil(t, c.Node("test"))
+	assert.Nil(t, c.Node("test2"))
 
 	assert.NoError(t, c.AddNode(createNode(t, "test")))
 	assert.Equal(t, len(c.Nodes()), 1)
+	assert.NotNil(t, c.Node("test"))
 
 	assert.Error(t, c.AddNode(createNode(t, "test")))
 	assert.Equal(t, len(c.Nodes()), 1)
+	assert.NotNil(t, c.Node("test"))
 
 	assert.NoError(t, c.AddNode(createNode(t, "test2")))
 	assert.Equal(t, len(c.Nodes()), 2)
+	assert.NotNil(t, c.Node("test2"))
+}
+
+func TestLookupContainer(t *testing.T) {
+	c := NewCluster()
+	container := dockerclient.Container{
+		Id:    "container-id",
+		Names: []string{"/container-name1", "/container-name2"},
+	}
+	node := createNode(t, "test-node", container)
+	assert.NoError(t, c.AddNode(node))
+
+	// Invalid lookup
+	assert.Nil(t, c.Container("invalid-id"))
+	assert.Nil(t, c.Container(""))
+	// Container ID lookup.
+	assert.NotNil(t, c.Container("container-id"))
+	// Container ID prefix lookup.
+	assert.NotNil(t, c.Container("container-"))
+	// Container name lookup.
+	assert.NotNil(t, c.Container("container-name1"))
+	assert.NotNil(t, c.Container("container-name2"))
+	// Container node/name matching.
+	assert.NotNil(t, c.Container("test-node/container-name1"))
+	assert.NotNil(t, c.Container("test-node/container-name2"))
 }


### PR DESCRIPTION
Fixed a bug which caused Swarm to issue an error when creating more than
one container with no name.

Added tests for container lookups.

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
