### PR TITLE
replace --discovery by argument

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	"github.com/codegangsta/cli"
+	"os"
 	"os/user"
 	"path"
+
+	"github.com/codegangsta/cli"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -14,6 +16,13 @@ func homepath(p string) string {
 		log.Fatal(err)
 	}
 	return path.Join(usr.HomeDir, p)
+}
+
+func getDiscovery(c *cli.Context) string {
+	if len(c.Args()) == 1 {
+		return c.Args()[0]
+	}
+	return os.Getenv("SWARM_DISCOVERY")
 }
 
 var (

--- a/help.go
+++ b/help.go
@@ -7,7 +7,7 @@ func init() {
 	cli.CommandHelpTemplate = `{{$DISCOVERY := or (eq .Name "manage") (eq .Name "join") (eq .Name "list")}}NAME:
    {{.Name}} - {{.Usage}}
 USAGE:
-   command {{.Name}}{{if .Flags}} [command options]{{end}} {{if $DISCOVERY}}[discovery]{{end}}{{if .Description}}
+   swarm {{.Name}}{{if .Flags}} [command options]{{end}} {{if $DISCOVERY}}[discovery]{{end}}{{if .Description}}
 DESCRIPTION:
    {{.Description}}{{end}}{{if $DISCOVERY}}
 ARGUMENTS:

--- a/help.go
+++ b/help.go
@@ -1,0 +1,25 @@
+package main
+
+import "github.com/codegangsta/cli"
+
+func init() {
+
+	cli.CommandHelpTemplate = `{{$DISCOVERY := or (eq .Name "manage") (eq .Name "join") (eq .Name "list")}}NAME:
+   {{.Name}} - {{.Usage}}
+USAGE:
+   command {{.Name}}{{if .Flags}} [command options]{{end}} {{if $DISCOVERY}}[discovery]{{end}}{{if .Description}}
+DESCRIPTION:
+   {{.Description}}{{end}}{{if $DISCOVERY}}
+ARGUMENTS:
+   discovery{{printf "\t"}}discovery service to use [$SWARM_DISCOVERY]
+            {{printf "\t"}} * token://<token>
+            {{printf "\t"}} * etcd://<ip1>,<ip2>/<path>
+            {{printf "\t"}} * file://path/to/file
+            {{printf "\t"}} * zk://<ip1>,<ip2>/<path>
+            {{printf "\t"}} * <ip1>,<ip2>{{end}}{{if .Flags}}
+OPTIONS:
+   {{range .Flags}}{{.}}
+   {{end}}{{ end }}
+`
+
+}

--- a/join.go
+++ b/join.go
@@ -15,12 +15,12 @@ func checkAddrFormat(addr string) bool {
 }
 
 func join(c *cli.Context) {
-
-	if c.String("discovery") == "" {
-		log.Fatal("--discovery required to join a cluster")
+	dflag := getDiscovery(c)
+	if dflag == "" {
+		log.Fatal("discovery required to join a cluster. See 'swarm join --help'.")
 	}
 
-	d, err := discovery.New(c.String("discovery"), c.Int("heartbeat"))
+	d, err := discovery.New(dflag, c.Int("heartbeat"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -60,13 +60,13 @@ func main() {
 			Name:      "list",
 			ShortName: "l",
 			Usage:     "list nodes in a cluster",
-			Flags:     []cli.Flag{flDiscovery},
 			Action: func(c *cli.Context) {
-				if c.String("discovery") == "" {
-					log.Fatal("--discovery required to list a cluster")
+				dflag := getDiscovery(c)
+				if dflag == "" {
+					log.Fatal("discovery required to list a cluster. See 'swarm list --help'.")
 				}
 
-				d, err := discovery.New(c.String("discovery"), 0)
+				d, err := discovery.New(dflag, 0)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -85,7 +85,6 @@ func main() {
 			ShortName: "m",
 			Usage:     "manage a docker cluster",
 			Flags: []cli.Flag{
-				flDiscovery,
 				flStore,
 				flStrategy, flFilter,
 				flHosts, flHeartBeat, flOverCommit,
@@ -97,7 +96,7 @@ func main() {
 			Name:      "join",
 			ShortName: "j",
 			Usage:     "join a docker cluster",
-			Flags:     []cli.Flag{flDiscovery, flAddr, flHeartBeat},
+			Flags:     []cli.Flag{flAddr, flHeartBeat},
 			Action:    join,
 		},
 	}

--- a/manage.go
+++ b/manage.go
@@ -81,8 +81,9 @@ func manage(c *cli.Context) {
 	cluster := cluster.NewCluster(store, tlsConfig, c.Float64("overcommit"))
 	cluster.Events(&logHandler{})
 
-	if c.String("discovery") == "" {
-		log.Fatal("--discovery required to manage a cluster")
+	dflag := getDiscovery(c)
+	if dflag == "" {
+		log.Fatal("discovery required to manage a cluster. See 'swarm manage --help'.")
 	}
 
 	s, err := strategy.New(c.String("strategy"))
@@ -102,7 +103,7 @@ func manage(c *cli.Context) {
 
 	// get the list of nodes from the discovery service
 	go func() {
-		d, err := discovery.New(c.String("discovery"), c.Int("heartbeat"))
+		d, err := discovery.New(dflag, c.Int("heartbeat"))
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Since `--discovery` is required in almost every command, let's use an argument instead of a flag.

```
$ swarm manage
FATA[0000] discovery required to manage a cluster. See 'swarm manage --help'.
```

```
$ swarm manage --help
NAME:
   manage - manage a docker cluster
USAGE:
   command manage [command options] [discovery]
ARGUMENTS:
   discovery	discovery service to use [$SWARM_DISCOVERY]
            	 * token://<token>
            	 * etcd://<ip1>,<ip2>/<path>
            	 * file://path/to/file
            	 * zk://<ip1>,<ip2>/<path>
            	 * <ip1>,<ip2>
OPTIONS:
   --rootdir "/home/vagrant/.swarm"
   --strategy "binpacking"				        placement strategy to use [binpacking, random]
   --filter, -f [--filter option --filter option]	        filter to use [constraint, affinity, health, port]
   --host, -H [--host option --host option]		ip/socket to listen on [$SWARM_HOST]
   --heartbeat, --hb "25"				        time in second between each heartbeat
   --overcommit, --oc "0.05"				overcommit to apply on resources
   --tls						                use TLS; implied by --tlsverify=true
   --tlscacert 						        trust only remotes providing a certificate signed by the CA given here
   --tlscert 						                path to TLS certificate file
   --tlskey 						                path to TLS key file
   --tlsverify						        use TLS and verify the remote
   --api-enable-cors, --cors				enable CORS headers in the remote API
```


There is no backward compat in this PR because we are still in beta, here is what it look like if you use the old flag:

```
$ swarm l --discovery token://XXXXXXXX
Incorrect Usage.

NAME:
   list - list nodes in a cluster
USAGE:
   command list [discovery]
ARGUMENTS:
   discovery	discovery service to use [$SWARM_DISCOVERY]
            	 * token://<token>
            	 * etcd://<ip1>,<ip2>/<path>
            	 * file://path/to/file
            	 * zk://<ip1>,<ip2>/<path>
            	 * <ip1>,<ip2>

FATA[0000] flag provided but not defined: -discovery
```

correct:
```
$ swarm l --discovery token://XXXXXXXX
<ip:port>
<ip:port>
<ip:port>
```