### PR TITLE
add info in join

### DIFF
--- a/join.go
+++ b/join.go
@@ -37,8 +37,9 @@ func join(c *cli.Context) {
 
 	hb := time.Duration(c.Int("heartbeat"))
 	for {
+		log.Infof("Registering %q on the discovery service %q every %d seconds...", addr, dflag, hb)
 		time.Sleep(hb * time.Second)
-		if err := d.Register(c.String("addr")); err != nil {
+		if err := d.Register(addr); err != nil {
 			log.Error(err)
 		}
 	}


### PR DESCRIPTION
Close #275

The current behaviour of `swarm join` isn't clear, some people think it's stuck because there is nothing printed.
I end the sentence by `...` so people know it will never end.

@aluzzardi suggestions are welcome.