### PR TITLE
refactor score to WeightedNode structure

### DIFF
--- a/scheduler/strategy/weighted_node.go
+++ b/scheduler/strategy/weighted_node.go
@@ -1,0 +1,30 @@
+package strategy
+
+import "github.com/docker/swarm/cluster"
+
+// WeightedNode represents a node in the cluster with a given weight, typically used for sorting
+// purposes.
+type weightedNode struct {
+	Node cluster.Node
+	// Weight is the inherent value of this node.
+	Weight int64
+}
+
+type weightedNodeList []*weightedNode
+
+func (n weightedNodeList) Len() int {
+	return len(n)
+}
+
+func (n weightedNodeList) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}
+
+func (n weightedNodeList) Less(i, j int) bool {
+	var (
+		ip = n[i]
+		jp = n[j]
+	)
+
+	return ip.Weight < jp.Weight
+}


### PR DESCRIPTION
In many different scheduling strategies, a node is typically given
a certain weight based upon its values that are important to the
overall strategy. Exposing a weightedNode structure as well as a
new weightedNodeList type allows one to operate upon a set of nodes for
sorting purposes by assigning weights to each node and calling
sort.Sort() on a weightedNodeList.

Signed-off-by: Matthew Fisher <matthewf@opdemand.com>

This partially affects #227 as well, since it relies on the original `scores` structure.