### PR TITLE
proxy simple requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -216,7 +216,7 @@ func proxyContainer(c *context, w http.ResponseWriter, r *http.Request) {
 			r.URL.Host = parts[0]
 		}
 
-		log.Println("[PROXY] -->", r.Method, r.URL)
+		log.Debugf("[PROXY] --> %s %s", r.Method, r.URL)
 		resp, err := client.Do(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Before, `start`, `kill`, `pause` and `unpause` used `dockerclient`, there is no real advantages and it added lots of boilerplate code.

Instead, use a generic proxy method. That better because:
- it's faster, for example for kill we don't have to extract the `signal` parameter anymore
- when docker gets updated, we don't have to wait for `dockerclient` to be updated.
- as it's generic I was able to add `stop`, `restart`, `exec/json`, `resize`, `wait` and `exec/resize` with one line

Also, I removed all the 302 redirect to use this "proxy". This means only the master is required to connect to the nodes.
Your cluster can be on a different network that the docker cli, as long as you have access to the master it'll work.
