### PR TITLE
Improve container state refresh.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -279,7 +279,7 @@ func proxyContainerAndForceRefresh(c *context, w http.ResponseWriter, r *http.Re
 	}
 
 	log.Debugf("[REFRESH CONTAINER] --> %s", container.Id)
-	container.Node.ForceRefreshContainer(container.Container)
+	container.Node.RefreshContainer(container.Id, true)
 }
 
 // Proxy a request to the right node


### PR DESCRIPTION
Currently, container inspection is performed only on creation (or during
exec by the API).

The problem is that certain informations such as NetworkSettings are not
available during creation, therefore we must inspect the containers
during other events.

This change refactors a bit the API so that RefreshContainer() and
RefreshContainers() now accept a `full` flag to force a deep refresh.

The node event handler in turn uses that flag whenever a container
starts or dies.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>