### PR TITLE
Fix potential null dereference in token discovery

### DIFF
--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -80,9 +80,10 @@ func (s *TokenDiscoveryService) Register(addr string) error {
 
 	resp, err := http.Post(fmt.Sprintf("%s/%s/%s", s.url,
 		"clusters", s.token), "application/json", buf)
-
-	// Force connection close
-	resp.Body.Close()
+	if err == nil {
+		// Force connection close
+		resp.Body.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
Noticed that this caused a panic during Docker node shutdown/reboot process.