### PR TITLE
remove proxyContainerAndForceRefresh

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -57,7 +57,7 @@ func closeIdleConnections(client *http.Client) {
 	}
 }
 
-func proxyAsync(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.Request, callback func(*http.Response)) error {
+func proxy(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.Request) error {
 	// Use a new client for each request
 	client, scheme := newClientAndScheme(tlsConfig)
 	// RequestURI may not be sent to client
@@ -72,10 +72,6 @@ func proxyAsync(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *ht
 		return err
 	}
 
-	if callback != nil {
-		callback(resp)
-	}
-
 	copyHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(NewWriteFlusher(w), resp.Body)
@@ -85,10 +81,6 @@ func proxyAsync(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *ht
 	closeIdleConnections(client)
 
 	return nil
-}
-
-func proxy(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.Request) error {
-	return proxyAsync(tlsConfig, addr, w, r, nil)
 }
 
 func hijack(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
Right now we have a "special" proxy for docker exec, because we need to do a force refresh in the before returning the result, do get the execID.

This PRs remove this `proxyContainerAndForceRefresh` to get the execID from return of the `/exec`.

Then we insert the execID to the container. Even though this is not saved in the store, it's fine, will be reflected in the store on the next refresh (a few seconds later).

Here are all the advantages of this PR:
* Removes a cast to `swarm.Node` because we were breaking the Node Interface.
* Exec much faster.
* Better error message.
