### PR TITLE
Add support for Soft Affinity

### DIFF
--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -185,6 +185,23 @@ For example,
 * `constraint:node!=/foo\[bar\]/` will match all nodes, except `foo[bar]`. You can see the use of escape characters here.
 * `constraint:node==/(?i)node1/` will match node `node1` case-insensitive. So 'NoDe1' or 'NODE1' will also match.
 
+#### Soft Affinities
+
+By default, affinities are hard enforced. If an affinity is not met, the container won't be scheduled.
+With soft affinites the scheduler will try to meet the affinity. If it is not met, the scheduler will discard the filter and schedule the container according to the scheduler strategy.
+
+soft affinites are expressed with a **~** in the expression
+Example ,
+```
+$ docker run -d --name redis1 -e affinity:image==~redis redis
+```
+If none of the nodes in the cluster has image redis, the scheduler will discard the affinity and schedules according to the strategy.
+
+```
+$ docker run -d --name redis5 -e affinity:container!=~redis* redis
+```
+The affinity filter is about scheduling a new redis5 container to a different node that doesn't have a container with the name that satisfies redis*. If each node in the cluster has a redis* container the scheduler with discard the affinity rule and schedules according to the strategy. 
+
 ## Port Filter
 
 With this filter, `ports` are considered as unique resources.

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -200,7 +200,7 @@ If none of the nodes in the cluster has image redis, the scheduler will discard 
 ```
 $ docker run -d --name redis5 -e affinity:container!=~redis* redis
 ```
-The affinity filter is about scheduling a new redis5 container to a different node that doesn't have a container with the name that satisfies redis*. If each node in the cluster has a redis* container the scheduler with discard the affinity rule and schedules according to the strategy. 
+The affinity filter will be used to schedule a new redis5 container to a different node that doesn't have a container with the name that satisfies redis*. If each node in the cluster has a redis* container, the scheduler will discard the affinity rule and schedules according to the strategy. 
 
 ## Port Filter
 

--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -185,22 +185,35 @@ For example,
 * `constraint:node!=/foo\[bar\]/` will match all nodes, except `foo[bar]`. You can see the use of escape characters here.
 * `constraint:node==/(?i)node1/` will match node `node1` case-insensitive. So 'NoDe1' or 'NODE1' will also match.
 
-#### Soft Affinities
+#### Soft Affinities/Constraints
 
-By default, affinities are hard enforced. If an affinity is not met, the container won't be scheduled.
-With soft affinites the scheduler will try to meet the affinity. If it is not met, the scheduler will discard the filter and schedule the container according to the scheduler strategy.
+By default, affinities and constraints are hard enforced. If an affinity or
+constraint is not met, the container won't be scheduled. With soft
+affinities/constraints the scheduler will try to meet the rule. If it is not
+met, the scheduler will discard the filter and schedule the container according
+to the scheduler's strategy.
 
-soft affinites are expressed with a **~** in the expression
+soft affinities/constraints are expressed with a **~** in the expression
 Example ,
 ```
 $ docker run -d --name redis1 -e affinity:image==~redis redis
 ```
-If none of the nodes in the cluster has image redis, the scheduler will discard the affinity and schedules according to the strategy.
+If none of the nodes in the cluster has the image redis, the scheduler will
+discard the affinity and schedules according to the strategy.
+
+```
+$ docker run -d --name redis2 -e constraint:region==~us* redis
+```
+If none of the nodes in the cluster belongs to `us` region, the scheduler will
+discard the constraint and schedules according to the strategy.
 
 ```
 $ docker run -d --name redis5 -e affinity:container!=~redis* redis
 ```
-The affinity filter will be used to schedule a new redis5 container to a different node that doesn't have a container with the name that satisfies redis*. If each node in the cluster has a redis* container, the scheduler will discard the affinity rule and schedules according to the strategy. 
+The affinity filter will be used to schedule a new `redis5` container to a
+different node that doesn't have a container with the name that satisfies
+`redis*`. If each node in the cluster has a `redis*` container, the scheduler
+will discard the affinity rule and schedules according to the strategy.
 
 ## Port Filter
 

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -48,7 +48,7 @@ func (f *AffinityFilter) Filter(config *dockerclient.ContainerConfig, nodes []cl
 			}
 		}
 		if len(candidates) == 0 {
-			if affinity.IsSoft() {
+			if affinity.isSoft {
 				return nodes, nil
 			}
 			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", affinity.key, OPERATORS[affinity.operator], affinity.value)

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -48,6 +48,9 @@ func (f *AffinityFilter) Filter(config *dockerclient.ContainerConfig, nodes []cl
 			}
 		}
 		if len(candidates) == 0 {
+			if affinity.IsSoft() {
+				return nodes, nil
+			}
 			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", affinity.key, OPERATORS[affinity.operator], affinity.value)
 		}
 		nodes = candidates

--- a/scheduler/filter/affinity_test.go
+++ b/scheduler/filter/affinity_test.go
@@ -201,6 +201,12 @@ func TestAffinityFilter(t *testing.T) {
 	assert.Len(t, result, 1)
 
 	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"affinity:image==~ima~ge-0:tag3"},
+	}, nodes)
+	assert.Error(t, err)
+	assert.Len(t, result, 0)
+
+	result, err = f.Filter(&dockerclient.ContainerConfig{
 		Env: []string{"affinity:image==~image-1:tag3"},
 	}, nodes)
 	assert.NoError(t, err)

--- a/scheduler/filter/affinity_test.go
+++ b/scheduler/filter/affinity_test.go
@@ -193,6 +193,38 @@ func TestAffinityFilter(t *testing.T) {
 	}, nodes)
 	assert.Error(t, err)
 
+	//Tests for Soft affinity
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"affinity:image==~image-0:tag3"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"affinity:image==~image-1:tag3"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"affinity:image==~image-*"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"affinity:image!=~image-*"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, result[0], nodes[2])
+
+	result, err = f.Filter(&dockerclient.ContainerConfig{
+		Env: []string{"affinity:image==~/image-\\d*/"},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+
 	// Not support = any more
 	result, err = f.Filter(&dockerclient.ContainerConfig{
 		Env: []string{"affinity:image=image-0:tag3"},
@@ -206,4 +238,5 @@ func TestAffinityFilter(t *testing.T) {
 	}, nodes)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)
+
 }

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -36,6 +36,9 @@ func (f *ConstraintFilter) Filter(config *dockerclient.ContainerConfig, nodes []
 			}
 		}
 		if len(candidates) == 0 {
+			if constraint.isSoft {
+				return nodes, nil
+			}
 			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", constraint.key, OPERATORS[constraint.operator], constraint.value)
 		}
 		nodes = candidates


### PR DESCRIPTION
Adds support for soft affinities as discussed in the [issue 447](https://github.com/docker/swarm/issues/447) 
soft affinites are expressed with a **~** in the expression
```
$ docker run -d --name redis1 -e affinity:image==~redis redis
```
If none of the nodes in the cluster has image redis, the scheduler will discard the affinity and schedules according to the strategy.
Provided Test cases to validate soft affinity expressions 