### PR TITLE
Cleanup: add docker build to README and CONTRIBUTING to cover godep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,15 @@ Then you can fetch `swarm` code to your `$GOPATH`.
 go get -d github.com/docker/swarm
 ```
 
-The final step is to prepare dependencies for `swarm` and compile it.
+#### Start hacking
+
+First, prepare dependencies for `swarm` and try to compile it.
 ```sh
 cd src/github.com/docker/swarm
 $GOBIN/godep restore
+go test
 go install
 ```
-You'll find the `swarm` binary under the `$GOBIN` directory.
 
 #### Adding New Dependencies
 
@@ -51,5 +53,12 @@ $GOBIN/godep save
 git diff # check what added or removed in Godep/Godeps.json
          # then manually add missing dependencies
 ```
+
+To make sure you newly added codes will make the build process happy, you can try building Swarm in the same way as defined in `Dockerfile`.
+
+```sh
+$GOBIN/godep go install
+```
+Then you should find the `swarm` binary under the `$GOBIN` directory.
 
 Happy hacking!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ go install
 To make sure other will not miss dependencies you've added to Swarm, you'll need to call `godep save` to make changes to the config file, `Godep/Godeps.json`. An important thing is that `godep` will replace the config file by the dependency information it learnt from your local machine. This step will mess the upstream config. So, changes to `Godep/Godeps.json` must be performed with care.
 
 ```sh
-$GOBIN/godep save
+$GOBIN/godep save ./...
 git diff # check what added or removed in Godep/Godeps.json
          # then manually add missing dependencies
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ To make sure other will not miss dependencies you've added to Swarm, you'll need
 
 ```sh
 $GOBIN/godep save ./...
+$GOBIN/godep update <an updated package>
 git diff # check what added or removed in Godep/Godeps.json
          # then manually add missing dependencies
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,46 @@ Docker does things, you'll feel right at home.
 Otherwise, go read
 [Docker's contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
 
+### Development Environment Setup
+
+Swarm is written in [the Go programming language](http://golang.org) and manages its dependencies using [Godep](http://github.com/tools/godep). Go and Godep also use `git` to fetch dependencies.
+So, you are required to install the Go compiler, and the `git` client (e.g. `apt-get install golang git` on Ubuntu).
+
+You may need to setup your path and set the `$GOPATH` and `$GOBIN` variables, e.g:
+```sh
+mkdir -p ~/projects/swarm
+cd ~/projects/swarm
+export GOPATH=$PWD
+export GOBIN=$GOPATH/bin
+```
+
+As previously mentioned, you need `godep` to manage dependencies for Swarm. The `godep` command can be installed using the following command:
+```sh
+go get github.com/tools/godep
+```
+and you will find the `godep` binary under `$GOBIN`.
+
+Then you can fetch `swarm` code to your `$GOPATH`.
+```sh
+go get -d github.com/docker/swarm
+```
+
+The final step is to prepare dependencies for `swarm` and compile it.
+```sh
+cd src/github.com/docker/swarm
+$GOBIN/godep restore
+go install
+```
+You'll find the `swarm` binary under the `$GOBIN` directory.
+
+#### Adding New Dependencies
+
+To make sure other will not miss dependencies you've added to Swarm, you'll need to call `godep save` to make changes to the config file, `Godep/Godeps.json`. An important thing is that `godep` will replace the config file by the dependency information it learnt from your local machine. This step will mess the upstream config. So, changes to `Godep/Godeps.json` must be performed with care.
+
+```sh
+$GOBIN/godep save
+git diff # check what added or removed in Godep/Godeps.json
+         # then manually add missing dependencies
+```
+
 Happy hacking!


### PR DESCRIPTION
`Godep` kicks in. This PR updates the document to cover how to compile `swarm` with it.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>