### PR TITLE
integration: add a test to verify creating cluster on hub

### DIFF
--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -88,24 +88,7 @@ function swarm_join() {
 		SWARM_JOIN_PID[$i]=$!
 		((++i))
 	done
-	wait_until_swarm_joined $i
-}
-
-# Wait until a swarm instance joins the cluster.
-# Parameter $1 is number of nodes to check.
-function wait_until_swarm_joined {
-	local attempts=0
-	local max_attempts=10
-
-	until [ $attempts -ge $max_attempts ]; do
-		run docker -H $SWARM_HOST info
-		if [[ "${lines[3]}" == *"Nodes: $1"* ]]; then
-			break
-		fi 
-		echo "Checking if joined successfully for the $((++attempts)) time" >&2
-		sleep 1
-	done
-	[[ $attempts -lt $max_attempts ]]
+	retry 30 1 [ `docker_swarm info | grep -q "Nodes: $i"` -eq 0 ]
 }
 
 # Stops the manager.

--- a/test/integration/token-discovery.bats
+++ b/test/integration/token-discovery.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function token_cleanup() {
+	curl -X DELETE https://discovery-stage.hub.docker.com/v1/clusters/$1
+}
+
+function teardown() {
+	swarm_join_cleanup
+	swarm_manage_cleanup
+	stop_docker
+}
+
+@test "token discovery should be working properly" {
+	start_docker 2
+
+	TOKEN=$(swarm create)
+	[ "$status" -eq 0 ]
+	[[ ${TOKEN} =~ ^[0-9a-f]{32}$ ]]
+
+	swarm_manage token://$TOKEN
+	swarm_join   token://$TOKEN
+
+	run docker_swarm info
+	[[ "${lines[3]}" == *"Nodes: 2"* ]]
+
+	token_cleanup $TOKEN
+}


### PR DESCRIPTION
This is a test for `swarm create` and `swarm c`. These command should return a proper cluster token, hexadecimal string of size 32.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>