### PR TITLE
dealing with agent disconnection

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -114,6 +114,27 @@ func (c *Cluster) RemoveContainer(container *cluster.Container, force bool) erro
 
 // Entries are Docker Nodes
 func (c *Cluster) newEntries(entries []*discovery.Entry) {
+	var removed []*node
+SKIP:
+	for _, node := range c.nodes {
+		for _, entry := range entries {
+			if node.Addr() == entry.String() {
+				continue SKIP
+			}
+		}
+		removed = append(removed, node)
+	}
+
+	for _, node := range removed {
+		log.Printf("node[%s] agent is disconnected", node.Addr())
+		// If the swarm agent is dead, we have to check the docker node is still available.
+		// etcd(or doozerd) discovery has no ephemeral node like zookeeper.
+		// So swarm uses TTL and renews the node. This can lead redundant calls to refreshLoop().
+		if node.IsHealthy() {
+			node.refreshContainersAsync()
+		}
+	}
+
 	for _, entry := range entries {
 		go func(m *discovery.Entry) {
 			if c.getNode(m.String()) == nil {


### PR DESCRIPTION
Hi.
Swarm seems to have two heart-beater: discovery watcher and node refresher.
- The node refresher has a role to refresh internal storage and modify the node's health.
- And the discovery watcher watches discovery's directory then add new nodes to the swarm cluster.

I think the discovery watcher should inform us of the agent disconnections and check docker connections right away.
- We can check the node's status before the stateRefreshPeriod(30s).
- Operators need to know about swarm-agent's status at least in form of a log.

This PR includes very basic features:
- figures out removed nodes from the discovery watch entries.
- logs them.
- refresh the node's storage to check the healthiness only if the node was healthy.