### PR TITLE
Proposal: Simple docker images support

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -8,8 +8,6 @@ Here are the main differences:
 ####Some endpoints are not (yet) implemented
 
 ```
-GET "/images/json"
-GET "/images/json"
 GET "/images/get"
 GET "/images/{name:.*}/get"
 GET "/images/{name:.*}/history"


### PR DESCRIPTION
Depends on ~~https://github.com/docker/docker/pull/10128~~ and ~~#243~~ (PR is actually only the last commit 556cddfcf5ea48517dbb641b43935640df515b93)

A very basic docker images:

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
vieux/gocover       latest              ceceb2151bf6        2 weeks ago         721.4 MB
vieux/gocover       latest              ceceb2151bf6        2 weeks ago         721.4 MB
redis               2                   3b7234aa3098        6 days ago          110.8 MB
redis               2.8                 3b7234aa3098        6 days ago          110.8 MB
redis               latest              3b7234aa3098        6 days ago          110.8 MB
redis               2.8.19              3b7234aa3098        6 days ago          110.8 MB
redis               2.6                 f1e1b664d8bd        6 days ago          110.4 MB
redis               2.6.17              f1e1b664d8bd        6 days ago          110.4 MB
vieux/gocover       latest              ceceb2151bf6        2 weeks ago         721.4 MB
redis               2.8.18              c1ecf7e69b16        4 weeks ago         111.2 MB
redis               2.8.17              dad71287aacb        7 weeks ago         111.1 MB
redis               2.8.9               e938c5d0ff85        10 weeks ago        111.1 MB
redis               2.8.8               acf48e3e78df        10 weeks ago        111 MB
redis               2.8.7               818c43182340        10 weeks ago        111 MB
redis               2.8.6               6064dc06cc6f        10 weeks ago        110.9 MB
redis               2.8.16              7c66279ca4e2        10 weeks ago        111 MB
redis               2.8.15              b1985912478d        10 weeks ago        111 MB
redis               2.8.14              9a809f4657ff        10 weeks ago        111 MB
redis               2.8.13              1e665a029cd6        10 weeks ago        111 MB
redis               2.8.12              a2f8e5952444        10 weeks ago        110.9 MB
redis               2.8.11              fb968d8e672d        10 weeks ago        111.1 MB
redis               2.8.10              9554c310cfeb        10 weeks ago        111.1 MB
```

You can use filters to select one or multiple hosts:

```
$ docker images -f node=fedora-1
REPOSITORY      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
vieux/gocover   latest              ceceb2151bf6        2 weeks ago         721.4 MB
```

It could be improved next, but for now it's very simple.

What do you think ?