### PR TITLE
Proposal: add `swarm config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ $ docker -H tcp://<swarm_ip:swarm_port> ps
 $ docker -H tcp://<swarm_ip:swarm_port> logs ...
 ...
 
+# connect to a node directly
+$ docker `swarm config token://<cluster_id> <node_name>` pull ...
+
 # list nodes in your cluster
 $ swarm list token://<cluster_id>
 <node_ip:2375>

--- a/config.go
+++ b/config.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/discovery"
+)
+
+func config(c *cli.Context) {
+	var (
+		tlsConfig *tls.Config = nil
+		err       error
+	)
+
+	// If either --tls or --tlsverify are specified, load the certificates.
+	if c.Bool("tls") || c.Bool("tlsverify") {
+		tlsConfig, err = loadTlsConfig(
+			c.String("tlscacert"),
+			c.String("tlscert"),
+			c.String("tlskey"),
+			c.Bool("tlsverify"))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if !c.IsSet("discovery") {
+		log.Fatal("--discovery required to get config of a node")
+	}
+
+	if len(c.Args()) != 1 {
+		log.Fatal("an argument is required to get config of a node")
+	}
+	// get the list of nodes from the discovery service
+	d, err := discovery.New(c.String("discovery"), 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	nodes, err := d.Fetch()
+	if err != nil {
+		log.Fatal(err)
+
+	}
+
+	connectedNodes := make(chan *cluster.Node, len(nodes))
+	for _, addr := range nodes {
+		go func(node *discovery.Node) {
+			n := cluster.NewNode(node.String(), 0)
+			if err := n.Connect(tlsConfig); err != nil {
+				log.Error(err)
+			}
+			connectedNodes <- n
+		}(addr)
+	}
+
+	for n := range connectedNodes {
+		if n.Name == c.Args().First() || n.ID == c.Args().First() {
+			fmt.Println(n.Addr)
+			return
+		}
+	}
+
+	log.Fatalf("Node %q not found", c.Args().First())
+}

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func config(c *cli.Context) {
 		}
 	}
 
-	if !c.IsSet("discovery") {
+	if c.String("discovery") == "" {
 		log.Fatal("--discovery required to get config of a node")
 	}
 
@@ -60,10 +60,19 @@ func config(c *cli.Context) {
 
 	for n := range connectedNodes {
 		if n.Name == c.Args().First() || n.ID == c.Args().First() {
-			fmt.Println(n.Addr)
+			fmt.Printf("-H %s", n.Addr)
+			duplicateFlags(c, "tls", "tlsverify", "tlscacert", "tlscert", "tlskey")
 			return
 		}
 	}
 
 	log.Fatalf("Node %q not found", c.Args().First())
+}
+
+func duplicateFlags(c *cli.Context, flags ...string) {
+	for _, flag := range flags {
+		if c.IsSet(flag) {
+			fmt.Printf("--%s", flag)
+		}
+	}
 }

--- a/config.go
+++ b/config.go
@@ -28,15 +28,16 @@ func config(c *cli.Context) {
 		}
 	}
 
-	if c.String("discovery") == "" {
-		log.Fatal("--discovery required to get config of a node")
+	dflag := getDiscovery(c)
+	if dflag == "" {
+		log.Fatal("discovery required to get the docker config of a node. See 'swarm config --help'.")
 	}
 
 	if len(c.Args()) != 1 {
 		log.Fatal("an argument is required to get config of a node")
 	}
 	// get the list of nodes from the discovery service
-	d, err := discovery.New(c.String("discovery"), 0)
+	d, err := discovery.New(dflag, 0)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/flags.go
+++ b/flags.go
@@ -19,7 +19,7 @@ func homepath(p string) string {
 }
 
 func getDiscovery(c *cli.Context) string {
-	if len(c.Args()) == 1 {
+	if len(c.Args()) >= 1 {
 		return c.Args()[0]
 	}
 	return os.Getenv("SWARM_DISCOVERY")

--- a/help.go
+++ b/help.go
@@ -4,10 +4,10 @@ import "github.com/codegangsta/cli"
 
 func init() {
 
-	cli.CommandHelpTemplate = `{{$DISCOVERY := or (eq .Name "manage") (eq .Name "join") (eq .Name "list")}}NAME:
+	cli.CommandHelpTemplate = `{{$DISCOVERY := or (eq .Name "manage") (eq .Name "join") (eq .Name "list") (eq .Name "config")}}NAME:
    {{.Name}} - {{.Usage}}
 USAGE:
-   swarm {{.Name}}{{if .Flags}} [options]{{end}} {{if $DISCOVERY}}<discovery>{{end}}{{if .Description}}
+   swarm {{.Name}}{{if .Flags}} [options]{{end}} {{if $DISCOVERY}}<discovery>{{end}}{{if eq .Name "config"}} <node>{{end}}{{if .Description}}
 DESCRIPTION:
    {{.Description}}{{end}}{{if $DISCOVERY}}
 ARGUMENTS:
@@ -16,7 +16,8 @@ ARGUMENTS:
             {{printf "\t"}} * etcd://<ip1>,<ip2>/<path>
             {{printf "\t"}} * file://path/to/file
             {{printf "\t"}} * zk://<ip1>,<ip2>/<path>
-            {{printf "\t"}} * <ip1>,<ip2>{{end}}{{if .Flags}}
+            {{printf "\t"}} * <ip1>,<ip2>{{end}}{{if eq .Name "config"}}
+   node{{printf "\t"}}node ID or node name to get the config for{{end}}{{if .Flags}}
 OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{ end }}

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 		{
 			Name:      "config",
 			ShortName: "cf",
-			Usage:     "get the config of a swarm node",
+			Usage:     "get the docker config to connect to a swarm node",
 			Flags: []cli.Flag{
 				flDiscovery,
 				flTls, flTlsCaCert, flTlsCert, flTlsKey, flTlsVerify,

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	app.Commands = []cli.Command{
 		{
 			Name:      "create",
-			ShortName: "c",
+			ShortName: "cr",
 			Usage:     "create a cluster",
 			Action: func(c *cli.Context) {
 				discovery := &token.TokenDiscoveryService{}
@@ -55,6 +55,16 @@ func main() {
 				}
 				fmt.Println(token)
 			},
+		},
+		{
+			Name:      "config",
+			ShortName: "cf",
+			Usage:     "get the config of a swarm node",
+			Flags: []cli.Flag{
+				flDiscovery,
+				flTls, flTlsCaCert, flTlsCert, flTlsKey, flTlsVerify,
+			},
+			Action: config,
 		},
 		{
 			Name:      "list",

--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ func main() {
 			ShortName: "cf",
 			Usage:     "get the docker config to connect to a swarm node",
 			Flags: []cli.Flag{
-				flDiscovery,
 				flTls, flTlsCaCert, flTlsCert, flTlsKey, flTlsVerify,
 			},
 			Action: config,


### PR DESCRIPTION
I believe that when we will support `docker pull`, we are going to pull on every machines.
When looking at the current docker cli, I don't see any way for us to specify a node.

This PR adds a `swarm config` commands that returns you the `<ip:port>` of a node using it's name/ID.

It can be used like this:

```
docker `swarm  config token://XXXX ubuntu-2` pull redis
docker `swarm  config token://XXXX ubuntu-1` rmi nginx
```

I called the command `config` to be consistant with docker machine and
also because I don't know how to call `<ip:port>` (we can't call  the command `swarm ip`)