### PR TITLE
add node name, ID and IP

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,59 @@
+Docker Swarm API
+================
+
+The Docker Swarm API is compatible with the [Offical Docker API](https://docs.docker.com/reference/api/docker_remote_api/):
+
+Here are the main differences:
+
+####Some endpoints are not (yet) implemented
+
+```
+GET "/images/json"
+GET "/images/json"
+GET "/images/search"
+GET "/images/get"
+GET "/images/{name:.*}/get"
+GET "/images/{name:.*}/history"
+GET "/images/{name:.*}/json"
+GET "/containers/{name:.*}/attach/ws"
+
+POST "/auth"
+POST "/commit"
+POST "/build"
+POST "/images/create"
+POST "/images/load"
+POST "/images/{name:.*}/push"
+POST "/images/{name:.*}/tag"
+POST "/containers/{name:.*}/attach"
+POST "/containers/{name:.*}/copy"
+POST "/containers/{name:.*}/exec"
+POST "/exec/{name:.*}/start"
+
+DELETE "/images/{name:.*}"
+```
+
+####Some endpoints have more information
+
+* `GET "/containers/{name:.*}/json"`: New field `Node` added:
+
+```json
+"Node": {
+        "ID": "ODAI:IC6Q:MSBL:TPB5:HIEE:6IKC:VCAM:QRNH:PRGX:ERZT:OK46:PMFX",
+	"IP": "0.0.0.0",
+	"Addr": "http://0.0.0.0:4243",
+	"Name": "vagrant-ubuntu-saucy-64",
+	"Cpus": 1,
+	"Memory": 2099654656,
+	"Labels": {
+            "executiondriver": "native-0.2",
+            "kernelversion": "3.11.0-15-generic",
+            "operatingsystem": "Ubuntu 13.10",
+            "storagedriver": "aufs"
+	    }
+    },
+```
+* `GET "/containers/{name:.*}/json"`: `HostIP` replaced by the the actual Node's IP if `HostIP` is `0.0.0.0`
+
+* `GET "/containers"/json"`: Node's name prepended to the container name.
+
+* `GET "/containers"/json"`: `HostIP` replaed by the the actual Node's IP if `HostIP` is `0.0.0.0`

--- a/api/api.go
+++ b/api/api.go
@@ -60,7 +60,7 @@ func getVersion(c *context, w http.ResponseWriter, r *http.Request) {
 	}{
 		Version:   "swarm/" + c.version,
 		GoVersion: runtime.Version(),
-		GitCommit: "swarm",
+		GitCommit: "n/a",
 	}
 
 	json.NewEncoder(w).Encode(version)
@@ -86,11 +86,12 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		if !container.Node().IsHealthy() {
 			tmp.Status = "Pending"
 		}
-		// TODO remove the Node ID in the name when we have a good solution
+		// TODO remove the Node Name in the name when we have a good solution
 		tmp.Names = make([]string, len(container.Names))
 		for i, name := range container.Names {
 			tmp.Names[i] = "/" + container.Node().Name + name
 		}
+		// insert node IP
 		tmp.Ports = make([]dockerclient.Port, len(container.Ports))
 		for i, port := range container.Ports {
 			tmp.Ports[i] = port
@@ -119,14 +120,20 @@ func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// insert node name
-		data = bytes.Replace(data, []byte("\"Name\":\"/"), []byte(fmt.Sprintf("\"NodeName\":%q,\"Name\":\"/", container.Node().Name)), -1)
-		// insert node ID
-		data = bytes.Replace(data, []byte("\"Name\":\"/"), []byte(fmt.Sprintf("\"NodeID\":%q,\"Name\":\"/", container.Node().ID)), -1)
+
+		n, err := json.Marshal(container.Node())
+		if err != nil {
+			httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// insert Node field
+		data = bytes.Replace(data, []byte("\"Name\":\"/"), []byte(fmt.Sprintf("\"Node\":%s,\"Name\":\"/", n)), -1)
+
 		// insert node IP
-		data = bytes.Replace(data, []byte("\"Name\":\"/"), []byte(fmt.Sprintf("\"NodeIP\":%q,\"Name\":\"/", container.Node().IP)), -1)
 		data = bytes.Replace(data, []byte("\"HostIp\":\"0.0.0.0\""), []byte(fmt.Sprintf("\"HostIp\":%q", container.Node().IP)), -1)
 		w.Write(data)
+
 	}
 }
 


### PR DESCRIPTION
fix #193

`docker inspect` will look like:

```
...
    "Node": {
        "ID": "ODAI:IC6Q:MSBL:TPB5:HIEE:6IKC:VCAM:QRNH:PRGX:ERZT:OK46:PMFX",
        "IP": "0.0.0.0",
        "Addr": "http://0.0.0.0:4243",
        "Name": "vagrant-ubuntu-saucy-64",
        "Cpus": 1,
        "Memory": 2099654656,
        "Labels": {
            "executiondriver": "native-0.2",
            "kernelversion": "3.11.0-15-generic",
            "operatingsystem": "Ubuntu 13.10",
            "storagedriver": "aufs"
        }
    },
...
```
