### PR TITLE
Add windows CI through Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: '{build}'
+build_script:
+- ps: >-
+    $env:GOPATH="c:/gocode";
+
+    mkdir $env:GOPATH | Out-Null
+
+    $env:GOBIN="$env:GOPATH/bin";
+
+    $env:PATH="$env:GOBIN;$env:PATH";
+
+    go version
+
+    go env
+
+
+    #Get deps
+
+    go get golang.org/x/tools/cmd/vet
+
+    go get github.com/tools/godep
+
+    godep restore
+
+    go get .
+test_script:
+- ps: >-
+    go vet ./...
+
+    go test -v -cover -race ./...


### PR DESCRIPTION
The project will likely need to be activated by maintainers at https://ci.appveyor.com/projects

Also, it would be nice to have a status badge from https://ci.appveyor.com/project/docker/swarm/settings/badges added to the readme as well.