### PR TITLE
Added consul to the list of planned backends

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,5 +24,6 @@ Docker Swarm Roadmap
 * [ ] Discovery backends
   * [x]    etcd
   * [ ]    zookeeper
+  * [ ]    consul
   * [x]    hub 
   * [x]    file


### PR DESCRIPTION
Is there a reason why consul is not on the list of planned backends?
[Atlas](https://atlas.hashicorp.com/) is able to deploy Docker containers and is using Consul for service discovery.
