### PR TITLE
Closes #501: Error if unknown args are used in create

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,9 @@ func main() {
 				discovery := &token.TokenDiscoveryService{}
 				discovery.Initialize("", 0)
 				token, err := discovery.CreateCluster()
+				if len(c.Args()) != 0 {
+					log.Fatalf("the `create` command takes no arguments. See '%s create --help'.", c.App.Name)
+				}
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/test/integration/main.bats
+++ b/test/integration/main.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "test that create doesn't accept any arugments" {
+        run swarm create derpderpderp
+	[ "$status" -ne 0 ]
+}
+


### PR DESCRIPTION
This implements the suggested method to check for additional arguments passed to the `create` command.