### PR TITLE
Proposal: report error when two Docker's IDs are duplicated

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -50,8 +50,7 @@ func (c *Cluster) AddNode(n *Node) error {
 
 	if old, exists := c.nodes[n.ID]; exists {
 		if old.IP != n.IP {
-			log.Errorf("ID duplicated: %s", n.ID)
-			log.Errorf("IP [%s] and [%s] share the same ID", old.IP, n.IP)
+			log.Errorf("ID duplicated. %s shared by %s and %s", n.ID, old.IP, n.IP)
 		}
 		return ErrNodeAlreadyRegistered
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -48,7 +48,11 @@ func (c *Cluster) AddNode(n *Node) error {
 	c.Lock()
 	defer c.Unlock()
 
-	if _, exists := c.nodes[n.ID]; exists {
+	if old, exists := c.nodes[n.ID]; exists {
+		if old.IP != n.IP {
+			log.Errorf("ID duplicated: %s", n.ID)
+			log.Errorf("IP [%s] and [%s] share the same ID", old.IP, n.IP)
+		}
 		return ErrNodeAlreadyRegistered
 	}
 


### PR DESCRIPTION
There is a corner case that a VM is duplicated from another. If `Docker` is already initialized on the source machine, the duplicated one will contain the same `~/.docker/key.json` file. This makes `Swarm` not adding the new node but the error report is difficult to trace the problem.

This PR makes `Swarm` a bit more verbose on this case. It reports two IP of machines that share the same ID, so the problem can be easier to fix.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>