### PR TITLE
Proposal: PoC for Bats integration tests

### DIFF
--- a/test/integration/manage-non-available-node.bats
+++ b/test/integration/manage-non-available-node.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load vars
+
+@test "managing non-available node should be timed out" {
+
+	#
+	# timeout does not accept a bash function, so hard-coded path is required
+	#
+	run timeout 15s $GOBIN/swarm manage -H 127.0.0.1:2375 nodes://8.8.8.8:2375
+
+	[ "$status" -ne 0 ]
+	[[ ${lines[0]} =~ "Listening for HTTP" ]]
+	[[ ${lines[1]} =~ "ConnectEx tcp: i/o timeout" ]]
+}

--- a/test/integration/vars.bash
+++ b/test/integration/vars.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+function swarm() {
+	$GOBIN/swarm $@
+}

--- a/test/integration/version-and-gitcommit.bats
+++ b/test/integration/version-and-gitcommit.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+load vars
+
+@test "version string should contain a proper number with git commit" {
+	run swarm -v
+
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ version\ [0-9]+\.[0-9]+\.[0-9]+\ \([0-9a-f]{7}\)$ ]]
+}


### PR DESCRIPTION
Swarm requires integration tests (#376) and @aluzzardi suggested in #400 that Swarm should use `Bats` to run this kind of tests. This PR follows Docker Machine's way of testing (docker/machine#615). It proposes a PoC to perform integration tests for Swarm.

There are 2 tests under `test/integration` directory:
  1. A test to match version and gitcommit.
  2. A test that uses `timeout` to check if Swarm fail to connect to a non-existed node.

To run these tests:
  1. Compile swarm and make sure that there's the binary in `$GOBIN`.
  2. Run `bats test/integration`

/cc @vieux 

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>