### PR TITLE
Cleanup: zookeeper discovery's watcher

### DIFF
--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -3,14 +3,23 @@ package zookeeper
 import (
 	"testing"
 
+	"github.com/docker/swarm/discovery"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInitialize(t *testing.T) {
-	discovery := &ZkDiscoveryService{}
-	assert.Error(t, discovery.Initialize("127.0.0.1/path", 0))
-	assert.Equal(t, discovery.path, "/path")
+	service := &ZkDiscoveryService{}
+	assert.Error(t, service.Initialize("127.0.0.1/path", 0))
+	assert.Equal(t, service.path, "/path")
 
-	assert.Error(t, discovery.Initialize("127.0.0.1,127.0.0.2,127.0.0.3/path", 0))
-	assert.Equal(t, discovery.path, "/path")
+	assert.Error(t, service.Initialize("127.0.0.1,127.0.0.2,127.0.0.3/path", 0))
+	assert.Equal(t, service.path, "/path")
+}
+
+func TestCreateNodes(t *testing.T) {
+	service := &ZkDiscoveryService{}
+	assert.Equal(t, service.createNodes(nil), []*discovery.Node{})
+	nodes := service.createNodes([]string{"127.0.0.1", "127.0.0.2"})
+	assert.Equal(t, nodes[0].String(), "http://127.0.0.1")
+	assert.Equal(t, nodes[1].String(), "http://127.0.0.2")
 }


### PR DESCRIPTION
This PR is to improve the ZooKeeper's discovery a bit by calling callback 1 more time before getting into the event channel loop. As zk.ChildrenW() returns a list of nodes for the first time, `Swarm` does not need to wait until the next event get fired.

A unit test is also added.