### PR TITLE
Ignore empty addresses when creating discovery entries

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -84,6 +84,9 @@ func CreateEntries(addrs []string) ([]*Entry, error) {
 	}
 
 	for _, addr := range addrs {
+		if len(addr) == 0 {
+			continue
+		}
 		entry, err := NewEntry(addr)
 		if err != nil {
 			return nil, err

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -43,7 +43,8 @@ func TestCreateEntries(t *testing.T) {
 	assert.Equal(t, entries, []*Entry{})
 	assert.NoError(t, err)
 
-	entries, err = CreateEntries([]string{"127.0.0.1:2375", "127.0.0.2:2375"})
+	entries, err = CreateEntries([]string{"127.0.0.1:2375", "127.0.0.2:2375", ""})
+	assert.Equal(t, len(entries), 2)
 	assert.Equal(t, entries[0].String(), "127.0.0.1:2375")
 	assert.Equal(t, entries[1].String(), "127.0.0.2:2375")
 	assert.NoError(t, err)


### PR DESCRIPTION
When using a static file to describe the cluster you always get a "FATA[0000] missing port in address" error. This is because an empty line appears when reading the file and [splitting it by new lines](https://github.com/docker/swarm/blob/master/discovery/file/file.go#L32). That empty line is sent to CreateEntries that will fail to [SplitHostPort](https://github.com/docker/swarm/blob/master/discovery/discovery.go#L18) the empty url. This seems a regression introduced at https://github.com/docker/swarm/commit/3df8bbed61f3ca409e464d89c190660bb2fefe50#diff-a89535e73dc6aa6a96a011d34159ab6aL35.

Instead of fixing the file discovery to remove the empty line, this fix ignores empty addresses when creating new discovery entries, as it would be useful on other discovery calls.

Signed-off-by: Ferran Rodenas <frodenas@gmail.com>