### PR TITLE
replace 4243 by the docker port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM golang:onbuild
-EXPOSE 4243
+EXPOSE 2375
 ENTRYPOINT ["swarm"]

--- a/api/server.go
+++ b/api/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/swarm/scheduler"
 )
 
+const DefaultDockerPort = ":2375"
+
 func newUnixListener(addr string, tlsConfig *tls.Config) (net.Listener, error) {
 	if err := syscall.Unlink(addr); err != nil && !os.IsNotExist(err) {
 		return nil, err
@@ -43,6 +45,9 @@ func newUnixListener(addr string, tlsConfig *tls.Config) (net.Listener, error) {
 func newListener(proto, addr string, tlsConfig *tls.Config) (net.Listener, error) {
 	l, err := net.Listen(proto, addr)
 	if err != nil {
+		if strings.Contains(err.Error(), "address already in use") && strings.Contains(addr, DefaultDockerPort) {
+			return nil, fmt.Errorf("%s: is Docker already running on this machine? Try using a different port", err)
+		}
 		return nil, err
 	}
 	if tlsConfig != nil {

--- a/flags.go
+++ b/flags.go
@@ -17,7 +17,7 @@ var (
 	}
 	flHosts = cli.StringSliceFlag{
 		Name:   "host, H",
-		Value:  &cli.StringSlice{"tcp://127.0.0.1:4243"},
+		Value:  &cli.StringSlice{"tcp://127.0.0.1:2375"},
 		Usage:  "ip/socket to listen on",
 		EnvVar: "SWARM_HOST",
 	}


### PR DESCRIPTION
And add a user friendly message:

`FATA[0000] listen tcp 127.0.0.1:2375: bind: address already in use: is Docker already running on this machine? Try using a different port`
