### PR TITLE
Proposal: standardise protocols : only ip:port

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ swarm create
 $ swarm join --discovery token://<cluster_id> --addr=<node_ip:2375>
 
 # start the manager on any machine or your laptop
-$ swarm manage --discovery token://<cluster_id> -H=<swarm_ip:swarm_port>
+$ swarm manage --discovery token://<cluster_id> -H <swarm_ip:swarm_port>
 
 # use the regular docker cli
 $ docker -H <swarm_ip:swarm_port> info
@@ -50,7 +50,7 @@ $ docker -H <swarm_ip:swarm_port> logs ...
 
 # list nodes in your cluster
 $ swarm list --discovery token://<cluster_id>
-http://<node_ip:2375>
+<node_ip:2375>
 ```
 
 See [here](discovery) for more information about

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -10,15 +10,15 @@ Discovery
 ```bash
 # create a cluster
 $ swarm create
-6856663cdefdec325839a4b7e1de38e8
+6856663cdefdec325839a4b7e1de38e8 # <- this is your unique <cluster_id>
 
 # on each of your nodes, start the swarm agent
 #  <node_ip> doesn't have to be public (eg. 192.168.0.X),
 #  as long as the other nodes can reach it, it is fine.
-$ swarm join --discovery token://6856663cdefdec325839a4b7e1de38e8 --addr=<node_ip:2375>
+$ swarm join --discovery token://<cluster_id> --addr=<node_ip:2375>
 
 # start the manager on any machine or your laptop
-$ swarm manage --discovery token://6856663cdefdec325839a4b7e1de38e8 -H=<swarm_ip:swarm_port>
+$ swarm manage --discovery token://<cluster_id> -H <swarm_ip:swarm_port>
 
 # use the regular docker cli
 $ docker -H <swarm_ip:swarm_port> info
@@ -28,8 +28,8 @@ $ docker -H <swarm_ip:swarm_port> logs ...
 ...
 
 # list nodes in your cluster
-$ swarm list --discovery token://6856663cdefdec325839a4b7e1de38e8
-http://<node_ip:2375>
+$ swarm list --discovery token://<cluster_id>
+<node_ip:2375>
 ```
 
 ###### Using a static file describing the cluster
@@ -38,10 +38,12 @@ http://<node_ip:2375>
 # for each of your nodes, add a line to a file
 #  <node_ip> doesn't have to be public (eg. 192.168.0.X),
 #  as long as the other nodes can reach it, it is fine.
-$ echo <node_ip:2375> >> /tmp/my_cluster
+$ echo <node_ip1:2375> >> /tmp/my_cluster
+$ echo <node_ip2:2375> >> /tmp/my_cluster
+$ echo <node_ip3:2375> >> /tmp/my_cluster
 
 # start the manager on any machine or your laptop
-$ swarm manage --discovery file:///tmp/my_cluster -H=<swarm_ip:swarm_port>
+$ swarm manage --discovery file:///tmp/my_cluster -H <swarm_ip:swarm_port>
 
 # use the regular docker cli
 $ docker -H <swarm_ip:swarm_port> info
@@ -52,7 +54,9 @@ $ docker -H <swarm_ip:swarm_port> logs ...
 
 # list nodes in your cluster
 $ swarm list --discovery file:///tmp/my_cluster
-http://<node_ip:2375>
+<node_ip1:2375>
+<node_ip2:2375>
+<node_ip3:2375>
 ```
 
 ###### Using etcd
@@ -64,7 +68,7 @@ http://<node_ip:2375>
 $ swarm join --discovery etcd://<etcd_ip>/<path> --addr=<node_ip:2375>
 
 # start the manager on any machine or your laptop
-$ swarm manage --discovery etcd://<etcd_ip>/<path> -H=<swarm_ip:swarm_port>
+$ swarm manage --discovery etcd://<etcd_ip>/<path> -H <swarm_ip:swarm_port>
 
 # use the regular docker cli
 $ docker -H <swarm_ip:swarm_port> info
@@ -75,7 +79,7 @@ $ docker -H <swarm_ip:swarm_port> logs ...
 
 # list nodes in your cluster
 $ swarm list --discovery etcd://<etcd_ip>/<path>
-http://<node_ip:2375>
+<node_ip:2375>
 ```
 
 ###### Using consul
@@ -87,7 +91,7 @@ http://<node_ip:2375>
 $ swarm join --discovery consul://<consul_addr>/<path> --addr=<node_ip:2375>
 
 # start the manager on any machine or your laptop
-$ swarm manage --discovery consul://<consul_addr>/<path> -H=<swarm_ip:swarm_port>
+$ swarm manage --discovery consul://<consul_addr>/<path> -H <swarm_ip:swarm_port>
 
 # use the regular docker cli
 $ docker -H <swarm_ip:swarm_port> info
@@ -98,7 +102,7 @@ $ docker -H <swarm_ip:swarm_port> logs ...
 
 # list nodes in your cluster
 $ swarm list --discovery consul://<consul_addr>/<path>
-http://<node_ip:2375>
+<node_ip:2375>
 ```
 
 ###### Using zookeeper
@@ -110,7 +114,7 @@ http://<node_ip:2375>
 $ swarm join --discovery zk://<zookeeper_addr1>,<zookeeper_addr2>/<path> --addr=<node_ip:2375>
 
 # start the manager on any machine or your laptop
-$ swarm manage --discovery zk://<zookeeper_addr1>,<zookeeper_addr2>/<path> -H=<swarm_ip:swarm_port>
+$ swarm manage --discovery zk://<zookeeper_addr1>,<zookeeper_addr2>/<path> -H <swarm_ip:swarm_port>
 
 # use the regular docker cli
 $ docker -H <swarm_ip:swarm_port> info
@@ -121,7 +125,7 @@ $ docker -H <swarm_ip:swarm_port> logs ...
 
 # list nodes in your cluster
 $ swarm list --discovery zk://<zookeeper_addr1>,<zookeeper_addr2>/<path>
-http://<node_ip:2375>
+<node_ip:2375>
 ```
 
 ## Contributing

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -14,9 +13,6 @@ type Node struct {
 }
 
 func NewNode(url string) *Node {
-	if !strings.Contains(url, "://") {
-		url = "http://" + url
-	}
 	return &Node{url: url}
 }
 

--- a/discovery/token/token_test.go
+++ b/discovery/token/token_test.go
@@ -25,7 +25,7 @@ func TestRegister(t *testing.T) {
 	addrs, err := discovery.Fetch()
 	assert.NoError(t, err)
 	assert.Equal(t, len(addrs), 1)
-	assert.Equal(t, addrs[0].String(), "http://"+expected)
+	assert.Equal(t, addrs[0].String(), expected)
 
 	assert.NoError(t, discovery.Register(expected))
 }

--- a/join.go
+++ b/join.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -19,7 +20,13 @@ func join(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	if err := d.Register(c.String("addr")); err != nil {
+	addr := c.String("addr")
+	addrParts := strings.SplitN(addr, ":", 2)
+	if len(addrParts) != 2 {
+		log.Fatal("--addr should be of the form ip:port")
+	}
+
+	if err := d.Register(addr); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Let's standardise the way addrs are handles by swarm:

```
--------------                   ---------------------                   ----------------
| swarm join | ----------------> | discovery service | ----------------> | swarm manage |
--------------                   ---------------------                   ----------------
                                           |                             --------------
                                           ----------------------------> | swarm list |
                                                                         --------------
```

#### Swarm join

`swarm join` will only support this format:
* `<ip:port>`

Any other format (`http://`, `https://`, `tcp://`, `foobar://`, etc...) will be denied

#### Swarm manage

`swarm manage` will try to connect using `https` if the `--tls` otherwise `http`

#### Swarm list

`swarm list` will always display addresses as `<ip:port>`

Replace #184
Close #184