### PR TITLE
Add support for pull on all hosts (no change in docker run)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,7 +18,7 @@ GET "/containers/{name:.*}/attach/ws"
 
 POST "/commit"
 POST "/build"
-POST "/images/create"
+POST "/images/create" (pull implemented)
 POST "/images/load"
 POST "/images/{name:.*}/push"
 POST "/images/{name:.*}/tag"

--- a/api/api.go
+++ b/api/api.go
@@ -263,13 +263,14 @@ func postImagesCreate(c *context, w http.ResponseWriter, r *http.Request) {
 		if tag := r.Form.Get("tag"); tag != "" {
 			image += ":" + tag
 		}
-		begin := func(name string) {
-			fmt.Fprintf(wf, "{%q:%q,%q:\"Pulling %s...\",%q:{}}", "id", name, "status", image, "progressDetail")
+		callback := func(what, status string) {
+			if status == "" {
+				fmt.Fprintf(wf, "{%q:%q,%q:\"Pulling %s...\",%q:{}}", "id", what, "status", image, "progressDetail")
+			} else {
+				fmt.Fprintf(wf, "{%q:%q,%q:\"Pulling %s... : %s\",%q:{}}", "id", what, "status", image, status, "progressDetail")
+			}
 		}
-		end := func(name string) {
-			fmt.Fprintf(wf, "{%q:%q,%q:\"Pulling %s... : downloaded\",%q:{}}", "id", name, "status", image, "progressDetail")
-		}
-		c.cluster.Pull(image, begin, end)
+		c.cluster.Pull(image, callback)
 	} else { //import
 		httpError(w, "Not supported in clustering mode.", http.StatusNotImplemented)
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -11,5 +11,7 @@ type Cluster interface {
 	Containers() []*Container
 	Container(IdOrName string) *Container
 
+	Pull(name string, begin, end func(string))
+
 	Info() [][2]string
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -3,15 +3,31 @@ package cluster
 import "github.com/samalba/dockerclient"
 
 type Cluster interface {
+	// Create a container
 	CreateContainer(config *dockerclient.ContainerConfig, name string) (*Container, error)
+
+	// Remove a container
 	RemoveContainer(container *Container, force bool) error
 
+	// Return all images
 	Images() []*Image
+
+	// Return one image matching `IdOrName`
 	Image(IdOrName string) *Image
+
+	// Return all containers
 	Containers() []*Container
+
+	// Return container the matching `IdOrName`
 	Container(IdOrName string) *Container
 
-	Pull(name string, begin, end func(string))
+	// Pull images
+	// `callback` can be called multiple time
+	//  `what` is what is being pulled
+	//  `status` is the current status, like "", "in progress" or "downloaded
+	Pull(name string, callback func(what, status string))
 
+	// Return some info about the cluster, like nb or containers / images
+	// It is pretty open, so the implementation decides what to return.
 	Info() [][2]string
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -186,14 +186,18 @@ func (c *Cluster) Image(IdOrName string) *cluster.Image {
 	return nil
 }
 
-func (c *Cluster) Pull(name string, begin, end func(string)) {
+func (c *Cluster) Pull(name string, callback func(what, status string)) {
 	size := len(c.nodes)
 	done := make(chan bool, size)
 	for _, n := range c.nodes {
 		go func(nn *node) {
-			begin(nn.Name())
-			nn.Pull(name)
-			end(nn.Name())
+			if callback != nil {
+				callback(nn.Name(), "")
+			}
+			nn.pull(name)
+			if callback != nil {
+				callback(nn.Name(), "downloaded")
+			}
 			done <- true
 		}(n)
 	}

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -186,6 +186,14 @@ func (c *Cluster) Image(IdOrName string) *cluster.Image {
 	return nil
 }
 
+func (c *Cluster) Pull(name string, begin, end func(string)) {
+	for _, node := range c.nodes {
+		begin(node.Name())
+		node.Pull(name)
+		end(node.Name())
+	}
+}
+
 // Containers returns all the containers in the cluster.
 func (c *Cluster) Containers() []*cluster.Container {
 	c.RLock()


### PR DESCRIPTION
Right now, we have an issue because when we do a docker run, the scheduler will select a node.
Then, if this node doesn't have the image already pulled, swarm will pull the image automatically.
We do that because there is no way to tell to the client to pull the missing image on a particular node.
One issue is: it doesn't work with private images, because swarm doesn't have the client credential.

With this PR, you are able to do a `docker pull` manually to pull an image on all the nodes, this works for private images.
This PR also add a basic implementation of `docker rmi` and `docker inspect` for images

There is no change in the way docker run works.

```bash
docker pull rethinkdb
ubuntu-2: Pulling downloaded... 
fedora-1: Pulling downloaded... 
ubuntu-1: Pulling downloaded... 
```
then 
```bash
docker pull rethinkdb
ubuntu-2: Pulling downloaded...
fedora-1: Pulling downloaded...
ubuntu-1: Pulling downloaded... : rethinkdb:latest
```
then 
```bash
docker pull rethinkdb
ubuntu-2: Pulling downloaded... : rethinkdb:latest
fedora-1: Pulling downloaded... : rethinkdb:latest
ubuntu-1: Pulling downloaded... : rethinkdb:latest
```
 