### PR TITLE
Proposal: port filter for the host mode

### DIFF
--- a/scheduler/filter/port_test.go
+++ b/scheduler/filter/port_test.go
@@ -278,24 +278,24 @@ func TestPortFilterRandomAssignment(t *testing.T) {
 func TestPortFilterForHostMode(t *testing.T) {
 	var (
 		p     = PortFilter{}
-		nodes = []cluster.Node{
-			&FakeNode{
-				id:   "node-1-id",
-				name: "node-1-name",
-				addr: "node-1",
+		nodes = []*node.Node{
+			{
+				ID:   "node-1-id",
+				Name: "node-1-name",
+				Addr: "node-1",
 			},
-			&FakeNode{
-				id:   "node-2-id",
-				name: "node-2-name",
-				addr: "node-2",
+			{
+				ID:   "node-2-id",
+				Name: "node-2-name",
+				Addr: "node-2",
 			},
-			&FakeNode{
-				id:   "node-3-id",
-				name: "node-3-name",
-				addr: "node-3",
+			{
+				ID:   "node-3-id",
+				Name: "node-3-name",
+				Addr: "node-3",
 			},
 		}
-		result []cluster.Node
+		result []*node.Node
 		err    error
 	)
 
@@ -312,9 +312,7 @@ func TestPortFilterForHostMode(t *testing.T) {
 		},
 	}
 
-	if n, ok := nodes[0].(*FakeNode); ok {
-		assert.NoError(t, n.AddContainer(container))
-	}
+	assert.NoError(t, nodes[0].AddContainer(container))
 
 	// Request port 80 in the host mode
 	config := &dockerclient.ContainerConfig{

--- a/test/integration/port-filter.bats
+++ b/test/integration/port-filter.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+	stop_manager
+	stop_docker
+}
+
+@test "docker should filter port in host mode correctly" {
+	start_docker 2
+	start_manager
+
+	#
+	# Use busybox to save image pulling time for integration test.
+	# Running the first 2 containers, it should be fine.
+	#
+	run docker_swarm run -d --expose=80 --net=host busybox sh
+	[ "$status" -eq 0 ]
+	run docker_swarm run -d --expose=80 --net=host busybox sh
+	[ "$status" -eq 0 ]
+
+	#
+	# When trying to start the 3rd one, it should be error finding port 80.
+	#
+	run docker_swarm run -d --expose=80 --net=host busybox sh
+	[ "$status" -ne 0 ]
+	[[ "${lines[0]}" == *"unable to find a node with port 80/tcp available in the Host mode"* ]]
+
+	#
+	# And the number of running containers should be still 2.
+	#
+	run docker_swarm ps -n 2
+	[ "${#lines[@]}" -eq  3 ]
+}


### PR DESCRIPTION
Currently, `swarm` supports port filtering for the `bridge` mode by default.
But behaviour of the port filter for the `host` mode is still undefined.

This PR proposes an improvement for the port filter to support `--net=host` mode.
It detects if `HostConfig.NetworkMode` is set to be `"host"` and finds available node through the value of `ContainerConfig.ExposedPorts`.
