### PR TITLE
Add --scheduler option in manage command to prepare pluggable schedulers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -22,7 +22,7 @@ import (
 
 type context struct {
 	cluster       *cluster.Cluster
-	scheduler     *scheduler.Scheduler
+	scheduler     scheduler.Scheduler
 	eventsHandler *eventsHandler
 	debug         bool
 	version       string
@@ -323,7 +323,7 @@ func createRouter(c *context, enableCors bool) (*mux.Router, error) {
 	return r, nil
 }
 
-func ListenAndServe(c *cluster.Cluster, s *scheduler.Scheduler, addr, version string, enableCors bool, tlsConfig *tls.Config) error {
+func ListenAndServe(c *cluster.Cluster, s scheduler.Scheduler, addr, version string, enableCors bool, tlsConfig *tls.Config) error {
 	context := &context{
 		cluster:       c,
 		scheduler:     s,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func serveRequest(c *cluster.Cluster, s *scheduler.Scheduler, w http.ResponseWriter, req *http.Request) error {
+func serveRequest(c *cluster.Cluster, s scheduler.Scheduler, w http.ResponseWriter, req *http.Request) error {
 	context := &context{
 		cluster:   c,
 		scheduler: s,

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -345,6 +345,18 @@ func (n *Node) Containers() []*Container {
 	return containers
 }
 
+func (n *Node) Container(id string) *Container {
+	n.refreshContainer(id)
+
+	n.RLock()
+	defer n.RUnlock()
+
+	if container, exists := n.containers[id]; exists {
+		return container
+	}
+	return nil
+}
+
 func (n *Node) String() string {
 	return fmt.Sprintf("node %s addr %s", n.ID, n.Addr)
 }

--- a/flags.go
+++ b/flags.go
@@ -49,9 +49,9 @@ var (
 		Usage: "Scheduler to use [swarm]",
 		Value: "swarm",
 	}
-	flStrategy = cli.StringFlag{
-		Name:  "strategy",
-		Usage: "PlacementStrategy to use [binpacking, random]",
-		Value: "binpacking:0.05",
+	flSchedulerOpt = cli.StringSliceFlag{
+		Name:  "scheduler-option",
+		Usage: "Scheduler option. For default scheduler (swarm): strategy:[binpackin, random]",
+		Value: &cli.StringSlice{"strategy:binpacking:005"},
 	}
 )

--- a/flags.go
+++ b/flags.go
@@ -44,6 +44,11 @@ var (
 		Name:  "tlsverify",
 		Usage: "Use TLS and verify the remote",
 	}
+	flScheduler = cli.StringFlag{
+		Name:  "scheduler",
+		Usage: "Scheduler to use [swarm]",
+		Value: "swarm",
+	}
 	flStrategy = cli.StringFlag{
 		Name:  "strategy",
 		Usage: "PlacementStrategy to use [binpacking, random]",

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 			ShortName: "m",
 			Usage:     "manage a docker cluster",
 			Flags: []cli.Flag{
-				flStrategy, flScheduler,
+				flScheduler, flSchedulerOpt,
 				flDiscovery, flAddr, flHeartBeat,
 				flTls, flTlsCaCert, flTlsCert, flTlsKey, flTlsVerify,
 				flEnableCors},

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 			ShortName: "m",
 			Usage:     "manage a docker cluster",
 			Flags: []cli.Flag{
-				flStrategy,
+				flStrategy, flScheduler,
 				flDiscovery, flAddr, flHeartBeat,
 				flTls, flTlsCaCert, flTlsCert, flTlsKey, flTlsVerify,
 				flEnableCors},

--- a/manage.go
+++ b/manage.go
@@ -12,8 +12,6 @@ import (
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/discovery"
 	"github.com/docker/swarm/scheduler"
-	"github.com/docker/swarm/scheduler/filter"
-	"github.com/docker/swarm/scheduler/strategy"
 )
 
 type logHandler struct {
@@ -98,19 +96,10 @@ func manage(c *cli.Context) {
 		}
 	}()
 
-	s, err := strategy.New(c.String("strategy"))
+	sched, err := scheduler.New(cluster, c.String("scheduler"), c)
 	if err != nil {
 		log.Fatal(err)
 	}
-	sched := scheduler.NewScheduler(
-		cluster,
-		s,
-		[]filter.Filter{
-			&filter.HealthFilter{},
-			&filter.LabelFilter{},
-			&filter.PortFilter{},
-		},
-	)
 
 	log.Fatal(api.ListenAndServe(cluster, sched, c.String("addr"), c.App.Version, c.Bool("cors"), tlsConfig))
 }

--- a/manage.go
+++ b/manage.go
@@ -96,7 +96,7 @@ func manage(c *cli.Context) {
 		}
 	}()
 
-	sched, err := scheduler.New(cluster, c.String("scheduler"), c)
+	sched, err := scheduler.New(cluster, c.String("scheduler"), c.StringSlice("scheduler-option"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scheduler/api.go
+++ b/scheduler/api.go
@@ -1,0 +1,94 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm/cluster"
+	"github.com/samalba/dockerclient"
+)
+
+type ApiScheduler struct {
+	cluster *cluster.Cluster
+	url     string
+}
+
+func (s *ApiScheduler) Initialize(cluster *cluster.Cluster, opts map[string]string) error {
+	url, exists := opts["url"]
+	if !exists {
+		log.Fatal("You have to provide --scheduler-option=url:<scheduler_api_host>")
+	}
+	if !strings.Contains(url, "://") {
+		url = "http://" + url
+	}
+	s.url = url
+	s.cluster = cluster
+	return nil
+}
+
+func (s *ApiScheduler) CreateContainer(config *dockerclient.ContainerConfig, name string) (*cluster.Container, error) {
+
+	url := s.url + "/containers/create"
+
+	// Request
+	reqData := map[string]interface{}{
+		"Name":      name,
+		"Container": config,
+		"Nodes":     s.cluster.Nodes(),
+	}
+	reqBytes, err := json.Marshal(reqData)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if resp.StatusCode != 200 {
+		log.Errorf("Scheduler API error: %d - %q", resp.StatusCode, err)
+		return nil, fmt.Errorf("%q", err)
+	}
+	defer resp.Body.Close()
+
+	// Response
+	body, _ := ioutil.ReadAll(resp.Body)
+	// Format: `{"Node": "http://<node_addr>", "Id": "<container_id>"}`
+	var respData map[string]string
+	_ = json.Unmarshal(body, &respData)
+
+	// Add container to cluster
+	node := s.cluster.Node(respData["Node"])
+	container := node.Container(respData["Id"])
+	return container, nil
+}
+
+func (s *ApiScheduler) RemoveContainer(container *cluster.Container, force bool) error {
+
+	node := container.Node()
+	url := s.url + "/containers/" + container.Id
+
+	// Request
+	reqData := map[string]interface{}{
+		"Node":  node,
+		"Force": force,
+	}
+	reqBytes, _ := json.Marshal(reqData)
+	req, err := http.NewRequest("DELETE", url, bytes.NewBuffer(reqBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Response
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if resp.StatusCode != 204 {
+		log.Errorf("Scheduler API error: %d - %q", resp.StatusCode, err)
+		return fmt.Errorf("%q", err)
+	}
+	defer resp.Body.Close()
+
+	// Remove container from cluster
+	err = node.RemoveContainer(container)
+	return err
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -25,6 +25,7 @@ var (
 func init() {
 	schedulers = map[string]Scheduler{
 		"swarm": &SwarmScheduler{},
+		"api":   &ApiScheduler{},
 	}
 }
 

--- a/scheduler/swarm.go
+++ b/scheduler/swarm.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"sync"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/scheduler/filter"
+	"github.com/docker/swarm/scheduler/strategy"
+	"github.com/samalba/dockerclient"
+)
+
+type SwarmScheduler struct {
+	sync.Mutex
+
+	cluster  *cluster.Cluster
+	strategy strategy.PlacementStrategy
+	filters  []filter.Filter
+}
+
+func (s *SwarmScheduler) Initialize(cluster *cluster.Cluster, c *cli.Context) error {
+	strat, err := strategy.New(c.String("strategy"))
+	if err != nil {
+		return err
+	}
+	s.strategy = strat
+	s.cluster = cluster
+	s.filters = []filter.Filter{
+		&filter.HealthFilter{},
+		&filter.LabelFilter{},
+		&filter.PortFilter{},
+	}
+	return nil
+}
+
+// Find a nice home for our container.
+func (s *SwarmScheduler) selectNodeForContainer(config *dockerclient.ContainerConfig) (*cluster.Node, error) {
+	candidates := s.cluster.Nodes()
+
+	accepted, err := filter.ApplyFilters(s.filters, config, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.strategy.PlaceContainer(config, accepted)
+}
+
+// Schedule a brand new container into the cluster.
+func (s *SwarmScheduler) CreateContainer(config *dockerclient.ContainerConfig, name string) (*cluster.Container, error) {
+	/*Disable for now
+	if config.Memory == 0 || config.CpuShares == 0 {
+		return nil, fmt.Errorf("Creating containers in clustering mode requires resource constraints (-c and -m) to be set")
+	}
+	*/
+
+	s.Lock()
+	defer s.Unlock()
+
+	node, err := s.selectNodeForContainer(config)
+	if err != nil {
+		return nil, err
+	}
+	return node.Create(config, name, true)
+}
+
+// Remove a container from the cluster. Containers should always be destroyed
+// through the scheduler to guarantee atomicity.
+func (s *SwarmScheduler) RemoveContainer(container *cluster.Container, force bool) error {
+	s.Lock()
+	defer s.Unlock()
+
+	return container.Node().Destroy(container, force)
+}

--- a/scheduler/swarm.go
+++ b/scheduler/swarm.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"sync"
 
-	"github.com/codegangsta/cli"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/filter"
 	"github.com/docker/swarm/scheduler/strategy"
@@ -18,8 +17,8 @@ type SwarmScheduler struct {
 	filters  []filter.Filter
 }
 
-func (s *SwarmScheduler) Initialize(cluster *cluster.Cluster, c *cli.Context) error {
-	strat, err := strategy.New(c.String("strategy"))
+func (s *SwarmScheduler) Initialize(cluster *cluster.Cluster, opts map[string]string) error {
+	strat, err := strategy.New(opts["strategy"])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi,

I've made some changes in order to add pluggable schedulers in the future.
Scheduler is an interface and SwarmScheduler its default implementation.

My idea is to add other scheduler, e.g. an ApiScheduler to connect to external services.