### PR TITLE
Correct IRC channel in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Note that Swarm certificates must be generated with`extendedKeyUsage = clientAut
 
 ## Participating
 
-We welcome pull requests and patches; come say hi on IRC, #swarm on freenode.
+We welcome pull requests and patches; come say hi on IRC, #docker-swarm on freenode.
 
 ## Creators
 


### PR DESCRIPTION
I joined #swarm and it was empty and I was like ":((((" and then I had to google the right one.