### PR TITLE
add ./script/doc to build swarm documentation using the docs.docker.com tooling

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,21 @@
+FROM docs/base:latest
+MAINTAINER Sven Dowideit <SvenDowideit@docker.com> (@SvenDowideit)
+
+# to get the git info for this repo
+COPY . /src
+
+# Reset the /docs dir so we can replace the theme meta with the new repo's git info
+RUN git reset --hard
+
+RUN grep "VERSION =" /src/version/version.go  | sed 's/.*"\(.*\)".*/\1/' > /docs/VERSION
+COPY docs/mkdocs.yml /docs/mkdocs-swarm.yml
+
+COPY ./scheduler/strategy/README.md /docs/sources/swarm/scheduler/strategy.md
+COPY ./scheduler/filter/README.md /docs/sources/swarm/scheduler/filter.md
+COPY ./api/README.md /docs/sources/swarm/API.md
+COPY ./discovery/README.md /docs/sources/swarm/discovery.md
+#COPY ./discovery/token/README.md /docs/sources/
+COPY ./docs/index.md /docs/sources/swarm/index.md
+
+# Then build everything together, ready for mkdocs
+RUN /docs/build.sh

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+# import the existing docs build cmds from docker/docker
+DOCSPORT=8000
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+DOCKER_DOCS_IMAGE="compose-docs$GIT_BRANCH"
+DOCKER_RUN_DOCS="docker run --rm -it -e NOCACHE"
+
+docker build -t "$DOCKER_DOCS_IMAGE" -f docs/Dockerfile .
+$DOCKER_RUN_DOCS -p $DOCSPORT:8000 "$DOCKER_DOCS_IMAGE" mkdocs serve

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,9 +91,9 @@ the certificates.
 
 ## Discovery services
 
-See the [Discovery service](../discovery) document for more information.
+See the [Discovery service](discovery.md) document for more information.
 
 ## Advanced Scheduling
 
-See [filters](../scheduler/filter) and [strategies](../scheduler/strategy) to learn
+See [filters](scheduler/filter.md) and [strategies](scheduler/strategy.md) to learn
 more about advanced scheduling.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,6 @@
+
+- ['swarm/index.md', 'User Guide', 'Docker Swarm' ]
+- ['swarm/discovery.md', 'Reference', 'Swarm discovery']
+- ['swarm/API.md', 'Reference', 'Swarm API']
+- ['swarm/scheduler/filter.md', 'Reference', 'Swarm filters']
+- ['swarm/scheduler/strategy.md', 'Reference', 'Swarm strategies']


### PR DESCRIPTION

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

This also fixes some broken links.

Once merged, I'll add another commit to https://github.com/docker/docker/pull/10869 to use the `docs/mkdocs.yml` in this repository.

