### PR TITLE
use number of containers in binpack + fix some tests

### DIFF
--- a/scheduler/strategy/binpack.go
+++ b/scheduler/strategy/binpack.go
@@ -23,5 +23,15 @@ func (p *BinpackPlacementStrategy) PlaceContainer(config *dockerclient.Container
 	// sort by highest weight
 	sort.Sort(sort.Reverse(weightedNodes))
 
-	return weightedNodes[0].Node, nil
+	topNode := weightedNodes[0]
+	for _, node := range weightedNodes {
+		if node.Weight != topNode.Weight {
+			break
+		}
+		if len(node.Node.Containers()) > len(topNode.Node.Containers()) {
+			topNode = node
+		}
+	}
+
+	return topNode.Node, nil
 }

--- a/scheduler/strategy/spread.go
+++ b/scheduler/strategy/spread.go
@@ -20,8 +20,18 @@ func (p *SpreadPlacementStrategy) PlaceContainer(config *dockerclient.ContainerC
 		return nil, err
 	}
 
-	// sort by highest weight
+	// sort by lowest weight
 	sort.Sort(weightedNodes)
 
-	return weightedNodes[0].Node, nil
+	bottomNode := weightedNodes[0]
+	for _, node := range weightedNodes {
+		if node.Weight != bottomNode.Weight {
+			break
+		}
+		if len(node.Node.Containers()) < len(bottomNode.Node.Containers()) {
+			bottomNode = node
+		}
+	}
+
+	return bottomNode.Node, nil
 }


### PR DESCRIPTION
When using binpacking, if multiple nodes get the same weight, swarm will now look at the number of containers to choose the node with the higher number of container.