### PR TITLE
Proposal: constraint & affinity filter expression enhancement

### DIFF
--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -150,15 +150,22 @@ As you can see here, the containers were only scheduled on nodes with the redis 
 #### Constraint Expression Syntax
 
 Additionally, you can use a not (`!`) to negate and a regular expression in the form of `/regexp/` for specifying a constraint.
+Relative comparisons, `>=` and `<=` are also supported, but they are limited to `string` comparison only.
+
 For example,
 
 * `constraint:name=node1` will match nodes named with `node1`.
-* `constraint:name=!node1` will match all nodes, except `node1`.
+* `constraint:name==node1` will also match nodes named with `node1`. Note that `==` also allowed.
+* `constraint:name!=node1` will match all nodes, except `node1`.
+* `constraint:name=!node1` will match all nodes, except `node1` (alternative syntax).
 * `constraint:region=!us*` will match all nodes outside the regions prefixed with `us`.
 * `constraint:name=/node[12]/` will match nodes named `node1` and `node2`.
 * `constraint:name=/node\d/` will match all nodes named with `node` + 1 digit.
 * `constraint:node=!/node-[01]-id/` will match all nodes, except those with ids `node-0-id` and `node-1-id`.
 * `constraint:name=!/foo\[bar\]/` will match all nodes, except those with name `foo[bar]`. You can see the use of escape characters here.
+* `constraint:name=/(?i)node1/` will match all nodes named with `node1` case-insensitive. So 'NoDe1' or 'NODE1' will also matched.
+* `constraint:kernel>=3.0` will match all nodes with label `kernel` greater than or equal to "3.0". This is the string, not numeric, comparison.
+* `constraint:group<=3` will match all nodes with `group`  less than or equal to "3". This is also the string, not numeric, comparison.
 
 ## Port Filter
 

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -152,12 +152,13 @@ As you can see here, the containers were only scheduled on nodes with the redis 
 Additionally, you can use a not (`!`) to negate and a regular expression in the form of `/regexp/` for specifying a constraint.
 For example,
 
-* `name=node1` will match nodes named with `node1`.
-* `name=!node1` will match all nodes, except `node1`.
-* `region=!us*` will match all nodes outside the regions prefixed with `us`.
-* `name=/node[12]/` will match nodes named `node1` and `node2`.
-* `name=/node\d/` will match all nodes named with `node` + 1 digit
-* `node=!/node-[01]-id/` will match all nodes, except those with ids `node-0-id` and `node-1-id`
+* `constraint:name=node1` will match nodes named with `node1`.
+* `constraint:name=!node1` will match all nodes, except `node1`.
+* `constraint:region=!us*` will match all nodes outside the regions prefixed with `us`.
+* `constraint:name=/node[12]/` will match nodes named `node1` and `node2`.
+* `constraint:name=/node\d/` will match all nodes named with `node` + 1 digit.
+* `constraint:node=!/node-[01]-id/` will match all nodes, except those with ids `node-0-id` and `node-1-id`.
+* `constraint:name=!/foo\[bar\]/` will match all nodes, except those with name `foo[bar]`. You can see the use of escape characters here.
 
 ## Port Filter
 

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -45,7 +45,7 @@ Once the nodes are registered with the cluster, the master pulls their respectiv
 Let's start a MySQL server and make sure it gets good I/O performance by selecting nodes with flash drives:
 
 ```
-$ docker run -d -P -e constraint:storage=ssd --name db mysql
+$ docker run -d -P -e constraint:storage==ssd --name db mysql
 f8b693db9cd6
 
 $ docker ps
@@ -59,7 +59,7 @@ In this case, the master selected all nodes that met the `storage=ssd` constrain
 Now we want to run an `nginx` frontend in our cluster. However, we don't want *flash* drives since we'll mostly write logs to disk.
 
 ```
-$ docker run -d -P -e constraint:storage=disk --name frontend nginx
+$ docker run -d -P -e constraint:storage==disk --name frontend nginx
 f8b693db9cd6
 
 $ docker ps
@@ -161,16 +161,14 @@ You can use a not (`!`) to negate and a regular expression in the form of `/rege
 Relative comparisons, `>=` and `<=` are also supported, but they are limited to `string` comparison only.
 
 For example,
-* `constraint:name=node1` will match nodes named with `node1`.
-* `constraint:name==node1` will also match nodes named with `node1`. Note that `==` also allowed.
+* `constraint:name==node1` will match nodes named with `node1`.
 * `constraint:name!=node1` will match all nodes, except `node1`.
-* `constraint:name=!node1` will match all nodes, except `node1` (alternative syntax).
-* `constraint:region=!us*` will match all nodes outside the regions prefixed with `us`.
-* `constraint:name=/node[12]/` will match nodes named `node1` and `node2`.
-* `constraint:name=/node\d/` will match all nodes named with `node` + 1 digit.
-* `constraint:node=!/node-[01]-id/` will match all nodes, except those with ids `node-0-id` and `node-1-id`.
-* `constraint:name=!/foo\[bar\]/` will match all nodes, except those with name `foo[bar]`. You can see the use of escape characters here.
-* `constraint:name=/(?i)node1/` will match all nodes named with `node1` case-insensitive. So 'NoDe1' or 'NODE1' will also matched.
+* `constraint:region!=us*` will match all nodes outside the regions prefixed with `us`.
+* `constraint:name==/node[12]/` will match nodes named `node1` and `node2`.
+* `constraint:name==/node\d/` will match all nodes named with `node` + 1 digit.
+* `constraint:node!=/node-[01]-id/` will match all nodes, except those with ids `node-0-id` and `node-1-id`.
+* `constraint:name!=/foo\[bar\]/` will match all nodes, except those with name `foo[bar]`. You can see the use of escape characters here.
+* `constraint:name==/(?i)node1/` will match all nodes named with `node1` case-insensitive. So 'NoDe1' or 'NODE1' will also matched.
 * `constraint:kernel>=3.0` will match all nodes with label `kernel` greater than or equal to "3.0". This is the string, not numeric, comparison.
 * `constraint:group<=3` will match all nodes with `group`  less than or equal to "3". This is also the string, not numeric, comparison.
 

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -95,11 +95,11 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 87c4376856a8        nginx:latest        "nginx"             Less than a second ago   running             192.168.0.42:80->80/tcp         node-1      front
 ```
 
-Using `-e affinity:container=front` will schedule a container next to the container `front`.
-You can also use IDs instead of name: `-e affinity:container=87c4376856a8`
+Using `-e affinity:container==front` will schedule a container next to the container `front`.
+You can also use IDs instead of name: `-e affinity:container==87c4376856a8`
 
 ```
-$ docker run -d --name logger -e affinity:container=front logger
+$ docker run -d --name logger -e affinity:container==front logger
  87c4376856a8
 
 $ docker ps
@@ -124,14 +124,14 @@ Here only `node-1` and `node-3` have the `redis` image. Using `-e affinity:image
 schedule container only on these 2 nodes. You can also use the image ID instead of it's name.
 
 ```
-$ docker run -d --name redis1 -e affinity:image=redis redis
-$ docker run -d --name redis2 -e affinity:image=redis redis
-$ docker run -d --name redis3 -e affinity:image=redis redis
-$ docker run -d --name redis4 -e affinity:image=redis redis
-$ docker run -d --name redis5 -e affinity:image=redis redis
-$ docker run -d --name redis6 -e affinity:image=redis redis
-$ docker run -d --name redis7 -e affinity:image=redis redis
-$ docker run -d --name redis8 -e affinity:image=redis redis
+$ docker run -d --name redis1 -e affinity:image==redis redis
+$ docker run -d --name redis2 -e affinity:image==redis redis
+$ docker run -d --name redis3 -e affinity:image==redis redis
+$ docker run -d --name redis4 -e affinity:image==redis redis
+$ docker run -d --name redis5 -e affinity:image==redis redis
+$ docker run -d --name redis6 -e affinity:image==redis redis
+$ docker run -d --name redis7 -e affinity:image==redis redis
+$ docker run -d --name redis8 -e affinity:image==redis redis
 
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED                  STATUS              PORTS                           NODE        NAMES
@@ -147,9 +147,9 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 
 As you can see here, the containers were only scheduled on nodes with the redis imagealreayd pulled.
 
-#### Constraint Expression Syntax
+#### Expression Syntax
 
-As previously mentioned, a constraint consists of a `key` and a `value`.
+An affinity or a constraint expression consists of a `key` and a `value`.
 A `key` must conform the alpha-numeric pattern, with the leading alphabet or underscore.
 
 A `value` must be one of the following:
@@ -157,8 +157,8 @@ A `value` must be one of the following:
 * A globbing pattern, i.e., `abc*`.
 * A regular expression in the form of `/regexp/`. We support the Go's regular expression syntax.
 
-You can use a not (`!`) to negate and a regular expression in the form of `/regexp/` for specifying a constraint.
-Relative comparisons, `>=` and `<=` are also supported, but they are limited to `string` comparison only.
+Current `swarm` supports affinity/constraint operators as the following: `==`, `!=`, `>=` and `<=`.
+Relative comparisons, `>=` and `<=` are supported, but limited to `string` comparison only.
 
 For example,
 * `constraint:name==node1` will match nodes named with `node1`.

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -147,6 +147,18 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 
 As you can see here, the containers were only scheduled on nodes with the redis imagealreayd pulled.
 
+#### Constraint Expression Syntax
+
+Additionally, you can use a not (`!`) to negate and a regular expression in the form of `/regexp/` for specifying a constraint.
+For example,
+
+* `name=node1` will match nodes named with `node1`.
+* `name=!node1` will match all nodes, except `node1`.
+* `region=!us*` will match all nodes outside the regions prefixed with `us`.
+* `name=/node[12]/` will match nodes named `node1` and `node2`.
+* `name=/node\d/` will match all nodes named with `node` + 1 digit
+* `node=!/node-[01]-id/` will match all nodes, except those with ids `node-0-id` and `node-1-id`
+
 ## Port Filter
 
 With this filter, `ports` are considered as a unique resource.

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -149,11 +149,18 @@ As you can see here, the containers were only scheduled on nodes with the redis 
 
 #### Constraint Expression Syntax
 
-Additionally, you can use a not (`!`) to negate and a regular expression in the form of `/regexp/` for specifying a constraint.
+As previously mentioned, a constraint consists of a `key` and a `value`.
+A `key` must conform the alpha-numeric pattern, with the leading alphabet or underscore.
+
+A `value` must be one of the following:
+* An alpha-numeric string, dots, hyphens, and underscores.
+* A globbing pattern, i.e., `abc*`.
+* A regular expression in the form of `/regexp/`. We support the Go's regular expression syntax.
+
+You can use a not (`!`) to negate and a regular expression in the form of `/regexp/` for specifying a constraint.
 Relative comparisons, `>=` and `<=` are also supported, but they are limited to `string` comparison only.
 
 For example,
-
 * `constraint:name=node1` will match nodes named with `node1`.
 * `constraint:name==node1` will also match nodes named with `node1`. Note that `==` also allowed.
 * `constraint:name!=node1` will match all nodes, except `node1`.

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -47,6 +47,14 @@ func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []
 		v0 := v
 		k0 := k
 
+		// support case of constraint:k==v
+		// try to check = on both sides, "k= : = : v" and "k : = : =v", to make sure it works everywhere
+		if strings.HasSuffix(k, "=") {
+			k = strings.TrimSuffix(k, "=")
+		} else if strings.HasPrefix(v, "=") {
+			v = strings.TrimPrefix(v, "=")
+		}
+
 		negate := false
 		if strings.HasPrefix(v, "!") {
 			log.Debugf("negate detected in value")

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -13,7 +13,10 @@ type ConstraintFilter struct {
 }
 
 func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
-	constraints := extractEnv("constraint", config.Env)
+	constraints, err := extractEnv("constraint", config.Env)
+	if err != nil {
+		return nil, err
+	}
 	for k, v := range constraints {
 		log.Debugf("matching constraint: %s=%s", k, v)
 

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -31,7 +31,7 @@ func (f *ConstraintFilter) match(pattern, s string, useRegex bool) bool {
 	if !useRegex {
 		regex = "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
 	}
-	matched, err := regexp.MatchString(regex, strings.ToLower(s))
+	matched, err := regexp.MatchString(regex, s)
 	if err != nil {
 		log.Error(err)
 	}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -12,41 +12,79 @@ import (
 type ConstraintFilter struct {
 }
 
+func (f *ConstraintFilter) extractConstraints(env []string) map[string]string {
+	constraints := make(map[string]string)
+	for _, e := range env {
+		if strings.HasPrefix(e, "constraint:") {
+			constraint := strings.TrimPrefix(e, "constraint:")
+			parts := strings.SplitN(constraint, "=", 2)
+			constraints[strings.ToLower(parts[0])] = strings.ToLower(parts[1])
+		}
+	}
+	return constraints
+}
+
+// Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$)
+// and match.
+func (f *ConstraintFilter) match(pattern, s string, useRegex bool) bool {
+	regex := pattern
+	if !useRegex {
+		regex = "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
+	}
+	matched, err := regexp.MatchString(regex, strings.ToLower(s))
+	if err != nil {
+		log.Error(err)
+	}
+	return matched
+}
+
 func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
 	constraints := extractEnv("constraint", config.Env)
 	for k, v := range constraints {
+
+		v0 := v
+
 		log.Debugf("matching constraint: %s=%s", k, v)
+
 		negate := false
+		useRegex := false
+
 		if strings.HasPrefix(v, "!") {
 			log.Debugf("negate detected")
 			v = strings.TrimPrefix(v, "!")
 			negate = true
 		}
+		if strings.HasPrefix(v, "/") && strings.HasSuffix(v, "/") {
+			log.Infof("regex detected")
+			v = strings.TrimPrefix(strings.TrimSuffix(v, "/"), "/")
+			useRegex = true
+		}
+
 		candidates := []*cluster.Node{}
 		for _, node := range nodes {
 			switch k {
 			case "node":
 				// "node" label is a special case pinning a container to a specific node.
+<<<<<<< HEAD
 				if match(v, node.ID) || match(v, node.Name) {
+=======
+				matchResult := f.match(v, node.ID, useRegex) || f.match(v, node.Name, useRegex)
+				if (negate && !matchResult) || (!negate && matchResult) {
+>>>>>>> improve regexp matching
 					candidates = append(candidates, node)
 				}
 			default:
 				// By default match the node labels.
 				if label, ok := node.Labels[k]; ok {
-					if negate {
-						if f.match(v, label) == false {
-							candidates = append(candidates, node)
-						}
-					} else {
-						if f.match(v, label) {
-							candidates = append(candidates, node)
-						}
+					matchResult := f.match(v, label, useRegex)
+					if (negate && !matchResult) || (!negate && matchResult) {
+						candidates = append(candidates, node)
 					}
 				}
 			}
 		}
 		if len(candidates) == 0 {
-			return nil, fmt.Errorf("unable to find a node that satisfies %s == %s", k, v)
+			return nil, fmt.Errorf("unable to find a node that satisfies %s = %s", k, v0)
 		}
 		nodes = candidates
 	}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -12,32 +12,6 @@ import (
 type ConstraintFilter struct {
 }
 
-func (f *ConstraintFilter) extractConstraints(env []string) map[string]string {
-	constraints := make(map[string]string)
-	for _, e := range env {
-		if strings.HasPrefix(e, "constraint:") {
-			constraint := strings.TrimPrefix(e, "constraint:")
-			parts := strings.SplitN(constraint, "=", 2)
-			constraints[strings.ToLower(parts[0])] = strings.ToLower(parts[1])
-		}
-	}
-	return constraints
-}
-
-// Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$)
-// and match.
-func (f *ConstraintFilter) match(pattern, s string, useRegex bool) bool {
-	regex := pattern
-	if !useRegex {
-		regex = "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
-	}
-	matched, err := regexp.MatchString(regex, s)
-	if err != nil {
-		log.Error(err)
-	}
-	return matched
-}
-
 func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
 	constraints := extractEnv("constraint", config.Env)
 	for k, v := range constraints {
@@ -47,71 +21,33 @@ func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []
 		v0 := v
 		k0 := k
 
-		// support case of constraint:k==v
-		// try to check = on both sides, "k= : = : v" and "k : = : =v", to make sure it works everywhere
-		if strings.HasSuffix(k, "=") {
-			k = strings.TrimSuffix(k, "=")
-		} else if strings.HasPrefix(v, "=") {
-			v = strings.TrimPrefix(v, "=")
-		}
-
-		negate := false
-		if strings.HasPrefix(v, "!") {
-			log.Debugf("negate detected in value")
-			v = strings.TrimPrefix(v, "!")
-			negate = true
-		} else if strings.HasSuffix(k, "!") {
-			log.Debugf("negate detected in key")
-			k = strings.TrimSuffix(k, "!")
-			negate = true
-		}
-
-		gte := strings.HasSuffix(k, ">")
-		lte := strings.HasSuffix(k, "<")
-		if gte {
-			log.Debugf("gt (>) detected in key")
-			k = strings.TrimSuffix(k, ">")
-		} else if lte {
-			log.Debugf("lt (<) detected in key")
-			k = strings.TrimSuffix(k, "<")
-		}
-
-		useRegex := false
-		if strings.HasPrefix(v, "/") && strings.HasSuffix(v, "/") {
-			log.Debugf("regex detected")
-			v = strings.TrimPrefix(strings.TrimSuffix(v, "/"), "/")
-			useRegex = true
-		}
+		k, v, mode, useRegex := parse(k, v)
 
 		candidates := []*cluster.Node{}
 		for _, node := range nodes {
 			switch k {
 			case "node":
-				// "node" label is a special case pinning a container to a specific node.
-				matchResult := f.match(v, node.ID, useRegex) || f.match(v, node.Name, useRegex)
-				if (negate && !matchResult) || (!negate && matchResult) {
-
-				if gte && node.ID >= v {
+				if mode == gte && node.ID >= v {
 					candidates = append(candidates, node)
-				} else if lte && node.ID <= v {
+				} else if mode == lte && node.ID <= v {
 					candidates = append(candidates, node)
 				} else {
 					// "node" label is a special case pinning a container to a specific node.
-					matchResult := f.match(v, node.ID, useRegex) || f.match(v, node.Name, useRegex)
-					if (negate && !matchResult) || (!negate && matchResult) {
+					matchResult := match(v, node.ID, useRegex) || match(v, node.Name, useRegex)
+					if (mode == neg && !matchResult) || (mode == equ && matchResult) {
 						candidates = append(candidates, node)
 					}
 				}
 			default:
 				// By default match the node labels.
 				if label, ok := node.Labels[k]; ok {
-					if gte && label >= v {
+					if mode == gte && label >= v {
 						candidates = append(candidates, node)
-					} else if lte && label <= v {
+					} else if mode == lte && label <= v {
 						candidates = append(candidates, node)
 					} else {
-						matchResult := f.match(v, label, useRegex)
-						if (negate && !matchResult) || (!negate && matchResult) {
+						matchResult := match(v, label, useRegex)
+						if (mode == neg && !matchResult) || (mode == equ && matchResult) {
 							candidates = append(candidates, node)
 						}
 					}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -41,21 +41,21 @@ func (f *ConstraintFilter) match(pattern, s string, useRegex bool) bool {
 func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
 	constraints := extractEnv("constraint", config.Env)
 	for k, v := range constraints {
-
-		v0 := v
-
 		log.Debugf("matching constraint: %s=%s", k, v)
 
-		negate := false
-		useRegex := false
+		// keep the original for display in case of error
+		v0 := v
 
+		negate := false
 		if strings.HasPrefix(v, "!") {
 			log.Debugf("negate detected")
 			v = strings.TrimPrefix(v, "!")
 			negate = true
 		}
+
+		useRegex := false
 		if strings.HasPrefix(v, "/") && strings.HasSuffix(v, "/") {
-			log.Infof("regex detected")
+			log.Debugf("regex detected")
 			v = strings.TrimPrefix(strings.TrimSuffix(v, "/"), "/")
 			useRegex = true
 		}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -45,11 +45,16 @@ func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []
 
 		// keep the original for display in case of error
 		v0 := v
+		k0 := k
 
 		negate := false
 		if strings.HasPrefix(v, "!") {
-			log.Debugf("negate detected")
+			log.Debugf("negate detected in value")
 			v = strings.TrimPrefix(v, "!")
+			negate = true
+		} else if strings.HasSuffix(k, "!") {
+			log.Debugf("negate detected in key")
+			k = strings.TrimSuffix(k, "!")
 			negate = true
 		}
 
@@ -84,7 +89,7 @@ func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []
 			}
 		}
 		if len(candidates) == 0 {
-			return nil, fmt.Errorf("unable to find a node that satisfies %s = %s", k, v0)
+			return nil, fmt.Errorf("unable to find a node that satisfies %s=%s", k0, v0)
 		}
 		nodes = candidates
 	}

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -111,6 +111,12 @@ func TestConstrainteFilter(t *testing.T) {
 	}, nodes)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:region=*us*"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
 }
 
 func TestConstraintNotExpr(t *testing.T) {
@@ -226,41 +232,6 @@ func TestConstraintRegExp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[2])
-}
-
-func TestFilterRegExpWithEscape(t *testing.T) {
-	var (
-		f      = ConstraintFilter{}
-		nodes  = testFixtures()
-		result []*cluster.Node
-		err    error
-	)
-
-	// Prepare node with a strange name
-	node3 := cluster.NewNode("node-3", 0)
-	node3.ID = "node-3-id"
-	node3.Name = "node-3-name"
-	node3.Labels = map[string]string{
-		"name":   "foo[bar]",
-		"group":  "2",
-		"region": "eu",
-	}
-	nodes = append(nodes, node3)
-
-	// Test filter with a strange name
-	result, err = f.Filter(&dockerclient.ContainerConfig{
-		Env: []string{`constraint:name=/foo\[bar\]/`},
-	}, nodes)
-	assert.NoError(t, err)
-	assert.Len(t, result, 1)
-	assert.Equal(t, result[0], nodes[3])
-
-	// Test ! filter with a strange name
-	result, err = f.Filter(&dockerclient.ContainerConfig{
-		Env: []string{`constraint:name=!/foo\[bar\]/`},
-	}, nodes)
-	assert.NoError(t, err)
-	assert.Len(t, result, 3)
 }
 
 func TestFilterRegExpCaseInsensitive(t *testing.T) {

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -356,3 +356,35 @@ func TestFilterWithRelativeComparisons(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 }
+
+func TestFilterWithDoubleEquals(t *testing.T) {
+	var (
+		f      = ConstraintFilter{}
+		nodes  = testFixtures()
+		result []*cluster.Node
+		err    error
+	)
+
+	// Check == comparison
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:name==node0"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+
+	// Test == with glob
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:region==us*"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+
+	// Validate node name with ==
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:node==node-1-name"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, result[0], nodes[1])
+
+}

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -151,6 +151,44 @@ func TestConstraintNotExpr(t *testing.T) {
 	assert.Equal(t, result[0].Labels["region"], "eu")
 }
 
+func TestConstraintAlternativeNotExpr(t *testing.T) {
+	var (
+		f      = ConstraintFilter{}
+		nodes  = testFixtures()
+		result []*cluster.Node
+		err    error
+	)
+
+	// Check not (!) expression
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:name!=node0"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+
+	// Check not does_not_exist. All should be found
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:name!=does_not_exist"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+
+	// Check name must not start with n
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:name!=n*"},
+	}, nodes)
+	assert.Error(t, err)
+	assert.Len(t, result, 0)
+
+	// Check not with globber pattern
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:region!=us*"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, result[0].Labels["region"], "eu")
+}
+
 func TestConstraintRegExp(t *testing.T) {
 	var (
 		f      = ConstraintFilter{}

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -199,7 +199,7 @@ func TestFilterRegExpWithEscape(t *testing.T) {
 	)
 
 	// Prepare node with a strange name
-	node3 := cluster.NewNode("node-3")
+	node3 := cluster.NewNode("node-3", 0)
 	node3.ID = "node-3-id"
 	node3.Name = "node-3-name"
 	node3.Labels = map[string]string{
@@ -234,7 +234,7 @@ func TestFilterRegExpCaseInsensitive(t *testing.T) {
 	)
 
 	// Prepare node with a strange name
-	node3 := cluster.NewNode("node-3")
+	node3 := cluster.NewNode("node-3", 0)
 	node3.ID = "node-3-id"
 	node3.Name = "node-3-name"
 	node3.Labels = map[string]string{

--- a/scheduler/filter/utils.go
+++ b/scheduler/filter/utils.go
@@ -7,6 +7,63 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+<<<<<<< HEAD
+=======
+type comparison int
+
+const (
+	equ = comparison(iota)
+	neg
+	gte
+	lte
+)
+
+func parse(k, v string) (string, string, comparison, bool) {
+	// default comparison mode
+	mode := equ
+
+	// support case of constraint:k==v
+	// with "=", it's possible for an entry "k==v" to be split as:
+	// 1. "k=" as key and "v" as value
+	// 2. "k" as key and "=v" as value
+	// Just to make sure it cover these cases.
+	if strings.HasSuffix(k, "=") {
+		k = strings.TrimSuffix(k, "=")
+	} else if strings.HasPrefix(v, "=") {
+		v = strings.TrimPrefix(v, "=")
+	}
+
+	if strings.HasPrefix(v, "!") {
+		log.Debugf("negate detected in value")
+		v = strings.TrimPrefix(v, "!")
+		mode = neg
+	} else if strings.HasSuffix(k, "!") {
+		log.Debugf("negate detected in key")
+		k = strings.TrimSuffix(k, "!")
+		mode = neg
+	} else {
+		if strings.HasSuffix(k, ">") {
+			log.Debugf("gt (>) detected in key")
+			k = strings.TrimSuffix(k, ">")
+			mode = gte
+		} else if strings.HasSuffix(k, "<") {
+			log.Debugf("lt (<) detected in key")
+			k = strings.TrimSuffix(k, "<")
+			mode = lte
+		}
+	}
+
+	useRegex := false
+	if strings.HasPrefix(v, "/") && strings.HasSuffix(v, "/") {
+		log.Debugf("regex detected")
+		v = strings.TrimPrefix(strings.TrimSuffix(v, "/"), "/")
+		useRegex = true
+	}
+
+	return k, v, mode, useRegex
+}
+
+>>>>>>> add double equals comparison
 func extractEnv(key string, env []string) map[string]string {
 	values := make(map[string]string)
 	for _, e := range env {
@@ -23,10 +80,21 @@ func extractEnv(key string, env []string) map[string]string {
 	return values
 }
 
+<<<<<<< HEAD
 // Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$) and match.
 func match(pattern, s string) bool {
 	regex := "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
 	matched, err := regexp.MatchString(regex, strings.ToLower(s))
+=======
+// Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$)
+// and match.
+func match(pattern, s string, useRegex bool) bool {
+	regex := pattern
+	if !useRegex {
+		regex = "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
+	}
+	matched, err := regexp.MatchString(regex, s)
+>>>>>>> add double equals comparison
 	if err != nil {
 		log.Error(err)
 	}

--- a/scheduler/filter/utils.go
+++ b/scheduler/filter/utils.go
@@ -7,8 +7,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-<<<<<<< HEAD
-=======
 type comparison int
 
 const (
@@ -63,7 +61,6 @@ func parse(k, v string) (string, string, comparison, bool) {
 	return k, v, mode, useRegex
 }
 
->>>>>>> add double equals comparison
 func extractEnv(key string, env []string) map[string]string {
 	values := make(map[string]string)
 	for _, e := range env {
@@ -71,7 +68,7 @@ func extractEnv(key string, env []string) map[string]string {
 			value := strings.TrimPrefix(e, key+":")
 			parts := strings.SplitN(value, "=", 2)
 			if len(parts) == 2 {
-				values[strings.ToLower(parts[0])] = strings.ToLower(parts[1])
+				values[strings.ToLower(parts[0])] = parts[1]
 			} else {
 				values[strings.ToLower(parts[0])] = ""
 			}
@@ -80,21 +77,14 @@ func extractEnv(key string, env []string) map[string]string {
 	return values
 }
 
-<<<<<<< HEAD
 // Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$) and match.
-func match(pattern, s string) bool {
-	regex := "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
-	matched, err := regexp.MatchString(regex, strings.ToLower(s))
-=======
-// Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$)
-// and match.
+// If useRegex is true, the pattern will be used directly
 func match(pattern, s string, useRegex bool) bool {
 	regex := pattern
 	if !useRegex {
 		regex = "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
 	}
 	matched, err := regexp.MatchString(regex, s)
->>>>>>> add double equals comparison
 	if err != nil {
 		log.Error(err)
 	}

--- a/scheduler/filter/utils.go
+++ b/scheduler/filter/utils.go
@@ -8,95 +8,54 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-type comparison int
+type opWithValue []string
 
-const (
-	equ = comparison(iota)
-	neg
-	gte
-	lte
-)
-
-func parse(k, v string) (string, string, comparison, bool) {
-	// default comparison mode
-	mode := equ
-
-	// support case of constraint:k==v
-	// with "=", it's possible for an entry "k==v" to be split as:
-	// 1. "k=" as key and "v" as value
-	// 2. "k" as key and "=v" as value
-	// Just to make sure it cover these cases.
-	if strings.HasSuffix(k, "=") {
-		k = strings.TrimSuffix(k, "=")
-	} else if strings.HasPrefix(v, "=") {
-		v = strings.TrimPrefix(v, "=")
-	}
-
-	if strings.HasPrefix(v, "!") {
-		log.Debugf("negate detected in value")
-		v = strings.TrimPrefix(v, "!")
-		mode = neg
-	} else if strings.HasSuffix(k, "!") {
-		log.Debugf("negate detected in key")
-		k = strings.TrimSuffix(k, "!")
-		mode = neg
-	} else {
-		if strings.HasSuffix(k, ">") {
-			log.Debugf("gt (>) detected in key")
-			k = strings.TrimSuffix(k, ">")
-			mode = gte
-		} else if strings.HasSuffix(k, "<") {
-			log.Debugf("lt (<) detected in key")
-			k = strings.TrimSuffix(k, "<")
-			mode = lte
-		}
-	}
-
-	useRegex := false
-	if strings.HasPrefix(v, "/") && strings.HasSuffix(v, "/") {
-		log.Debugf("regex detected")
-		v = strings.TrimPrefix(strings.TrimSuffix(v, "/"), "/")
-		useRegex = true
-	}
-
-	return k, v, mode, useRegex
-}
-
-func extractEnv(key string, env []string) (map[string]string, error) {
-	values := make(map[string]string)
+func extractEnv(key string, env []string) (map[string]opWithValue, error) {
+	ops := []string{"==", "!=", ">=", "<="}
+	values := make(map[string]opWithValue)
 	for _, e := range env {
 		if strings.HasPrefix(e, key+":") {
-			value := strings.TrimPrefix(e, key+":")
-			parts := strings.SplitN(value, "=", 2)
+			entry := strings.TrimPrefix(e, key+":")
+			found := false
+			for _, op := range ops {
+				if strings.Contains(entry, op) {
+					// split with the op
+					parts := strings.SplitN(entry, op, 2)
 
-			// validate key
-			// allow alpha-numeric
-			// but also allow !,>,< operators as suffix
-			matched, err := regexp.MatchString(`^(?i)[a-z_][a-z0-9\-_]+[><!]?$`, parts[0])
+					// validate key
+					// allow alpha-numeric
+					matched, err := regexp.MatchString(`^(?i)[a-z_][a-z0-9\-_]+$`, parts[0])
+					if err != nil {
+						return nil, err
+					}
+					if matched == false {
+						return nil, fmt.Errorf("Key '%s' is invalid", parts[0])
+					}
 
-			if err != nil {
-				return nil, err
-			}
-			if matched == false {
-				return nil, fmt.Errorf("Key '%s' is not valid", parts[0])
-			}
+					if len(parts) == 2 {
 
-			if len(parts) == 2 {
+						// validate value
+						// allow leading = in case of using ==
+						// allow * for globbing
+						// allow regexp
+						matched, err := regexp.MatchString(`^(?i)[=!\/]?[a-z0-9:\-_\.\*/\(\)\?\+\[\]\\\^\$]+$`, parts[1])
+						if err != nil {
+							return nil, err
+						}
+						if matched == false {
+							return nil, fmt.Errorf("Value '%s' is invalid", parts[1])
+						}
+						values[strings.ToLower(parts[0])] = opWithValue{op, parts[1]}
+					} else {
+						values[strings.ToLower(parts[0])] = opWithValue{op, ""}
+					}
 
-				// validate value
-				// allow leading = in case of using ==
-				// allow * for globbing
-				// allow regexp
-				matched, err := regexp.MatchString(`^(?i)[=!\/]?[a-z0-9:\-_\.\*/\(\)\?\+\[\]\\\^\$]+$`, parts[1])
-				if err != nil {
-					return nil, err
+					found = true
+					break // found an op, move to next entry
 				}
-				if matched == false {
-					return nil, fmt.Errorf("Value '%s' is not valid", parts[1])
-				}
-				values[strings.ToLower(parts[0])] = parts[1]
-			} else {
-				values[strings.ToLower(parts[0])] = ""
+			}
+			if !found {
+				return nil, fmt.Errorf("One of operator ==, !=, >=, <= is expected")
 			}
 		}
 	}
@@ -105,8 +64,15 @@ func extractEnv(key string, env []string) (map[string]string, error) {
 
 // Create the regex for globbing (ex: ub*t* -> ^ub.*t.*$) and match.
 // If useRegex is true, the pattern will be used directly
-func match(pattern, s string, useRegex bool) bool {
+func internalMatch(pattern, s string) bool {
 	regex := pattern
+	useRegex := false
+	if strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") {
+		log.Debugf("regex detected")
+		regex = strings.TrimPrefix(strings.TrimSuffix(pattern, "/"), "/")
+		useRegex = true
+	}
+
 	if !useRegex {
 		regex = "^" + strings.Replace(pattern, "*", ".*", -1) + "$"
 	}
@@ -115,4 +81,20 @@ func match(pattern, s string, useRegex bool) bool {
 		log.Error(err)
 	}
 	return matched
+}
+
+func match(val opWithValue, what string) bool {
+	op, v := val[0], val[1]
+	if op == ">=" && what >= v {
+		return true
+	} else if op == "<=" && what <= v {
+		return true
+	} else {
+		matchResult := internalMatch(v, what)
+		if (op == "!=" && !matchResult) || (op == "==" && matchResult) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/scheduler/filter/utils_test.go
+++ b/scheduler/filter/utils_test.go
@@ -1,0 +1,38 @@
+package filter
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidatingEnvExtraction(t *testing.T) {
+	err := error(nil)
+
+	// Cannot use the leading digit for key
+	_, err = extractEnv("constraint", []string{"constraint:1node"})
+	assert.Error(t, err)
+
+	// Cannot use space in key
+	_, err = extractEnv("constraint", []string{"constraint:node ==node1"})
+	assert.Error(t, err)
+
+	// Cannot use dot in key
+	_, err = extractEnv("constraint", []string{"constraint:no.de==node1"})
+	assert.Error(t, err)
+
+	// Cannot use * in key
+	_, err = extractEnv("constraint", []string{"constraint:no*de==node1"})
+	assert.Error(t, err)
+
+	// Allow leading underscore
+	_, err = extractEnv("constraint", []string{"constraint:_node==_node1"})
+	assert.NoError(t, err)
+
+	// Allow globbing
+	_, err = extractEnv("constraint", []string{"constraint:node==*node*"})
+	assert.NoError(t, err)
+
+	// Allow regexp in value
+	_, err = extractEnv("constraint", []string{"constraint:node==/(?i)^[a-b]+c*$/"})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This PR proposes the use of `!=` for negate and `/regexp/` for direct regexp matching to improve the constraint filters. It supports `==` and relative comparisons `>=` and `<=` for range matching (string only).

For example,

*  `constraint:name==node1` will match `node1`.
*  `constraint:name!=node1` will match all nodes, expect `node1`.
*  `constraint:name!=n*` will match all, except nodes whose name starting with `n`.
*  `constraint:region!=us*` will match all, except nodes in `us` regions like `us-west` or `us-east`.
*  `constraint:name==/node\d/` will match all nodes named by `node` plus 1 digit.
*  `constraint:name==/node[12]/` will match nodes named by `node1` and `node2`.
*  `constraint:node!=/node-[01]-id/` will match all, except nodes id `node-0-id` and `node-1-id`.
*  `constraint:name!=/foo\[bar\]/` will match all nodes, except those with name `foo[bar]`. You can see the use of escape characters here.
*  `constraint:name!=/(?i)node/` will match all nodes name case-insensitivity, so `NoDe` and `NODE` are also matched.
* `constraint:group<=3` will match all nodes in group less than or equal to "3". This is string, not numeric, comparison.
* `constraint:kernel>=3.0` will match all nodes having label kernel greater than or equal to "3.0". This is also string, not numeric, comparison.
