### PR TITLE
restart the event monitor when unhealthy node comes back

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -90,6 +90,7 @@ func (n *Node) connectClient(client dockerclient.Client) error {
 
 	// Start monitoring events from the Node.
 	n.client.StartMonitorEvents(n.handler)
+	n.emitCustomEvent("node_connect")
 
 	return nil
 }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -250,6 +250,9 @@ func (n *Node) refreshLoop() {
 				n.client.StopAllMonitorEvents()
 				n.client.StartMonitorEvents(n.handler)
 				n.emitCustomEvent("node_reconnect")
+				if err := n.updateSpecs(); err != nil {
+					log.Errorf("[%s/%s] Update node specs failed: %v", n.ID, n.Name, err)
+				}
 			}
 			n.healthy = true
 		}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -243,6 +243,8 @@ func (n *Node) refreshLoop() {
 		} else {
 			if !n.healthy {
 				log.Infof("[%s/%s] Node came back to life. Hooray!", n.ID, n.Name)
+				n.client.StopAllMonitorEvents()
+				n.client.StartMonitorEvents(n.handler)
 			}
 			n.healthy = true
 		}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -239,7 +239,7 @@ func (n *Node) refreshLoop() {
 
 		if err != nil {
 			if n.healthy {
-				n.emitCustomEvent("node_die")
+				n.emitCustomEvent("node_disconnect")
 			}
 			n.healthy = false
 			log.Errorf("[%s/%s] Flagging node as dead. Updated state failed: %v", n.ID, n.Name, err)
@@ -248,7 +248,7 @@ func (n *Node) refreshLoop() {
 				log.Infof("[%s/%s] Node came back to life. Hooray!", n.ID, n.Name)
 				n.client.StopAllMonitorEvents()
 				n.client.StartMonitorEvents(n.handler)
-				n.emitCustomEvent("node_comes_back")
+				n.emitCustomEvent("node_reconnect")
 			}
 			n.healthy = true
 		}


### PR DESCRIPTION
When an unhealthy node comes back, the event monitor should be restarted.
Otherwise the events can't be received.

The problem can be reproduced by:
1. Start the leader process
2. Join a node to the cluster
3. Stop the docker daemon on the agent node after the node is discovered by the cluster, and start it again after the leader marks it as unhealthy
4. Try to stop/start or run a container and see the logs of the leader,  you'll find that no events are received any more.
