### PR TITLE
make use of the "pullImage" parameter of node.Create method

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -264,7 +264,7 @@ func (n *Node) Create(config *dockerclient.ContainerConfig, name string, pullIma
 
 	if id, err = client.CreateContainer(&newConfig, name); err != nil {
 		// If the error is other than not found, abort immediately.
-		if err != dockerclient.ErrNotFound {
+		if err != dockerclient.ErrNotFound || !pullImage {
 			return nil, err
 		}
 		// Otherwise, try to pull the image...


### PR DESCRIPTION
The 'pullImage' parameter of node.Create method is not used currently.