### PR TITLE
add search and login

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -10,14 +10,12 @@ Here are the main differences:
 ```
 GET "/images/json"
 GET "/images/json"
-GET "/images/search"
 GET "/images/get"
 GET "/images/{name:.*}/get"
 GET "/images/{name:.*}/history"
 GET "/images/{name:.*}/json"
 GET "/containers/{name:.*}/attach/ws"
 
-POST "/auth"
 POST "/commit"
 POST "/build"
 POST "/images/create"

--- a/api/utils.go
+++ b/api/utils.go
@@ -51,15 +51,14 @@ func copyHeader(dst, src http.Header) {
 	}
 }
 
-func proxy(tlsConfig *tls.Config, container *cluster.Container, w http.ResponseWriter, r *http.Request) error {
+func proxy(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.Request) error {
 	// Use a new client for each request
 	client, scheme := newClientAndScheme(tlsConfig)
 	// RequestURI may not be sent to client
 	r.RequestURI = ""
 
 	r.URL.Scheme = scheme
-
-	r.URL.Host = container.Node.Addr
+	r.URL.Host = addr
 
 	log.Debugf("[PROXY] --> %s %s", r.Method, r.URL)
 	resp, err := client.Do(r)
@@ -74,9 +73,8 @@ func proxy(tlsConfig *tls.Config, container *cluster.Container, w http.ResponseW
 	return nil
 }
 
-func hijack(tlsConfig *tls.Config, container *cluster.Container, w http.ResponseWriter, r *http.Request) error {
-	addr := container.Node.Addr
-	if parts := strings.SplitN(container.Node.Addr, "://", 2); len(parts) == 2 {
+func hijack(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.Request) error {
+	if parts := strings.SplitN(addr, "://", 2); len(parts) == 2 {
 		addr = parts[1]
 	}
 

--- a/scheduler/filter/health.go
+++ b/scheduler/filter/health.go
@@ -15,7 +15,7 @@ var (
 type HealthFilter struct {
 }
 
-func (f *HealthFilter) Filter(config *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
+func (f *HealthFilter) Filter(_ *dockerclient.ContainerConfig, nodes []*cluster.Node) ([]*cluster.Node, error) {
 	result := []*cluster.Node{}
 	for _, node := range nodes {
 		if node.IsHealthy() {


### PR DESCRIPTION
`docker search` and `docker login` use the docker daemon as a proxy, they aren't doing anything meaningful on the daemon
(they could be implemented client side)

So, for those we simply pick a random node and proxy the request.