### PR TITLE
Persistent store and Virtual ID support.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -89,19 +89,19 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(tmp.Status, "Up") && !all {
 			continue
 		}
-		if !container.Node().IsHealthy() {
+		if !container.Node.IsHealthy() {
 			tmp.Status = "Pending"
 		}
 		// TODO remove the Node ID in the name when we have a good solution
 		tmp.Names = make([]string, len(container.Names))
 		for i, name := range container.Names {
-			tmp.Names[i] = "/" + container.Node().Name + name
+			tmp.Names[i] = "/" + container.Node.Name + name
 		}
 		tmp.Ports = make([]dockerclient.Port, len(container.Ports))
 		for i, port := range container.Ports {
 			tmp.Ports[i] = port
 			if port.IP == "0.0.0.0" {
-				tmp.Ports[i].IP = container.Node().IP
+				tmp.Ports[i].IP = container.Node.IP
 			}
 		}
 		out = append(out, &tmp)
@@ -115,7 +115,7 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	container := c.cluster.Container(mux.Vars(r)["name"])
 	if container != nil {
-		resp, err := http.Get(container.Node().Addr + "/containers/" + container.Id + "/json")
+		resp, err := http.Get(container.Node.Addr + "/containers/" + container.Id + "/json")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -125,7 +125,7 @@ func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(bytes.Replace(data, []byte("\"HostIp\":\"0.0.0.0\""), []byte(fmt.Sprintf("\"HostIp\":%q", container.Node().IP)), -1))
+		w.Write(bytes.Replace(data, []byte("\"HostIp\":\"0.0.0.0\""), []byte(fmt.Sprintf("\"HostIp\":%q", container.Node.IP)), -1))
 	}
 }
 
@@ -211,7 +211,7 @@ func proxyContainer(c *context, w http.ResponseWriter, r *http.Request) {
 		// RequestURI may not be sent to client
 		r.RequestURI = ""
 
-		parts := strings.SplitN(container.Node().Addr, "://", 2)
+		parts := strings.SplitN(container.Node.Addr, "://", 2)
 		if len(parts) == 2 {
 			r.URL.Scheme = parts[0]
 			r.URL.Host = parts[1]

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -33,7 +33,9 @@ func NewCluster(tlsConfig *tls.Config) *Cluster {
 
 func (c *Cluster) Handle(e *Event) error {
 	// Refresh the container list for `node` as soon as we receive an event.
+	c.Lock()
 	c.containers[e.Node] = e.Node.Containers()
+	c.Unlock()
 
 	// Dispatch the event to all the handlers.
 	for _, eventHandler := range c.eventHandlers {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -48,7 +48,7 @@ func (c *Cluster) assignVirtualId(container *Container) {
 	}
 
 	// This is an unknown container - generate a VID and store it.
-	vid := generateVirtualID()
+	vid := generateVirtualId()
 	log.Debugf("Mapping container %s to VID %s", container.Id, vid)
 	container.VirtualId = vid
 	if err := c.store.Add(vid, container); err != nil {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -20,16 +20,22 @@ type Cluster struct {
 	tlsConfig     *tls.Config
 	eventHandlers []EventHandler
 	nodes         map[string]*Node
+	containers    map[*Node][]*Container
 }
 
 func NewCluster(tlsConfig *tls.Config) *Cluster {
 	return &Cluster{
-		tlsConfig: tlsConfig,
-		nodes:     make(map[string]*Node),
+		tlsConfig:  tlsConfig,
+		nodes:      make(map[string]*Node),
+		containers: make(map[*Node][]*Container),
 	}
 }
 
 func (c *Cluster) Handle(e *Event) error {
+	// Refresh the container list for `node` as soon as we receive an event.
+	c.containers[e.Node] = e.Node.Containers()
+
+	// Dispatch the event to all the handlers.
 	for _, eventHandler := range c.eventHandlers {
 		if err := eventHandler.Handle(e); err != nil {
 			log.Error(err)
@@ -52,7 +58,10 @@ func (c *Cluster) AddNode(n *Node) error {
 		return ErrNodeAlreadyRegistered
 	}
 
+	// Register the node and its containers.
 	c.nodes[n.ID] = n
+	c.containers[n] = n.Containers()
+
 	return n.Events(c)
 }
 
@@ -76,14 +85,13 @@ func (c *Cluster) UpdateNodes(nodes []*discovery.Node) {
 
 // Containers returns all the containers in the cluster.
 func (c *Cluster) Containers() []*Container {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 
 	out := []*Container{}
-	for _, n := range c.nodes {
-		containers := n.Containers()
-		for _, container := range containers {
-			out = append(out, container)
+	for _, containers := range c.containers {
+		for _, c := range containers {
+			out = append(out, c)
 		}
 	}
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -63,11 +63,10 @@ func (c *Cluster) DeployContainer(node *Node, config *dockerclient.ContainerConf
 
 // Destroys a given `container` from the cluster.
 func (c *Cluster) DestroyContainer(container *Container, force bool) error {
-	node := container.Node()
-	if err := node.Destroy(container, force); err != nil {
+	if err := container.Node.Destroy(container, force); err != nil {
 		return err
 	}
-	c.refreshContainers(node)
+	c.refreshContainers(container.Node)
 	return nil
 }
 
@@ -155,7 +154,7 @@ func (c *Cluster) Container(IdOrName string) *Container {
 
 		// Match name, /name or engine/name.
 		for _, name := range container.Names {
-			if name == IdOrName || name == "/"+IdOrName || container.node.ID+name == IdOrName || container.node.Name+name == IdOrName {
+			if name == IdOrName || name == "/"+IdOrName || container.Node.ID+name == IdOrName || container.Node.Name+name == IdOrName {
 				return container
 			}
 		}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/samalba/dockerclient"
@@ -31,9 +33,14 @@ func createNode(t *testing.T, ID string, containers ...dockerclient.Container) *
 	return node
 }
 
-func TestAddNode(t *testing.T) {
-	c := NewCluster(nil)
+func newCluster(t *testing.T) *Cluster {
+	dir, err := ioutil.TempDir("", "store-test")
+	assert.NoError(t, err)
+	return NewCluster(NewStore(dir), nil)
+}
 
+func TestAddNode(t *testing.T) {
+	c := newCluster(t)
 	assert.Equal(t, len(c.Nodes()), 0)
 	assert.Nil(t, c.Node("test"))
 	assert.Nil(t, c.Node("test2"))
@@ -51,8 +58,8 @@ func TestAddNode(t *testing.T) {
 	assert.NotNil(t, c.Node("test2"))
 }
 
-func TestLookupContainer(t *testing.T) {
-	c := NewCluster(nil)
+func TestContainerLookup(t *testing.T) {
+	c := newCluster(t)
 	container := dockerclient.Container{
 		Id:    "container-id",
 		Names: []string{"/container-name1", "/container-name2"},
@@ -75,4 +82,64 @@ func TestLookupContainer(t *testing.T) {
 	assert.NotNil(t, c.Container(vid))
 	// Container ID prefix lookup.
 	assert.NotNil(t, c.Container(vid[0:3]))
+}
+
+func TestContainerNodeMapping(t *testing.T) {
+	// Create a test node.
+	node := NewNode("test")
+
+	client := mockclient.NewMockClient()
+	client.On("Info").Return(mockInfo, nil)
+	client.On("StartMonitorEvents", mock.Anything, mock.Anything).Return()
+
+	// The client will return one container at first, then a second one will appear.
+	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
+	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
+	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
+	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
+
+	assert.NoError(t, node.connectClient(client))
+	assert.True(t, node.IsConnected())
+
+	// Create a test cluster.
+	c := newCluster(t)
+	assert.NoError(t, c.AddNode(node))
+
+	// Ensure that the cluster picked up the already existing container from
+	// our test node.
+	assert.Len(t, c.Containers(), 1)
+	assert.Equal(t, c.Containers()[0].Id, "one")
+	// And make sure a virtual id was generated.
+	assert.NotEmpty(t, c.Containers()[0].VirtualId)
+
+	// Simulate a manually created container on the node.
+	node.handler(&dockerclient.Event{Id: "two", Status: "created"})
+	// Make sure it got picked up...
+	assert.Len(t, node.Containers(), 2)
+	// ...And that it has a virtual id
+	assert.NotEmpty(t, c.Containers()[0].VirtualId)
+	assert.NotEmpty(t, c.Containers()[1].VirtualId)
+
+	client.Mock.AssertExpectations(t)
+}
+
+func TestDeployContainer(t *testing.T) {
+	// Create a test node.
+	node := createNode(t, "test")
+
+	// Create a test cluster.
+	c := newCluster(t)
+	assert.NoError(t, c.AddNode(node))
+
+	// Fake dockerclient calls to deploy a container.
+	client := node.client.(*mockclient.MockClient)
+	client.On("CreateContainer", mock.Anything, mock.Anything).Return("id", nil).Once()
+	client.On("ListContainers", true, false, mock.Anything).Return([]dockerclient.Container{{Id: "id"}}, nil).Once()
+	client.On("InspectContainer", "id").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
+
+	// Ensure the container gets deployed and a virtual id generated.
+	container, err := c.DeployContainer(node, &dockerclient.ContainerConfig{}, "name")
+	assert.NoError(t, err)
+	assert.Equal(t, container.Id, "id")
+	assert.NotEmpty(t, container.VirtualId)
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -63,14 +63,16 @@ func TestLookupContainer(t *testing.T) {
 	// Invalid lookup
 	assert.Nil(t, c.Container("invalid-id"))
 	assert.Nil(t, c.Container(""))
-	// Container ID lookup.
-	assert.NotNil(t, c.Container("container-id"))
-	// Container ID prefix lookup.
-	assert.NotNil(t, c.Container("container-"))
 	// Container name lookup.
 	assert.NotNil(t, c.Container("container-name1"))
 	assert.NotNil(t, c.Container("container-name2"))
 	// Container node/name matching.
 	assert.NotNil(t, c.Container("test-node/container-name1"))
 	assert.NotNil(t, c.Container("test-node/container-name2"))
+
+	// Container ID lookup.
+	vid := c.Container("container-name1").VirtualId
+	assert.NotNil(t, c.Container(vid))
+	// Container ID prefix lookup.
+	assert.NotNil(t, c.Container(vid[0:3]))
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/samalba/dockerclient"
@@ -33,14 +34,12 @@ func createNode(t *testing.T, ID string, containers ...dockerclient.Container) *
 	return node
 }
 
-func newCluster(t *testing.T) *Cluster {
+func TestAddNode(t *testing.T) {
 	dir, err := ioutil.TempDir("", "store-test")
 	assert.NoError(t, err)
-	return NewCluster(NewStore(dir), nil)
-}
+	defer assert.NoError(t, os.RemoveAll(dir))
+	c := NewCluster(NewStore(dir), nil)
 
-func TestAddNode(t *testing.T) {
-	c := newCluster(t)
 	assert.Equal(t, len(c.Nodes()), 0)
 	assert.Nil(t, c.Node("test"))
 	assert.Nil(t, c.Node("test2"))
@@ -59,7 +58,11 @@ func TestAddNode(t *testing.T) {
 }
 
 func TestContainerLookup(t *testing.T) {
-	c := newCluster(t)
+	dir, err := ioutil.TempDir("", "store-test")
+	assert.NoError(t, err)
+	defer assert.NoError(t, os.RemoveAll(dir))
+	c := NewCluster(NewStore(dir), nil)
+
 	container := dockerclient.Container{
 		Id:    "container-id",
 		Names: []string{"/container-name1", "/container-name2"},
@@ -102,7 +105,10 @@ func TestContainerNodeMapping(t *testing.T) {
 	assert.True(t, node.IsConnected())
 
 	// Create a test cluster.
-	c := newCluster(t)
+	dir, err := ioutil.TempDir("", "store-test")
+	assert.NoError(t, err)
+	defer assert.NoError(t, os.RemoveAll(dir))
+	c := NewCluster(NewStore(dir), nil)
 	assert.NoError(t, c.AddNode(node))
 
 	// Ensure that the cluster picked up the already existing container from
@@ -128,7 +134,10 @@ func TestDeployContainer(t *testing.T) {
 	node := createNode(t, "test")
 
 	// Create a test cluster.
-	c := newCluster(t)
+	dir, err := ioutil.TempDir("", "store-test")
+	assert.NoError(t, err)
+	defer assert.NoError(t, os.RemoveAll(dir))
+	c := NewCluster(NewStore(dir), nil)
 	assert.NoError(t, c.AddNode(node))
 
 	// Fake dockerclient calls to deploy a container.

--- a/cluster/container.go
+++ b/cluster/container.go
@@ -7,9 +7,5 @@ type Container struct {
 	dockerclient.Container
 
 	Info dockerclient.ContainerInfo
-	node *Node
-}
-
-func (c *Container) Node() *Node {
-	return c.node
+	Node *Node
 }

--- a/cluster/container.go
+++ b/cluster/container.go
@@ -3,6 +3,7 @@ package cluster
 import "github.com/samalba/dockerclient"
 
 type Container struct {
+	VirtualId string
 	dockerclient.Container
 
 	Info dockerclient.ContainerInfo

--- a/cluster/id.go
+++ b/cluster/id.go
@@ -1,0 +1,16 @@
+package cluster
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+)
+
+func generateVirtualID() string {
+	id := make([]byte, 32)
+
+	if _, err := io.ReadFull(rand.Reader, id); err != nil {
+		panic(err) // This shouldn't happen
+	}
+	return hex.EncodeToString(id)
+}

--- a/cluster/id.go
+++ b/cluster/id.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-func generateVirtualID() string {
+func generateVirtualId() string {
 	id := make([]byte, 32)
 
 	if _, err := io.ReadFull(rand.Reader, id); err != nil {

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -186,7 +186,7 @@ func (n *Node) updateContainer(c dockerclient.Container, containers map[string]*
 		// This is a brand new container.
 		container := &Container{}
 		container.Container = c
-		container.node = n
+		container.Node = n
 
 		info, err := n.client.InspectContainer(c.Id)
 		if err != nil {

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -1,0 +1,177 @@
+package cluster
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+)
+
+var (
+	ErrNotFound      = errors.New("not found")
+	ErrAlreadyExists = errors.New("already exists")
+)
+
+// A simple key<->Container store.
+type Store struct {
+	RootDir    string
+	containers map[string]*Container
+
+	sync.RWMutex
+}
+
+func NewStore(rootdir string) *Store {
+	return &Store{
+		RootDir:    rootdir,
+		containers: make(map[string]*Container),
+	}
+}
+
+// Initialize must be called before performing any operation on the store. It
+// will attempt to restore the data from disk.
+func (s *Store) Initialize() error {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := os.MkdirAll(s.RootDir, 0700); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := s.restore(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) path(key string) string {
+	return path.Join(s.RootDir, key+".json")
+}
+
+func (s *Store) restore() error {
+	files, err := ioutil.ReadDir(s.RootDir)
+	if err != nil {
+		return err
+	}
+	for _, fileinfo := range files {
+		file := fileinfo.Name()
+
+		// Verify the file extension.
+		extension := filepath.Ext(file)
+		if extension != ".json" {
+			return fmt.Errorf("invalid file extension for filename %s (%s)", file, extension)
+		}
+
+		// Load the object back.
+		container, err := s.load(path.Join(s.RootDir, file))
+		if err != nil {
+			return err
+		}
+
+		// Extract the key.
+		key := file[0 : len(file)-len(extension)]
+		if len(key) == 0 {
+			return fmt.Errorf("invalid filename %s", file)
+		}
+
+		// Store it back.
+		s.containers[key] = container
+	}
+	return nil
+}
+
+func (s *Store) load(file string) (*Container, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load %s: %v", file, err)
+	}
+	container := &Container{}
+	if err := json.Unmarshal(data, container); err != nil {
+		return nil, err
+	}
+	return container, nil
+}
+
+// Retrieves an object from the store keyed by `key`.
+func (s *Store) Get(key string) (*Container, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	if value, ok := s.containers[key]; ok {
+		return value, nil
+	}
+	return nil, ErrNotFound
+}
+
+// Return all objects of the store.
+func (s *Store) All() []*Container {
+	s.RLock()
+	defer s.RUnlock()
+
+	states := make([]*Container, len(s.containers))
+	i := 0
+	for _, state := range s.containers {
+		states[i] = state
+		i = i + 1
+	}
+	return states
+}
+
+func (s *Store) set(key string, value *Container) error {
+	data, err := json.MarshalIndent(value, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(s.path(key), data, 0600); err != nil {
+		return err
+	}
+
+	s.containers[key] = value
+	return nil
+}
+
+// Add a new object on the store. `key` must be unique.
+func (s *Store) Add(key string, value *Container) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, exists := s.containers[key]; exists {
+		return ErrAlreadyExists
+	}
+
+	return s.set(key, value)
+}
+
+// Replaces an already existing object from the store.
+func (s *Store) Replace(key string, value *Container) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, exists := s.containers[key]; !exists {
+		return ErrNotFound
+	}
+
+	return s.set(key, value)
+}
+
+// Remove `key` from the store.
+func (s *Store) Remove(key string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, exists := s.containers[key]; !exists {
+		return ErrNotFound
+	}
+
+	if err := os.Remove(s.path(key)); err != nil {
+		return err
+	}
+
+	delete(s.containers, key)
+	return nil
+}

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1,0 +1,47 @@
+package cluster
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStore(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store-test")
+	assert.NoError(t, err)
+	store := NewStore(dir)
+	assert.NoError(t, store.Initialize())
+
+	c1 := &Container{}
+	c1.Id = "foo"
+	c2 := &Container{}
+	c2.Id = "bar"
+
+	var ret *Container
+
+	// Add "foo" into the store.
+	assert.NoError(t, store.Add("foo", c1))
+
+	// Retrieve "foo" from the store.
+	ret, err = store.Get("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, c1.Id, ret.Id)
+
+	// Try to add "foo" again.
+	assert.EqualError(t, store.Add("foo", c1), ErrAlreadyExists.Error())
+
+	// Replace "foo" with c2.
+	assert.NoError(t, store.Replace("foo", c2))
+	ret, err = store.Get("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, c2.Id, ret.Id)
+
+	// Initialize a brand new store and retrieve "foo" again.
+	// This is to ensure data load on initialization works correctly.
+	store = NewStore(dir)
+	assert.NoError(t, store.Initialize())
+	ret, err = store.Get("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, c2.Id, ret.Id)
+}

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 func TestStore(t *testing.T) {
 	dir, err := ioutil.TempDir("", "store-test")
 	assert.NoError(t, err)
+	defer assert.NoError(t, os.RemoveAll(dir))
 	store := NewStore(dir)
 	assert.NoError(t, store.Initialize())
 

--- a/flags.go
+++ b/flags.go
@@ -3,6 +3,11 @@ package main
 import "github.com/codegangsta/cli"
 
 var (
+	flStore = cli.StringFlag{
+		Name:  "store",
+		Value: "/var/lib/docker/swarm/store",
+		Usage: "",
+	}
 	flDiscovery = cli.StringFlag{
 		Name:   "discovery",
 		Value:  "",

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func main() {
 			ShortName: "m",
 			Usage:     "manage a docker cluster",
 			Flags: []cli.Flag{
+				flStore,
 				flStrategy, flFilter,
 				flDiscovery, flHosts, flHeartBeat,
 				flTls, flTlsCaCert, flTlsCert, flTlsKey, flTlsVerify,

--- a/manage.go
+++ b/manage.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -71,7 +72,12 @@ func manage(c *cli.Context) {
 		}
 	}
 
-	cluster := cluster.NewCluster(tlsConfig)
+	store := cluster.NewStore(path.Join(c.String("store"), "state"))
+	if err := store.Initialize(); err != nil {
+		log.Fatal(err)
+	}
+
+	cluster := cluster.NewCluster(store, tlsConfig)
 	cluster.Events(&logHandler{})
 
 	go func() {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -61,5 +61,5 @@ func (s *Scheduler) RemoveContainer(container *cluster.Container, force bool) er
 	s.Lock()
 	defer s.Unlock()
 
-	return container.Node().Destroy(container, force)
+	return container.Node.Destroy(container, force)
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -52,7 +52,7 @@ func (s *Scheduler) CreateContainer(config *dockerclient.ContainerConfig, name s
 	if err != nil {
 		return nil, err
 	}
-	return node.Create(config, name, true)
+	return s.cluster.DeployContainer(node, config, name)
 }
 
 // Remove a container from the cluster. Containers should always be destroyed


### PR DESCRIPTION
Eventually, in order to support rebalancing, Swarm will need to store the requested state in a persistent way.
Also, rebalancing containers will require them to be re-created on a different node, resulting in a different container ID.

In order to keep IDs consistent across node moves, Swarm will generate a "Virtual ID" that is exposed through the API and guaranteed to never change.
The API takes care of remapping the Virtual ID back into the ID.