### PR TITLE
Cleanup: make SWARM_ROOT configurable

### DIFF
--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Root directory of the repository.
-SWARM_ROOT=${BATS_TEST_DIRNAME}/../..
+SWARM_ROOT=${SWARM_ROOT:-${BATS_TEST_DIRNAME}/../..}
 
 # Docker image and version to use for integration tests.
 DOCKER_IMAGE=${DOCKER_IMAGE:-aluzzardi/docker}
@@ -33,7 +33,7 @@ function wait_until_reachable() {
 		echo "Attempt to connect to ${HOSTS[$i]} failed for the $((++attempts)) time" >&2
 		sleep 0.5
 	done
-	[[ $attempts -lt $max_attempts ]] 
+	[[ $attempts -lt $max_attempts ]]
 }
 
 # Start the swarm manager in background.


### PR DESCRIPTION
This PR makes SWARM_ROOT configurable. So we can do:
```
SWARM_ROOT=$GOBIN bats test/integration
```
It allows me to work on integration tests easier :-)

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>