### PR TITLE
use cross-compile compatible home dir detection

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -1,21 +1,17 @@
 package main
 
 import (
-	"os"
-	"os/user"
-	"path"
-
 	"github.com/codegangsta/cli"
-
-	log "github.com/Sirupsen/logrus"
+	"os"
+	"path/filepath"
+	"runtime"
 )
 
 func homepath(p string) string {
-	usr, err := user.Current()
-	if err != nil {
-		log.Fatal(err)
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("USERPROFILE"), p)
 	}
-	return path.Join(usr.HomeDir, p)
+	return filepath.Join(os.Getenv("HOME"), p)
 }
 
 func getDiscovery(c *cli.Context) string {


### PR DESCRIPTION
The use of `os/user` does not work when cross compiling this binary on Mac. It requires cgo and will fail at runtime with the message `user: Current not implemented on linux/amd64 `. This PR replaces it's use in a default flag value with a cross-compilation compatible version from https://github.com/mitchellh/go-homedir