### PR TITLE
Cleanup: need int64 cast to prevent overflow on the 32-bit architecture

### DIFF
--- a/scheduler/strategy/binpacking_test.go
+++ b/scheduler/strategy/binpacking_test.go
@@ -47,7 +47,7 @@ func TestPlaceContainerMemory(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, node2.AddContainer(createContainer("c2", config)))
 
-	assert.Equal(t, node2.ReservedMemory(), 2*1024*1024*1024)
+	assert.Equal(t, node2.ReservedMemory(), int64(2*1024*1024*1024))
 
 	// check that both containers ended on the same node
 	assert.Equal(t, node1.ID, node2.ID, "")


### PR DESCRIPTION
This PR is a trivial fix.

Per #210 , there will be cross-compiling for both `amd64` and `386` archs. A test failed because an `int64` value needs an explicit cast on the `386` arch.

Signed-off-by: Chanwit Kaewkasi chanwit@gmail.com
