### PR TITLE
Cleanup: fix fatal error when registering node

### DIFF
--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -124,7 +124,7 @@ func (s *ZkDiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 func (s *ZkDiscoveryService) Register(addr string) error {
-	nodePath := "/" + path.Join(s.fullpath(), addr)
+	nodePath := path.Join(s.fullpath(), addr)
 
 	// check existing for the parent path first
 	exist, _, err := s.conn.Exists(s.fullpath())


### PR DESCRIPTION
The extra leading `/` causes fatal error when registering nodes. This PR fixes it.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>