### PR TITLE
Fixing the Readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You may need to set `$GOPATH`, e.g `mkdir ~/gocode; export GOPATH=~/gocode`.
 Then install the `swarm` binary:
 
 ```bash
+cd $GOPATH/src/github.com/docker/
 git clone https://github.com/docker/swarm
 cd swarm
 godep go install .


### PR DESCRIPTION
Before cloning swarm, one needs to go into the right directory (e.g.
~/gocode/src/github.com/docker) else godeps will start complaining.

Fixes #520

Signed-off-by: Pratap Chand <pchand@amplify.com>