### PR TITLE
Add node's addr as a constraint.

### DIFF
--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm/cluster"
@@ -26,7 +27,7 @@ func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []
 			switch constraint.key {
 			case "node":
 				// "node" label is a special case pinning a container to a specific node.
-				if constraint.Match(node.ID, node.Name) {
+				if constraint.Match(node.ID, node.Name, node.Addr, strings.Split(node.Addr, ":")[0]) {
 					candidates = append(candidates, node)
 				}
 			default:

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -40,7 +40,7 @@ func testFixtures() (nodes []*cluster.Node) {
 	return
 }
 
-func TestConstrainteFilter(t *testing.T) {
+func TestConstraintFilter(t *testing.T) {
 	var (
 		f      = ConstraintFilter{}
 		nodes  = testFixtures()
@@ -320,6 +320,49 @@ func TestFilterEquals(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
+}
+
+func TestConstraintAddr(t *testing.T) {
+	var (
+		f      = ConstraintFilter{}
+		nodes  = testFixtures()
+		result []*cluster.Node
+		err    error
+	)
+
+	node3_0 := cluster.NewNode("node-3", 0)
+	node3_0.ID = "node-3-0-id"
+	node3_0.Name = "node-3-name"
+	node3_0.Labels = map[string]string{
+		"name":   "node3-0",
+		"group":  "2",
+		"region": "eu",
+	}
+	node3_1 := cluster.NewNode("node-3:2375", 0)
+	node3_1.ID = "node-3-1-id"
+	node3_1.Name = "node-3-name"
+	node3_1.Labels = map[string]string{
+		"name":   "node-3-1",
+		"group":  "2",
+		"region": "eu",
+	}
+	nodes = append(nodes, node3_0, node3_1)
+
+	// Validate with exact node addr match
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:node==node-3:2375"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, result[0], node3_1)
+
+	// Validate with host/ip part of the node's addr
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"constraint:node==node-3"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, result[0], node3_0)
 }
 
 func TestUnsupportedOperators(t *testing.T) {


### PR DESCRIPTION
Currently, there's 2 ways to put a constraint on a node, that is node's ID and node's name.

It would also be useful when using swarm within a somehow fixed network environment to be able to select a node by its domain name or ip address, including or excluding the listening port.

Let suppose we have a node started like this:

```$ swarm join --addr 'node1.private:2375' token://```

Then this PR allows to put a constraint on this node this ways:

```$ docker run -it -e constraint:node=node1.private:2375 busybox```

or even

```$ docker run -it -e constraint:node=node1.private busybox```

Signed-off-by: Pierre Wacrenier <pierre.wacrenier@gmail.com>