### PR TITLE
 Proposal: Support the cross-host linking on swarm cluster

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"runtime"
 	"sort"
 	"strings"
@@ -154,13 +156,57 @@ func postContainersCreate(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	container, err := c.scheduler.CreateContainer(&config, name)
+	//Find the node to place container firstly
+	node, err := c.scheduler.SelectNodeForContainer(&config)
+
+	if err != nil {
+		log.Debug("Cannot find the node for create the container")
+		httpError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	//Create the abassador containers for links if need
+	err = processLinks(c, node, &config.HostConfig)
+	if err != nil {
+		log.Debug("Failed to create the amabassadors for the links")
+		httpError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	//Create the container with the updated links
+	container, err := node.Create(&config, name, true)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	fmt.Fprintf(w, "{%q:%q}", "Id", container.Id)
 	return
+}
+
+// DELETE /containers/{name:.*}
+func deleteAssociatedAmbassadorContainers(c *context, container *cluster.Container) error {
+
+	containers := c.cluster.Containers()
+
+	src := container.Info.Name
+	if len(src) > 1 {
+		//Find the associated container by prefix/suffix of name
+		cname := src[1:]
+		suffix := "_ambassador_" + cname
+
+		for _, ct := range containers {
+			name := ct.Info.Name
+			if strings.HasSuffix(name, suffix) && name[1:] == getAmbassadorName(ct.Node(), cname) {
+				//TODO adding image checking
+				log.Infof("Delete ambassador container'%s for %s", name, src)
+				if err := c.scheduler.RemoveContainer(ct, true); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // DELETE /containers/{name:.*}
@@ -177,11 +223,19 @@ func deleteContainer(c *context, w http.ResponseWriter, r *http.Request) {
 		httpError(w, fmt.Sprintf("Container %s not found", name), http.StatusNotFound)
 		return
 	}
-	if err := c.scheduler.RemoveContainer(container, force); err != nil {
+	var err error
+
+	//Delete the associated ambassador containers
+	err = deleteAssociatedAmbassadorContainers(c, container)
+
+	if err == nil {
+		err = c.scheduler.RemoveContainer(container, force)
+	}
+
+	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
 }
 
 // GET /events
@@ -286,7 +340,7 @@ func createRouter(c *context, enableCors bool) (*mux.Router, error) {
 			"/containers/{name:.*}/pause":   proxyContainer,
 			"/containers/{name:.*}/unpause": proxyContainer,
 			"/containers/{name:.*}/restart": proxyContainer,
-			"/containers/{name:.*}/start":   proxyContainer,
+			"/containers/{name:.*}/start":   startContainer,
 			"/containers/{name:.*}/stop":    proxyContainer,
 			"/containers/{name:.*}/wait":    proxyContainer,
 			"/containers/{name:.*}/resize":  proxyContainer,
@@ -328,4 +382,189 @@ func createRouter(c *context, enableCors bool) (*mux.Router, error) {
 	}
 
 	return r, nil
+}
+
+var AMBASSADOR_IMAGE string
+
+//Get ambassador image from the OS env
+func getAmbassadorImage() string {
+	if AMBASSADOR_IMAGE == "" {
+		img := os.Getenv("AMBASSADOR_IMAGE")
+		if img == "" {
+			img = "svendowideit/ambassador:latest"
+		} else {
+			list := strings.Split(img, "/")
+			name := list[len(list)-1]
+			if strings.Index(name, ":") < 0 {
+				//Append the latest to the image
+				img += ":latest"
+			}
+		}
+		AMBASSADOR_IMAGE = img
+	}
+	return AMBASSADOR_IMAGE
+}
+
+func getAmbassadorName(node *cluster.Node, name string) string {
+	nodeID := strings.Replace(node.ID, ":", "", -1)
+	return fmt.Sprintf("node_%s_ambassador_%s", nodeID, name)
+}
+
+func processLinks(c *context, containerNode *cluster.Node, config *dockerclient.HostConfig) error {
+
+	var EMPTY struct{}
+
+	links := config.Links
+	if links == nil {
+		return nil
+	}
+	containers := c.cluster.Containers()
+
+	cache := map[string](*dockerclient.ContainerInfo){}
+
+	addr := containerNode.Addr
+
+	var newLinks []string
+
+	for _, link := range links {
+		//Parse the link info
+		linkInfo := strings.Split(link, ":")
+		name, alias := linkInfo[0], linkInfo[1]
+		linkContainerName := "/" + name
+		for _, target := range containers {
+			if target.Info.Name == linkContainerName {
+				if addr == target.Node().Addr {
+					log.Debug("No additional work for the container link on the same host")
+				} else {
+					//Update the link
+					ambassadorName := getAmbassadorName(containerNode, name)
+					link = ambassadorName + ":" + alias
+					//Create ambassador container for cross-host link
+					//TODO: Remove ambassador when the container is removed.
+					var targetInfo *dockerclient.ContainerInfo
+					var err error
+					targetInfo = cache[target.Id]
+					if targetInfo == nil {
+						targetInfo, err = target.Node().InspectContainer(target.Id)
+						if err == nil && targetInfo != nil {
+							cache[target.Id] = targetInfo
+							//Check if ambassadorName exists, if no create a new one
+
+							ambassadorInfo, _ := containerNode.InspectContainer(ambassadorName)
+							if ambassadorInfo == nil {
+
+								var ambassadorConfig dockerclient.ContainerConfig
+								var env []string
+								ambassadorConfig.ExposedPorts = make(map[string]struct{})
+								ambassadorConfig.Image = getAmbassadorImage()
+								ipAddr := targetInfo.NetworkSettings.IpAddress
+								//Set the port as the environment variable
+								for p, _ := range targetInfo.NetworkSettings.Ports {
+									portInfo := strings.Split(p, "/")
+									port, protocol := portInfo[0], portInfo[1]
+									env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", strings.ToUpper(alias), port, strings.ToUpper(protocol), protocol, ipAddr, port))
+									ambassadorConfig.ExposedPorts[p] = EMPTY
+								}
+								//Copy the environment variables from linked container
+								env = append(env, targetInfo.Config.Env...)
+
+								ambassadorConfig.Env = env
+								log.Infof("Create ambassador container %s with exposed ports: %v", ambassadorName, ambassadorConfig.ExposedPorts)
+								var ambassadorContainer *cluster.Container
+								ambassadorContainer, err := containerNode.Create(&ambassadorConfig, ambassadorName, false)
+								if err != nil {
+									log.Warningf("Failed to create the ambassador container %s: %v", ambassadorName, err)
+									return err
+								}
+								var hostConfig dockerclient.HostConfig
+								err = containerNode.StartContainer(ambassadorContainer.Id, &hostConfig)
+								if err != nil {
+									log.Warningf("Failed to start the ambassador container %s: %v", ambassadorName, err)
+									return err
+								}
+							}
+						} else {
+							log.Warningf("Failed to inspect link container %s: %v", target.Id, err)
+							return err
+						}
+					}
+				}
+				break
+			}
+		}
+		newLinks = append(newLinks, link)
+	}
+	//Update the Links
+	config.Links = newLinks
+	return nil
+}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+// Start the container and process the links for cross-host links
+func startContainerHandler(c *context, w http.ResponseWriter, r *http.Request, container *cluster.Container) error {
+	var config dockerclient.HostConfig
+	var err error
+	if r.ContentLength > 0 { //Ignore handling if no request body
+		err = json.NewDecoder(r.Body).Decode(&config)
+
+		if err == nil {
+			err = processLinks(c, container.Node(), &config)
+			if err == nil {
+				new_body, _ := json.Marshal(config)
+				r.Body = nopCloser{bytes.NewBuffer(new_body)}
+				r.ContentLength = 0
+			}
+		}
+	}
+
+	return err
+}
+
+type ProxyHandler func(c *context, w http.ResponseWriter, r *http.Request, container *cluster.Container) error
+
+func abstractContainerProxyImpl(c *context, w http.ResponseWriter, r *http.Request, handler ProxyHandler) {
+	container := c.cluster.Container(mux.Vars(r)["name"])
+	if container != nil {
+		// The handler to intercept the request processing.
+		if handler != nil {
+			err := handler(c, w, r, container)
+			if err != nil {
+				httpError(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+		}
+		// Use a new client for each request
+		client := &http.Client{}
+
+		// RequestURI may not be sent to client
+		r.RequestURI = ""
+
+		parts := strings.SplitN(container.Node().Addr, "://", 2)
+		if len(parts) == 2 {
+			r.URL.Scheme = parts[0]
+			r.URL.Host = parts[1]
+		} else {
+			r.URL.Scheme = "http"
+			r.URL.Host = parts[0]
+		}
+
+		log.Debugf("[PROXY] --> %s %s", r.Method, r.URL)
+		resp, err := client.Do(r)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	}
+}
+
+func startContainer(c *context, w http.ResponseWriter, r *http.Request) {
+	abstractContainerProxyImpl(c, w, r, startContainerHandler)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -459,7 +459,7 @@ func processLinks(c *context, containerNode *cluster.Node, config *dockerclient.
 								ambassadorConfig.Image = getAmbassadorImage()
 								ipAddr := targetInfo.NetworkSettings.IpAddress
 								//Set the port as the environment variable
-								for p, _ := range targetInfo.NetworkSettings.Ports {
+								for p := range targetInfo.NetworkSettings.Ports {
 									portInfo := strings.Split(p, "/")
 									port, protocol := portInfo[0], portInfo[1]
 									env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", strings.ToUpper(alias), port, strings.ToUpper(protocol), protocol, ipAddr, port))

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -396,3 +396,14 @@ func (n *Node) CleanupContainers() {
 	n.containers = make(map[string]*Container)
 	n.Unlock()
 }
+
+// Inject a container into the internal state.
+func (n *Node) InspectContainer(id string) (*dockerclient.ContainerInfo, error) {
+
+	return n.client.InspectContainer(id)
+}
+
+// Inject a container into the internal state.
+func (n *Node) StartContainer(id string, config *dockerclient.HostConfig) error {
+	return n.client.StartContainer(id, config)
+}

--- a/flags.go
+++ b/flags.go
@@ -6,7 +6,6 @@ var (
 	flDiscovery = cli.StringFlag{
 		Name:   "discovery",
 		Value:  "",
-		Usage:  "DiscoveryService to use [token://<token>, etcd://<ip1>,<ip2>/<path>, file://path/to/file, consul://<addr>/<path>]",
 		EnvVar: "SWARM_DISCOVERY",
 	}
 	flAddr = cli.StringFlag{
@@ -57,7 +56,7 @@ var (
 	}
 	flFilter = cli.StringSliceFlag{
 		Name:  "filter, f",
-		Usage: "Filter to use [constraint, health, port]",
-		Value: &cli.StringSlice{"constraint", "health", "port"},
+		Usage: "Filter to use [constraint, health, port, volume, net]",
+		Value: &cli.StringSlice{"constraint", "health", "port", "volume", "net"},
 	}
 )

--- a/scheduler/filter/collocation.go
+++ b/scheduler/filter/collocation.go
@@ -1,0 +1,30 @@
+package filter
+
+import (
+	"github.com/docker/swarm/cluster"
+	"strings"
+)
+
+// CollocationFilter provides the helper to find the node to locate the containers.
+
+type CollocationFilter struct {
+}
+
+func (c *CollocationFilter) FindNode(IdOrName string, nodes []*cluster.Node) *cluster.Node {
+
+	for _, node := range nodes {
+		for _, container := range node.Containers() {
+			// Match ID prefix.
+			if strings.HasPrefix(container.Id, IdOrName) {
+				return node
+			}
+			// Match name, /name or engine/name.
+			for _, name := range container.Names {
+				if name == IdOrName || name == "/"+IdOrName || node.ID+name == IdOrName || node.Name+name == IdOrName {
+					return node
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/scheduler/filter/filter.go
+++ b/scheduler/filter/filter.go
@@ -23,6 +23,8 @@ func init() {
 		"health":     &HealthFilter{},
 		"constraint": &ConstraintFilter{},
 		"port":       &PortFilter{},
+		"volume":     &VolumeFilter{},
+		"net":        &NetFilter{},
 	}
 }
 

--- a/scheduler/filter/net.go
+++ b/scheduler/filter/net.go
@@ -1,0 +1,32 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/docker/swarm/cluster"
+	"github.com/samalba/dockerclient"
+	"strings"
+)
+
+// VolumeFilter guarantees that, when scheduling a container with the volumes from other containers
+// , it will be located on the same node.
+type NetFilter struct {
+	CollocationFilter
+}
+
+const CONTAINER_PREFIX = "container:"
+
+func (v *NetFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
+	candidates := []*cluster.Node{}
+	networkMode := config.HostConfig.NetworkMode
+	if strings.HasPrefix(networkMode, CONTAINER_PREFIX) {
+		IdOrName := networkMode[len(CONTAINER_PREFIX):]
+		node := v.FindNode(IdOrName, nodes)
+		if node == nil {
+			return nil, fmt.Errorf("unable to find a node with container %s", IdOrName)
+		}
+		candidates = append(candidates, node)
+	} else {
+		candidates = append(candidates, nodes...)
+	}
+	return candidates, nil
+}

--- a/scheduler/filter/volume.go
+++ b/scheduler/filter/volume.go
@@ -1,0 +1,36 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/docker/swarm/cluster"
+	"github.com/samalba/dockerclient"
+)
+
+// VolumeFilter guarantees that, when scheduling a container with the volumes from other containers
+// , it will be located on the same node.
+type VolumeFilter struct {
+	CollocationFilter
+}
+
+func (v *VolumeFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
+	candidates := []*cluster.Node{}
+	volumesFrom := config.HostConfig.VolumesFrom
+	if volumesFrom != nil && len(volumesFrom) > 0 {
+		var result *cluster.Node
+		for _, IdOrName := range volumesFrom {
+			node := v.FindNode(IdOrName, nodes)
+			if node == nil {
+				return nil, fmt.Errorf("unable to find a node with container %s", IdOrName)
+			}
+			if result == nil {
+				result = node
+			} else if result != node {
+				return nil, fmt.Errorf("unable to find a node for conflicts of VolumesFrom %v", volumesFrom)
+			}
+		}
+		candidates = append(candidates, result)
+	} else {
+		candidates = append(candidates, nodes...)
+	}
+	return candidates, nil
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -26,7 +26,10 @@ func NewScheduler(cluster *cluster.Cluster, strategy strategy.PlacementStrategy,
 }
 
 // Find a nice home for our container.
-func (s *Scheduler) selectNodeForContainer(config *dockerclient.ContainerConfig) (*cluster.Node, error) {
+func (s *Scheduler) SelectNodeForContainer(config *dockerclient.ContainerConfig) (*cluster.Node, error) {
+	s.Lock()
+	defer s.Unlock()
+
 	candidates := s.cluster.Nodes()
 
 	accepted, err := filter.ApplyFilters(s.filters, config, candidates)
@@ -45,10 +48,7 @@ func (s *Scheduler) CreateContainer(config *dockerclient.ContainerConfig, name s
 	}
 	*/
 
-	s.Lock()
-	defer s.Unlock()
-
-	node, err := s.selectNodeForContainer(config)
+	node, err := s.SelectNodeForContainer(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To enable the cross-host linking on the swarm, I made the following enhancement to the current swarm code base

1) Create the ambassador container if the linked container is on the different host.
The ambassador container will be created when create/start container has the "Links" in the HostConfig. And the ambassador container will be removed automatically if the corresponding container is removed.

By default, the ambassador container is using the image "svendowideit/ambassador:latest" and it can be overridden with the Env variable AMBASSADOR_IMAGE. So it is possible to provide the ambassador for dynamic docker link cross-host in the future. 

2) Provide the new filters to handle the --volume-from and  --net=container:xxx
The new container will be collocated with the one to share the volumes and network configuration.

NOTE:
To make the cross-host link on Swarm work properly, It need to enable the network access for the containers in cluster. I leverage Kubernetes code to create sample config of swarm cluster with Vagrant.  The detail could be found in https://github.com/denverdino/docker-swarm-vagrant

Test cases

a) For volume filter

docker run -d -v /foo --name data busybox true
CID=$(docker run -d --volumes-from data busybox true)
docker inspect --format="{{.Volumes}}" $CID

You will see the volume created from "data" container. 

b) For volume filter
docker run -d --name nettest nginx
CID=$(docker run -d --net=container:nettest busybox /bin/sh -c "while true; do echo hello world; sleep 1; done")
docker inspect --format="{{.NetworkSettings}}" $CID

You will see there is no IPAddress assigned for the 2nd container. 

c) For linked containers

docker run --name some_mysql -e MYSQL_ROOT_PASSWORD=password -d mysql
docker run --name some_wp -p 8888:80 --link some_mysql:mysql -d wordpress
docker run --name some_wp1 -p 8888:80 --link some_mysql:mysql -d wordpress
docker run --name some_wp2 -p 8888:80 --link some_mysql:mysql -d wordpress
docker ps

The wordpress containers will be placed on the different hosts, and they will connect to the same mysql database. The ambassador container for mysql will be created If wordpress and mysql container are not on the same host.

d) For fig template
fig.yml is as following

```
web:
  image: wordpress
  ports:
    - "8000:80"
  links:
    - db:mysql
db:
  image: mysql
  environment:
    MYSQL_ROOT_PASSWORD: password
```

It need the fig with the enhancement for the Swarm cluster support from https://github.com/denverdino/fig

Thanks



