### PR TITLE
add Round-Robin placement strategy

### DIFF
--- a/scheduler/strategy/README.md
+++ b/scheduler/strategy/README.md
@@ -10,9 +10,10 @@ The `Docker Swarm` scheduler comes with multiple strategies.
 
 These strategies are used to rank nodes using a scores computed by the strategy.
 
-`Docker Swarm` currently supports 2 strategies:
+`Docker Swarm` currently supports 3 strategies:
 * [BinPacking](#binpacking-strategy)
 * [Random](#random-strategy)
+* [Round-Robin](#roundrobin-strategy)
 
 You can choose the strategy you want to use with the `--strategy` flag of `swarm manage`
 
@@ -54,3 +55,10 @@ already. This allows us to start a container requiring 2G of RAM on `node-2`.
 ## Random strategy
 
 The Random strategy, as it's name says, chose a random node, it's used mainly for debug.
+
+## Round-Robin strategy
+
+The Round-Robin strategy will rank the nodes based on the number of running containers on each node
+and will return the node with the least amount of containers. This is useful when you want to have
+network traffic distributed evenly across all nodes, ensuring high availability of your containers
+in case of a node failure.

--- a/scheduler/strategy/errors.go
+++ b/scheduler/strategy/errors.go
@@ -1,0 +1,5 @@
+package strategy
+
+const (
+	ErrNoResourcesAvailable = "no resources available to schedule container"
+)

--- a/scheduler/strategy/roundrobin.go
+++ b/scheduler/strategy/roundrobin.go
@@ -8,19 +8,18 @@ import (
 	"github.com/samalba/dockerclient"
 )
 
-type BinPackingPlacementStrategy struct{}
+type RoundRobinPlacementStrategy struct{}
 
-func (p *BinPackingPlacementStrategy) Initialize() error {
+func (ps *RoundRobinPlacementStrategy) Initialize() error {
 	return nil
 }
 
-func (p *BinPackingPlacementStrategy) PlaceContainer(config *dockerclient.ContainerConfig, nodes []*cluster.Node) (*cluster.Node, error) {
-	scores := scores{}
+func (ps *RoundRobinPlacementStrategy) PlaceContainer(config *dockerclient.ContainerConfig, nodes []*cluster.Node) (*cluster.Node, error) {
+	scores := lowScores{}
 
 	for _, node := range nodes {
 		nodeMemory := node.UsableMemory()
 		nodeCpus := node.UsableCpus()
-
 		// Skip nodes that are smaller than the requested resources.
 		if nodeMemory < int64(config.Memory) || nodeCpus < config.CpuShares {
 			continue
@@ -39,7 +38,7 @@ func (p *BinPackingPlacementStrategy) PlaceContainer(config *dockerclient.Contai
 		}
 
 		if cpuScore <= 100 && memoryScore <= 100 {
-			scores = append(scores, &score{node: node, score: cpuScore + memoryScore})
+			scores = append(scores, &score{node: node, score: int64(len(node.Containers()))})
 		}
 	}
 
@@ -48,30 +47,24 @@ func (p *BinPackingPlacementStrategy) PlaceContainer(config *dockerclient.Contai
 	}
 
 	sort.Sort(scores)
-
 	return scores[0].node, nil
 }
 
-type score struct {
-	node  *cluster.Node
-	score int64
-}
+type lowScores []*score
 
-type scores []*score
-
-func (s scores) Len() int {
+func (s lowScores) Len() int {
 	return len(s)
 }
 
-func (s scores) Swap(i, j int) {
+func (s lowScores) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-func (s scores) Less(i, j int) bool {
+func (s lowScores) Less(i, j int) bool {
 	var (
 		ip = s[i]
 		jp = s[j]
 	)
 
-	return ip.score > jp.score
+	return ip.score < jp.score
 }

--- a/scheduler/strategy/roundrobin_test.go
+++ b/scheduler/strategy/roundrobin_test.go
@@ -1,0 +1,207 @@
+package strategy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/docker/swarm/cluster"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlaceContainerRoundRobinMemory(t *testing.T) {
+	s := &RoundRobinPlacementStrategy{}
+
+	nodes := []*cluster.Node{}
+	for i := 0; i < 2; i++ {
+		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 1, 1))
+	}
+
+	// add 1 container 1G
+	config := createConfig(1, 0)
+	node1, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node1.AddContainer(createContainer("c1", config)))
+	assert.Equal(t, 1, len(node1.Containers()))
+
+	// add another container 1G
+	node2, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node2.AddContainer(createContainer("c2", config)))
+	assert.Equal(t, 1, len(node2.Containers()))
+
+	// check that both containers ended on different nodes
+	assert.NotEqual(t, node1.ID, node2.ID, "")
+	assert.Equal(t, len(node1.Containers()), len(node2.Containers()), "")
+}
+
+func TestPlaceContainerRoundRobinCPU(t *testing.T) {
+	s := &RoundRobinPlacementStrategy{}
+
+	nodes := []*cluster.Node{}
+	for i := 0; i < 2; i++ {
+		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 1, 2))
+	}
+
+	// add 1 container 1CPU
+	config := createConfig(0, 1)
+	node1, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node1.AddContainer(createContainer("c1", config)))
+
+	assert.Equal(t, 1, node1.ReservedCpus())
+
+	// add another container 1CPU
+	config = createConfig(0, 1)
+	node2, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node2.AddContainer(createContainer("c2", config)))
+	assert.Equal(t, 1, node2.ReservedCpus())
+
+	// check that both containers ended on different nodes
+	assert.NotEqual(t, node1.ID, node2.ID, "")
+	assert.Equal(t, len(node1.Containers()), len(node2.Containers()), "")
+}
+
+func TestPlaceContainerRoundRobinHuge(t *testing.T) {
+	s := &RoundRobinPlacementStrategy{}
+
+	nodes := []*cluster.Node{}
+	for i := 0; i < 100; i++ {
+		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 1, 1))
+	}
+
+	// add 100 container 1CPU
+	for i := 0; i < 100; i++ {
+		node, err := s.PlaceContainer(createConfig(0, 1), nodes)
+		assert.NoError(t, err)
+		assert.NoError(t, node.AddContainer(createContainer(fmt.Sprintf("c%d", i), createConfig(0, 100))))
+	}
+
+	// try to add another container 1CPU
+	_, err := s.PlaceContainer(createConfig(0, 1), nodes)
+	assert.Error(t, err)
+
+	// add 100 container 1G
+	for i := 100; i < 200; i++ {
+		node, err := s.PlaceContainer(createConfig(1, 0), nodes)
+		assert.NoError(t, err)
+		assert.NoError(t, node.AddContainer(createContainer(fmt.Sprintf("c%d", i), createConfig(1, 0))))
+	}
+
+	// try to add another container 1G
+	_, err = s.PlaceContainer(createConfig(1, 0), nodes)
+	assert.Error(t, err)
+}
+
+func TestPlaceContainerRoundRobinOvercommit(t *testing.T) {
+	s, err := New("roundrobin")
+	assert.NoError(t, err)
+
+	nodes := []*cluster.Node{createNode("node-1", 0, 1)}
+	nodes[0].Memory = 100
+
+	config := createConfig(0, 0)
+
+	// Below limit should still work.
+	config.Memory = 90
+	node, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.Equal(t, node, nodes[0])
+
+	// At memory limit should still work.
+	config.Memory = 100
+	node, err = s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.Equal(t, node, nodes[0])
+
+	// Up to 105% it should still work.
+	config.Memory = 105
+	node, err = s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.Equal(t, node, nodes[0])
+
+	// Above it should return an error.
+	config.Memory = 106
+	node, err = s.PlaceContainer(config, nodes)
+	assert.Error(t, err)
+}
+
+func TestPlaceContainerRoundRobinDemo(t *testing.T) {
+	s := &RoundRobinPlacementStrategy{}
+
+	nodes := []*cluster.Node{}
+	for i := 0; i < 3; i++ {
+		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 2, 4))
+	}
+
+	// try to place a 10G container
+	config := createConfig(10, 0)
+	_, err := s.PlaceContainer(config, nodes)
+
+	// check that it refuses because the cluster is full
+	assert.Error(t, err)
+
+	// add one container 1G
+	config = createConfig(1, 0)
+	node1, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node1.AddContainer(createContainer("c1", config)))
+
+	// add another container 1G
+	config = createConfig(1, 0)
+	node2, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node2.AddContainer(createContainer("c2", config)))
+
+	// check that both containers ended on different nodes
+	assert.NotEqual(t, node1.ID, node2.ID, "")
+	assert.Equal(t, len(node1.Containers()), len(node2.Containers()), "")
+
+	// add another container 2G
+	config = createConfig(2, 0)
+	node3, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node3.AddContainer(createContainer("c3", config)))
+
+	// check that it ends up on another node
+	assert.NotEqual(t, node1.ID, node3.ID, "")
+	assert.NotEqual(t, node2.ID, node3.ID, "")
+
+	// add another container 1G
+	config = createConfig(1, 0)
+	node4, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node4.AddContainer(createContainer("c4", config)))
+
+	// check that it ends up on node1
+	assert.Equal(t, node4.ID, node1.ID, "")
+
+	// add another container 2G
+	config = createConfig(2, 0)
+	_, err = s.PlaceContainer(config, nodes)
+
+	// check that it refuses because the cluster only has capacity for 1G
+	assert.Error(t, err)
+
+	// add another container 1G
+	config = createConfig(1, 0)
+	node5, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node5.AddContainer(createContainer("c5", config)))
+
+	// check that it ends up on node2
+	assert.Equal(t, node5.ID, node2.ID, "")
+
+	// remove container in the middle
+	node2.CleanupContainers()
+
+	// add another container
+	config = createConfig(1, 0)
+	node6, err := s.PlaceContainer(config, nodes)
+	assert.NoError(t, err)
+	assert.NoError(t, node6.AddContainer(createContainer("c6", config)))
+
+	// check that it ends up on node2
+	assert.Equal(t, node6.ID, node2.ID, "")
+	assert.Equal(t, len(node2.Containers()), len(node6.Containers()), "")
+}

--- a/scheduler/strategy/strategy.go
+++ b/scheduler/strategy/strategy.go
@@ -24,6 +24,7 @@ func init() {
 	strategies = map[string]PlacementStrategy{
 		"binpacking": &BinPackingPlacementStrategy{},
 		"random":     &RandomPlacementStrategy{},
+		"roundrobin": &RoundRobinPlacementStrategy{},
 	}
 }
 


### PR DESCRIPTION
The Round-Robin strategy will rank the nodes based on the number of
running containers on each node and will return the node with the least
amount of containers. This is useful when you want to have network
traffic distributed evenly across all nodes, ensuring high availability
of your containers in case of a node failure.

Signed-off-by: Matthew Fisher <matthewf@opdemand.com>