### PR TITLE
Add test that fails to execute the proper binpacking strategy

### DIFF
--- a/scheduler/strategy/binpacking.go
+++ b/scheduler/strategy/binpacking.go
@@ -41,10 +41,9 @@ func (p *BinPackingPlacementStrategy) PlaceContainer(config *dockerclient.Contai
 		if config.Memory > 0 {
 			memoryScore = (node.ReservedMemory() + config.Memory) * 100 / nodeMemory
 		}
-		var total = (cpuScore + memoryScore) / 2
 
 		if cpuScore <= 100 && memoryScore <= 100 {
-			scores = append(scores, &score{node: node, score: total})
+			scores = append(scores, &score{node: node, score: cpuScore + memoryScore})
 		}
 	}
 

--- a/scheduler/strategy/binpacking.go
+++ b/scheduler/strategy/binpacking.go
@@ -41,7 +41,7 @@ func (p *BinPackingPlacementStrategy) PlaceContainer(config *dockerclient.Contai
 		if config.Memory > 0 {
 			memoryScore = (node.ReservedMemory() + config.Memory) * 100 / nodeMemory
 		}
-		var total = ((cpuScore + memoryScore) / 200) * 100
+		var total = (cpuScore + memoryScore) / 2
 
 		if cpuScore <= 100 && memoryScore <= 100 {
 			scores = append(scores, &score{node: node, score: total})

--- a/scheduler/strategy/binpacking_test.go
+++ b/scheduler/strategy/binpacking_test.go
@@ -248,7 +248,7 @@ func TestComplexPlacement(t *testing.T) {
 	assert.NoError(t, node2.AddContainer(createContainer("c2", config)))
 
 	// check that they end up on separate nodes
-	assert.NotEqual(t, node1.ID, node2.ID, "")
+	assert.NotEqual(t, node1.ID, node2.ID)
 
 	// add one container 1G
 	config = createConfig(1, 0)
@@ -257,5 +257,5 @@ func TestComplexPlacement(t *testing.T) {
 	assert.NoError(t, node3.AddContainer(createContainer("c3", config)))
 
 	// check that it ends up on the same node as the 3G
-	assert.Equal(t, node2.ID, node3.ID, "")
+	assert.Equal(t, node2.ID, node3.ID)
 }

--- a/scheduler/strategy/binpacking_test.go
+++ b/scheduler/strategy/binpacking_test.go
@@ -226,3 +226,36 @@ func TestPlaceContainerDemo(t *testing.T) {
 	assert.Equal(t, node2.ID, node2bis.ID, "")
 	assert.Equal(t, len(node2.Containers()), len(node2bis.Containers()), "")
 }
+
+func TestComplexPlacement(t *testing.T) {
+	s := &BinPackingPlacementStrategy{}
+
+	nodes := []*cluster.Node{}
+	for i := 0; i < 2; i++ {
+		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 4, 4))
+	}
+
+	// add one container 2G
+	config := createConfig(2, 0)
+	node1, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node1.AddContainer(createContainer("c1", config)))
+
+	// add one container 3G
+	config = createConfig(3, 0)
+	node2, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node2.AddContainer(createContainer("c2", config)))
+
+	// check that they end up on separate nodes
+	assert.NotEqual(t, node1.ID, node2.ID, "")
+
+	// add one container 1G
+	config = createConfig(1, 0)
+	node3, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node3.AddContainer(createContainer("c3", config)))
+
+	// check that it ends up on the same node as the 3G
+	assert.Equal(t, node2.ID, node3.ID, "")
+}


### PR DESCRIPTION
This creates two nodes, each with 4GB of memory, and allocates first a 2GB container, then a 3GB container, then a 1GB container. According to the binpacking strategy, the 3GB and 1GB should end up on the same node, but they do not, due to the issue in #253.