### PR TITLE
Cleanup: separate unix-related codes to make Swarm buildable on Windows

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strings"
-	"syscall"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm/cluster"
@@ -15,32 +13,6 @@ import (
 )
 
 const DefaultDockerPort = ":2375"
-
-func newUnixListener(addr string, tlsConfig *tls.Config) (net.Listener, error) {
-	if err := syscall.Unlink(addr); err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	// there is no way to specify the unix rights to use when
-	// creating the socket with net.Listener, so we use umask
-	// to create the file without rights and then we chmod
-	// to the desired unix rights. This prevent unwanted
-	// connections between the creation and the chmod
-	mask := syscall.Umask(0777)
-	defer syscall.Umask(mask)
-
-	l, err := newListener("unix", addr, tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// only usable by the user who started swarm
-	if err := os.Chmod(addr, 0600); err != nil {
-		return nil, err
-	}
-
-	return l, nil
-}
 
 func newListener(proto, addr string, tlsConfig *tls.Config) (net.Listener, error) {
 	l, err := net.Listen(proto, addr)

--- a/api/server_unix.go
+++ b/api/server_unix.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package api
+
+import (
+	"crypto/tls"
+	"net"
+	"os"
+	"syscall"
+)
+
+func newUnixListener(addr string, tlsConfig *tls.Config) (net.Listener, error) {
+	if err := syscall.Unlink(addr); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// there is no way to specify the unix rights to use when
+	// creating the socket with net.Listener, so we use umask
+	// to create the file without rights and then we chmod
+	// to the desired unix rights. This prevent unwanted
+	// connections between the creation and the chmod
+	mask := syscall.Umask(0777)
+	defer syscall.Umask(mask)
+
+	l, err := newListener("unix", addr, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// only usable by the user who started swarm
+	if err := os.Chmod(addr, 0600); err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}

--- a/api/server_windows.go
+++ b/api/server_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package api
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+)
+
+func newUnixListener(addr string, tlsConfig *tls.Config) (net.Listener, error) {
+	return nil, fmt.Errorf("Windows platform does not support a unix socket")
+}


### PR DESCRIPTION
I am new to contributing to Docker projects. Let me know if I am doing something wrong.

There will be some move to make `Docker` and its related projects available for Windows in the new future. `Swarm` is still young so it's great to have some Windows-related refactoring early for this project.

This PR is initially separating Unix / Windows specific codes into different files and guarding them with the platform `+build` flag. This PR also allows contributors to compile and start hacking `Swarm` on Windows.
