### PR TITLE
Proposal: require ps -a to show swarm containers

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -49,6 +49,9 @@ DELETE "/images/{name:.*}"
 ```
 * `GET "/containers/{name:.*}/json"`: `HostIP` replaced by the the actual Node's IP if `HostIP` is `0.0.0.0`
 
-* `GET "/containers"/json"`: Node's name prepended to the container name.
+* `GET "/containers/json"`: Node's name prepended to the container name.
 
-* `GET "/containers"/json"`: `HostIP` replaed by the the actual Node's IP if `HostIP` is `0.0.0.0`
+* `GET "/containers/json"`: `HostIP` replaced by the the actual Node's IP if `HostIP` is `0.0.0.0`
+
+* `GET "/containers/json"` : Containers started from the `swarm` official image are hidden by default, use `all=1` to display them.
+

--- a/api/api.go
+++ b/api/api.go
@@ -136,6 +136,10 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(tmp.Status, "Up") && !all {
 			continue
 		}
+		// Skip swarm containers unless -a was specified.
+		if strings.Split(tmp.Image, ":")[0] == "swarm" && !all {
+			continue
+		}
 		if !container.Node.IsHealthy() {
 			tmp.Status = "Pending"
 		}


### PR DESCRIPTION
If you do the `swarm join` in a container, you will end up with one line per node in docker ps `on swarm join` per node.

In this PR I propose to hide the swarm containers in `docker ps`.
They will be visible with `docker ps --all`