### PR TITLE
closeIdleConnections to prevent leaks with https

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -180,6 +180,11 @@ func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// cleanup
+	defer resp.Body.Close()
+	defer closeIdleConnections(client)
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Fix #342 

This is a solution that works for me and doesn't requite a change in `dockerclient`

If it's still not enough, I have a step2: instead of creating a client for each proxy, we use the one from `dockerclient`