### PR TITLE
Move note on top of Nodes config to avoid confusion

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,11 @@ Each swarm node will run a swarm node agent which will register the referenced
 Docker daemon, and will then monitor it, updating the discovery backend to its
 status.
 
+> **Note**: In order for the Swarm manager to be able to communicate with the node 
+agent on each node, they must listen to a common network interface. This can be 
+achieved by starting docker with the `-H` flag (e.g. `docker -H tcp://0.0.0.0:2375 -d` 
+on each swarm node).
+
 The following example uses the Docker Hub based `token` discovery service:
 
 ```bash
@@ -69,11 +74,6 @@ $ docker -H tcp://<swarm_ip:swarm_port> logs ...
 $ docker run --rm swarm list token://<cluster_id>
 <node_ip:2375>
 ```
-
-> **Note**: In order for the Swarm manager to be able to communicate with the node agent on
-each node, they must listen to a common network interface. This can be achieved
-by starting with the `-H` flag (e.g. `-H tcp://0.0.0.0:2375`).
-
 
 ## TLS
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,15 +6,12 @@ page_keywords: docker, swarm, clustering
 
 # Docker Swarm
 
-> **Note**: Swarm is currently in beta, so things are likely to change. We
-> don't recommend you use it in production yet.
-
 Docker Swarm is native clustering for Docker. It turns a pool of Docker hosts
 into a single, virtual host.
 
 Swarm serves the standard Docker API, so any tool which already communicates
 with a Docker daemon can use Swarm to transparently scale to multiple hosts:
-Dokku, Compose, Krane, Flynn, Deis, DockerUI, Shipyard, Drone, Jenkins... and,
+Dokku, Compose, Krane, Deis, DockerUI, Shipyard, Drone, Jenkins... and,
 of course, the Docker client itself.
 
 Like other Docker projects, Swarm follows the "batteries included but removable"
@@ -24,11 +21,19 @@ The goal is to provide a smooth out-of-box experience for simple use cases, and
 allow swapping in more powerful backends, like Mesos, for large scale production
 deployments.
 
-## Installation
+## Pre-requisites for running Swarm
 
-> **Note**: The only requirement for Swarm nodes is they all run the _same_ release
-> Docker daemon (version `1.4.0` and later), configured to listen to a `tcp`
-> port that the Swarm manager can access.
+You must install Docker 1.4.0 or later on all nodes. While each node's IP need not
+be public, the Swarm manager must be able to access each node across the network.
+
+To enable communication between the Swarm manager and the Swarm node agent on each 
+node, each node must listen to the same network interface (tcp port). Follow the set
+up below to ensure you configure your nodes correctly for this behavior.
+
+> **Note**: Swarm is currently in beta, so things are likely to change. We
+> don't recommend you use it in production yet.
+
+## Install Swarm
 
 The easiest way to get started with Swarm is to use the
 [official Docker image](https://registry.hub.docker.com/_/swarm/).
@@ -37,40 +42,98 @@ The easiest way to get started with Swarm is to use the
 docker pull swarm
 ```
 
-## Nodes setup
+## Set up Swarm nodes
 
-Each swarm node will run a swarm node agent which will register the referenced
-Docker daemon, and will then monitor it, updating the discovery backend to its
-status.
-
-> **Note**: In order for the Swarm manager to be able to communicate with the node 
-agent on each node, they must listen to a common network interface. This can be 
-achieved by starting docker with the `-H` flag (e.g. `docker -H tcp://0.0.0.0:2375 -d` 
-on each swarm node).
+Each swarm node will run a swarm node agent. The agent registers the referenced
+Docker daemon, monitors it, and updates the discovery backend with the node's status.
 
 The following example uses the Docker Hub based `token` discovery service:
 
-```bash
-# create a cluster
-$ docker run --rm swarm create
-6856663cdefdec325839a4b7e1de38e8 # <- this is your unique <cluster_id>
+1. Create a Swarm cluster using the `docker` command.
 
-# on each of your nodes, start the swarm agent
-#  <node_ip> doesn't have to be public (eg. 192.168.0.X),
-#  as long as the swarm manager can access it.
-$ docker run -d swarm join --addr=<node_ip:2375> token://<cluster_id>
+    ```bash
+    $ docker run --rm swarm create
+    6856663cdefdec325839a4b7e1de38e8 # <- this is your unique <cluster_id>
+    ```
 
-# start the manager on any machine or your laptop
-$ docker run -d -p <swarm_port>:2375 swarm manage token://<cluster_id>
+    The create command returns a unique cluster id (`cluster_id`). You'll need
+    this id when starting the Swarm agent on a node.
 
-# use the regular docker cli
+2. Log into **each node** and do the following.
+
+    i. Start the docker daemon with the `-H` flag. This ensures that the docker remote API on *Swarm Agents* is available over TCP for the *Swarm Manager*.
+
+    ```bash
+    $ docker -H tcp://0.0.0.0:2375 -d
+    ```
+
+    ii. Register the Swarm agents to the discovery service. The node's IP must be accessible from the Swarm Manager. Use the following command and replace with the proper `node_ip` and `cluster_id` to start an agent:
+
+    ```bash
+    $ docker run -d swarm join --addr=<node_ip:2375> token://<cluster_id>
+    ```
+
+    For example:
+
+    ```bash
+    $ docker run -d swarm join --addr=172.31.40.100:2375 token://6856663cdefdec325839a4b7e1de38e8
+    ```
+
+3. Start the Swarm manager on any machine or your laptop. The following command
+illustrates how to do this:
+
+    ```bash
+    $ docker run -d -p <swarm_port>:2375 swarm manage token://<cluster_id>
+    ```
+
+4. Once the manager is running, check your configuration by running `docker info` as follows:
+
+    ```
+    $ docker -H tcp://<manager_ip:manager_port> info
+    ```
+    
+    For example, if you run the manager locally on your machine:
+
+    ```bash
+    $ docker -H tcp://0.0.0.0:2375 info
+    Containers: 0
+    Nodes: 3
+     agent-2: 172.31.40.102:2375
+      └ Containers: 0
+      └ Reserved CPUs: 0 / 1
+      └ Reserved Memory: 0 B / 514.5 MiB
+     agent-1: 172.31.40.101:2375
+      └ Containers: 0
+      └ Reserved CPUs: 0 / 1
+      └ Reserved Memory: 0 B / 514.5 MiB
+     agent-0: 172.31.40.100:2375
+      └ Containers: 0
+      └ Reserved CPUs: 0 / 1
+      └ Reserved Memory: 0 B / 514.5 MiB
+    ```
+    
+    If you are running a test cluster without TLS enabled, you may get an error. In that case, be sure to unset `DOCKER_TLS_VERIFY` with:
+    
+    ```bash
+    $ unset DOCKER_TLS_VERIFY
+    ```
+
+## Using the docker CLI
+
+You can now use the regular `docker` CLI to access your nodes:
+
+```
 $ docker -H tcp://<swarm_ip:swarm_port> info
 $ docker -H tcp://<swarm_ip:swarm_port> run ...
 $ docker -H tcp://<swarm_ip:swarm_port> ps
 $ docker -H tcp://<swarm_ip:swarm_port> logs ...
-...
+```
 
-# list nodes in your cluster
+## List nodes in your cluster
+
+You can get a list of all your running nodes using the `swarm list` command:
+
+```
 $ docker run --rm swarm list token://<cluster_id>
 <node_ip:2375>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,35 +61,35 @@ The following example uses the Docker Hub based `token` discovery service:
 
 2. Log into **each node** and do the following.
 
-    i. Start the docker daemon with the `-H` flag. This ensures that the docker remote API on *Swarm Agents* is available over TCP for the *Swarm Manager*.
+    1. Start the docker daemon with the `-H` flag. This ensures that the docker remote API on *Swarm Agents* is available over TCP for the *Swarm Manager*.
 
-    ```bash
-    $ docker -H tcp://0.0.0.0:2375 -d
-    ```
+        ```bash
+        $ docker -H tcp://0.0.0.0:2375 -d
+        ```
 
-    ii. Register the Swarm agents to the discovery service. The node's IP must be accessible from the Swarm Manager. Use the following command and replace with the proper `node_ip` and `cluster_id` to start an agent:
+    2. Register the Swarm agents to the discovery service. The node's IP must be accessible from the Swarm Manager. Use the following command and replace with the proper `node_ip` and `cluster_id` to start an agent:
 
-    ```bash
-    $ docker run -d swarm join --addr=<node_ip:2375> token://<cluster_id>
-    ```
+        ```bash
+        `docker run -d swarm join --addr=<node_ip:2375> token://<cluster_id>`
+        ```
 
-    For example:
+        For example:
 
-    ```bash
-    $ docker run -d swarm join --addr=172.31.40.100:2375 token://6856663cdefdec325839a4b7e1de38e8
-    ```
+        ```bash
+        $ docker run -d swarm join --addr=172.31.40.100:2375 token://6856663cdefdec325839a4b7e1de38e8
+        ```
 
 3. Start the Swarm manager on any machine or your laptop. The following command
 illustrates how to do this:
 
     ```bash
-    $ docker run -d -p <swarm_port>:2375 swarm manage token://<cluster_id>
+    `docker run -d -p <swarm_port>:2375 swarm manage token://<cluster_id>`
     ```
 
 4. Once the manager is running, check your configuration by running `docker info` as follows:
 
     ```
-    $ docker -H tcp://<manager_ip:manager_port> info
+    `docker -H tcp://<manager_ip:manager_port> info`
     ```
     
     For example, if you run the manager locally on your machine:
@@ -122,7 +122,7 @@ illustrates how to do this:
 
 You can now use the regular `docker` CLI to access your nodes:
 
-```
+```bash
 $ docker -H tcp://<swarm_ip:swarm_port> info
 $ docker -H tcp://<swarm_ip:swarm_port> run ...
 $ docker -H tcp://<swarm_ip:swarm_port> ps
@@ -134,8 +134,17 @@ $ docker -H tcp://<swarm_ip:swarm_port> logs ...
 You can get a list of all your running nodes using the `swarm list` command:
 
 ```
-$ docker run --rm swarm list token://<cluster_id>
+`docker run --rm swarm list token://<cluster_id>`
 <node_ip:2375>
+```
+
+For example:
+
+```bash
+$ docker run --rm swarm list token://6856663cdefdec325839a4b7e1de38e8
+172.31.40.100:2375
+172.31.40.101:2375
+172.31.40.102:2375
 ```
 
 ## TLS

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,15 +63,11 @@ The following example uses the Docker Hub based `token` discovery service:
 
     1. Start the docker daemon with the `-H` flag. This ensures that the docker remote API on *Swarm Agents* is available over TCP for the *Swarm Manager*.
 
-        ```bash
-        $ docker -H tcp://0.0.0.0:2375 -d
-        ```
+    		$ docker -H tcp://0.0.0.0:2375 -d
 
     2. Register the Swarm agents to the discovery service. The node's IP must be accessible from the Swarm Manager. Use the following command and replace with the proper `node_ip` and `cluster_id` to start an agent:
 
-        ```bash
-        `docker run -d swarm join --addr=<node_ip:2375> token://<cluster_id>`
-        ```
+        	docker run -d swarm join --addr=<node_ip:2375> token://<cluster_id>
 
         For example:
 
@@ -82,15 +78,11 @@ The following example uses the Docker Hub based `token` discovery service:
 3. Start the Swarm manager on any machine or your laptop. The following command
 illustrates how to do this:
 
-    ```bash
-    `docker run -d -p <swarm_port>:2375 swarm manage token://<cluster_id>`
-    ```
+    	docker run -d -p <swarm_port>:2375 swarm manage token://<cluster_id>
 
 4. Once the manager is running, check your configuration by running `docker info` as follows:
 
-    ```
-    `docker -H tcp://<manager_ip:manager_port> info`
-    ```
+    	docker -H tcp://<manager_ip:manager_port> info
     
     For example, if you run the manager locally on your machine:
 
@@ -114,19 +106,17 @@ illustrates how to do this:
     
     If you are running a test cluster without TLS enabled, you may get an error. In that case, be sure to unset `DOCKER_TLS_VERIFY` with:
     
-    ```bash
-    $ unset DOCKER_TLS_VERIFY
-    ```
+    	$ unset DOCKER_TLS_VERIFY
 
 ## Using the docker CLI
 
 You can now use the regular `docker` CLI to access your nodes:
 
-```bash
-$ docker -H tcp://<swarm_ip:swarm_port> info
-$ docker -H tcp://<swarm_ip:swarm_port> run ...
-$ docker -H tcp://<swarm_ip:swarm_port> ps
-$ docker -H tcp://<swarm_ip:swarm_port> logs ...
+```
+docker -H tcp://<manager_ip:manager_port> info
+docker -H tcp://<manager_ip:manager_port> run ...
+docker -H tcp://<manager_ip:manager_port> ps
+docker -H tcp://<manager_ip:manager_port> logs ...
 ```
 
 ## List nodes in your cluster


### PR DESCRIPTION
Moving the Note at the bottom of the Nodes Configuration part for better visibility. Saw a lot of confusion on IRC and a few Issues on the setup part (and the fact that you need to launch the docker daemon listening on TCP).

ping @SvenDowideit 