### PR TITLE
Make Swarm CpuShares compatible with Docker API

### DIFF
--- a/api/events_test.go
+++ b/api/events_test.go
@@ -28,7 +28,7 @@ func (fn *FakeNode) Image(_ string) *cluster.Image         { return nil }
 func (fn *FakeNode) Containers() []*cluster.Container      { return nil }
 func (fn *FakeNode) Container(_ string) *cluster.Container { return nil }
 func (fn *FakeNode) TotalCpus() int64                      { return 0 }
-func (fn *FakeNode) UsedCpus() int64                       { return 0 }
+func (fn *FakeNode) UsedCpus() float64                     { return 0 }
 func (fn *FakeNode) TotalMemory() int64                    { return 0 }
 func (fn *FakeNode) UsedMemory() int64                     { return 0 }
 func (fn *FakeNode) Labels() map[string]string             { return nil }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -15,7 +15,7 @@ type Node interface {
 	Container(IdOrName string) *Container //used by the filters
 
 	TotalCpus() int64   //used by the strategy
-	UsedCpus() int64    //used by the strategy
+	UsedCpus() float64  //used by the strategy
 	TotalMemory() int64 //used by the strategy
 	UsedMemory() int64  //used by the strategy
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -288,7 +288,7 @@ func (c *Cluster) Info() [][2]string {
 	for _, node := range c.nodes {
 		info = append(info, [2]string{node.Name(), node.Addr()})
 		info = append(info, [2]string{" └ Containers", fmt.Sprintf("%d", len(node.Containers()))})
-		info = append(info, [2]string{" └ Reserved CPUs", fmt.Sprintf("%f / %d", node.UsedCpus(), node.TotalCpus())})
+		info = append(info, [2]string{" └ Reserved CPUs", fmt.Sprintf("%.3f / %d", node.UsedCpus(), node.TotalCpus())})
 		info = append(info, [2]string{" └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(node.UsedMemory())), units.BytesSize(float64(node.TotalMemory())))})
 	}
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -288,7 +288,7 @@ func (c *Cluster) Info() [][2]string {
 	for _, node := range c.nodes {
 		info = append(info, [2]string{node.Name(), node.Addr()})
 		info = append(info, [2]string{" └ Containers", fmt.Sprintf("%d", len(node.Containers()))})
-		info = append(info, [2]string{" └ Reserved CPUs", fmt.Sprintf("%d / %d", node.UsedCpus(), node.TotalCpus())})
+		info = append(info, [2]string{" └ Reserved CPUs", fmt.Sprintf("%f / %d", node.UsedCpus(), node.TotalCpus())})
 		info = append(info, [2]string{" └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(node.UsedMemory())), units.BytesSize(float64(node.TotalMemory())))})
 	}
 

--- a/cluster/swarm/node.go
+++ b/cluster/swarm/node.go
@@ -263,8 +263,6 @@ func (n *node) updateContainer(c dockerclient.Container, containers map[string]*
 			return nil, err
 		}
 		container.Info = *info
-		// real CpuShares -> nb of CPUs
-		container.Info.Config.CpuShares = container.Info.Config.CpuShares
 	}
 
 	return containers, nil

--- a/cluster/swarm/node.go
+++ b/cluster/swarm/node.go
@@ -264,7 +264,7 @@ func (n *node) updateContainer(c dockerclient.Container, containers map[string]*
 		}
 		container.Info = *info
 		// real CpuShares -> nb of CPUs
-		container.Info.Config.CpuShares = container.Info.Config.CpuShares / 100.0 * n.Cpus
+		container.Info.Config.CpuShares = container.Info.Config.CpuShares
 	}
 
 	return containers, nil
@@ -337,14 +337,14 @@ func (n *node) UsedMemory() int64 {
 }
 
 // Return the sum of CPUs reserved by containers.
-func (n *node) UsedCpus() int64 {
+func (n *node) UsedCpus() float64 {
 	var r int64 = 0
 	n.RLock()
 	for _, c := range n.containers {
 		r += c.Info.Config.CpuShares
 	}
 	n.RUnlock()
-	return r
+	return float64(r*n.Cpus) / 1024
 }
 
 func (n *node) TotalMemory() int64 {
@@ -352,7 +352,7 @@ func (n *node) TotalMemory() int64 {
 }
 
 func (n *node) TotalCpus() int64 {
-	return n.Cpus + (n.Cpus * n.overcommitRatio / 100)
+	return n.Cpus
 }
 
 func (n *node) create(config *dockerclient.ContainerConfig, name string, pullImage bool) (*cluster.Container, error) {
@@ -365,7 +365,7 @@ func (n *node) create(config *dockerclient.ContainerConfig, name string, pullIma
 	newConfig := *config
 
 	// nb of CPUs -> real CpuShares
-	newConfig.CpuShares = config.CpuShares * 100 / n.Cpus
+	newConfig.CpuShares = config.CpuShares
 
 	if id, err = client.CreateContainer(&newConfig, name); err != nil {
 		// If the error is other than not found, abort immediately.

--- a/cluster/swarm/node_test.go
+++ b/cluster/swarm/node_test.go
@@ -187,7 +187,7 @@ func TestCreateContainer(t *testing.T) {
 	assert.True(t, node.isConnected())
 
 	mockConfig := *config
-	mockConfig.CpuShares = config.CpuShares * mockInfo.NCPU
+	mockConfig.CpuShares = config.CpuShares
 
 	// Everything is ok
 	name := "test1"
@@ -203,7 +203,7 @@ func TestCreateContainer(t *testing.T) {
 
 	// Image not found, pullImage == false
 	name = "test2"
-	mockConfig.CpuShares = config.CpuShares * mockInfo.NCPU
+	mockConfig.CpuShares = config.CpuShares
 	client.On("CreateContainer", &mockConfig, name).Return("", dockerclient.ErrNotFound).Once()
 	container, err = node.create(config, name, false)
 	assert.Equal(t, err, dockerclient.ErrNotFound)
@@ -212,7 +212,7 @@ func TestCreateContainer(t *testing.T) {
 	// Image not found, pullImage == true, and the image can be pulled successfully
 	name = "test3"
 	id = "id3"
-	mockConfig.CpuShares = config.CpuShares * mockInfo.NCPU
+	mockConfig.CpuShares = config.CpuShares
 	client.On("PullImage", config.Image+":latest", mock.Anything).Return(nil).Once()
 	client.On("CreateContainer", &mockConfig, name).Return("", dockerclient.ErrNotFound).Once()
 	client.On("CreateContainer", &mockConfig, name).Return(id, nil).Once()
@@ -238,7 +238,7 @@ func TestTotalMemory(t *testing.T) {
 func TestTotalCpus(t *testing.T) {
 	node := NewNode("test", 0.05)
 	node.Cpus = 2
-	assert.Equal(t, node.TotalCpus(), 2+2*5/100)
+	assert.Equal(t, node.TotalCpus(), 2)
 
 	node = NewNode("test", 0)
 	node.Cpus = 2

--- a/scheduler/filter/fakenode_test.go
+++ b/scheduler/filter/fakenode_test.go
@@ -34,7 +34,7 @@ func (fn *FakeNode) Container(id string) *cluster.Container {
 	return nil
 }
 func (fn *FakeNode) TotalCpus() int64          { return 0 }
-func (fn *FakeNode) UsedCpus() int64           { return 0 }
+func (fn *FakeNode) UsedCpus() float64         { return 0 }
 func (fn *FakeNode) TotalMemory() int64        { return 0 }
 func (fn *FakeNode) UsedMemory() int64         { return 0 }
 func (fn *FakeNode) Labels() map[string]string { return fn.labels }

--- a/scheduler/strategy/binpack_test.go
+++ b/scheduler/strategy/binpack_test.go
@@ -95,15 +95,15 @@ func TestPlaceContainerCPU(t *testing.T) {
 		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 0, 2))
 	}
 
-	// add 1 container 1CPU
-	config := createConfig(0, 1)
+	// add 1 container 512 CPU SHARES
+	config := createConfig(0, 512)
 	node1, err := s.PlaceContainer(config, nodes)
 	assert.NoError(t, err)
 	assert.NoError(t, AddContainer(node1, createContainer("c1", config)))
 	assert.Equal(t, node1.UsedCpus(), 1)
 
-	// add another container 1CPU
-	config = createConfig(0, 1)
+	// add another container 512 CPU SHARES
+	config = createConfig(0, 512)
 	node2, err := s.PlaceContainer(config, nodes)
 	assert.NoError(t, err)
 	assert.NoError(t, AddContainer(node2, createContainer("c2", config)))
@@ -122,15 +122,15 @@ func TestPlaceContainerHuge(t *testing.T) {
 		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 1, 1))
 	}
 
-	// add 100 container 1CPU
+	// add 100 container 1024 CPU SHARES
 	for i := 0; i < 100; i++ {
-		node, err := s.PlaceContainer(createConfig(0, 1), nodes)
+		node, err := s.PlaceContainer(createConfig(0, 1024), nodes)
 		assert.NoError(t, err)
-		assert.NoError(t, AddContainer(node, createContainer(fmt.Sprintf("c%d", i), createConfig(0, 1))))
+		assert.NoError(t, AddContainer(node, createContainer(fmt.Sprintf("c%d", i), createConfig(0, 1024))))
 	}
 
-	// try to add another container 1CPU
-	_, err := s.PlaceContainer(createConfig(0, 1), nodes)
+	// try to add another container 1024 CPU SHARES
+	_, err := s.PlaceContainer(createConfig(0, 1024), nodes)
 	assert.Error(t, err)
 
 	// add 100 container 1G

--- a/scheduler/strategy/fakenode_test.go
+++ b/scheduler/strategy/fakenode_test.go
@@ -13,7 +13,7 @@ type FakeNode struct {
 	memory     int64
 	usedmemory int64
 	cpus       int64
-	usedcpus   int64
+	usedcpus   float64
 	containers []*cluster.Container
 }
 
@@ -26,7 +26,7 @@ func (fn *FakeNode) Image(_ string) *cluster.Image         { return nil }
 func (fn *FakeNode) Containers() []*cluster.Container      { return fn.containers }
 func (fn *FakeNode) Container(_ string) *cluster.Container { return nil }
 func (fn *FakeNode) TotalCpus() int64                      { return fn.cpus }
-func (fn *FakeNode) UsedCpus() int64                       { return fn.usedcpus }
+func (fn *FakeNode) UsedCpus() float64                     { return fn.usedcpus }
 func (fn *FakeNode) TotalMemory() int64                    { return fn.memory }
 func (fn *FakeNode) UsedMemory() int64                     { return fn.usedmemory }
 func (fn *FakeNode) Labels() map[string]string             { return nil }
@@ -34,8 +34,8 @@ func (fn *FakeNode) IsHealthy() bool                       { return true }
 
 func (fn *FakeNode) AddContainer(container *cluster.Container) error {
 	memory := container.Info.Config.Memory
-	cpus := container.Info.Config.CpuShares
-	if fn.memory-memory < 0 || fn.cpus-cpus < 0 {
+	cpus := float64(container.Info.Config.CpuShares*fn.cpus) / 1024
+	if fn.memory-memory < 0 || float64(fn.cpus)-cpus < 0 {
 		return errors.New("not enough resources")
 	}
 	fn.usedmemory = fn.usedmemory + memory

--- a/scheduler/strategy/spread_test.go
+++ b/scheduler/strategy/spread_test.go
@@ -75,15 +75,15 @@ func TestSpreadPlaceContainerCPU(t *testing.T) {
 		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 0, 2))
 	}
 
-	// add 1 container 1CPU
-	config := createConfig(0, 1)
+	// add 1 container 512 CPU SHARES
+	config := createConfig(0, 512)
 	node1, err := s.PlaceContainer(config, nodes)
 	assert.NoError(t, err)
 	assert.NoError(t, AddContainer(node1, createContainer("c1", config)))
 	assert.Equal(t, node1.UsedCpus(), 1)
 
-	// add another container 1CPU
-	config = createConfig(0, 1)
+	// add another container 512 CPU SHARES
+	config = createConfig(0, 512)
 	node2, err := s.PlaceContainer(config, nodes)
 	assert.NoError(t, err)
 	assert.NoError(t, AddContainer(node2, createContainer("c2", config)))
@@ -102,15 +102,15 @@ func TestSpreadPlaceContainerHuge(t *testing.T) {
 		nodes = append(nodes, createNode(fmt.Sprintf("node-%d", i), 1, 1))
 	}
 
-	// add 100 container 1CPU
+	// add 100 container 1024 CPU SHARES
 	for i := 0; i < 100; i++ {
-		node, err := s.PlaceContainer(createConfig(0, 1), nodes)
+		node, err := s.PlaceContainer(createConfig(0, 1024), nodes)
 		assert.NoError(t, err)
-		assert.NoError(t, AddContainer(node, createContainer(fmt.Sprintf("c%d", i), createConfig(0, 1))))
+		assert.NoError(t, AddContainer(node, createContainer(fmt.Sprintf("c%d", i), createConfig(0, 1024))))
 	}
 
-	// try to add another container 1CPU
-	_, err := s.PlaceContainer(createConfig(0, 1), nodes)
+	// try to add another container some cpushare
+	_, err := s.PlaceContainer(createConfig(0, 5), nodes)
 	assert.Error(t, err)
 
 	// add 100 container 1G

--- a/scheduler/strategy/weighted_node.go
+++ b/scheduler/strategy/weighted_node.go
@@ -10,7 +10,7 @@ import (
 type weightedNode struct {
 	Node cluster.Node
 	// Weight is the inherent value of this node.
-	Weight int64
+	Weight float64
 }
 
 type weightedNodeList []*weightedNode
@@ -45,19 +45,19 @@ func weighNodes(config *dockerclient.ContainerConfig, nodes []cluster.Node) (wei
 		}
 
 		var (
-			cpuScore    int64 = 100
-			memoryScore int64 = 100
+			cpuScore    float64 = 100
+			memoryScore int64   = 100
 		)
 
 		if config.CpuShares > 0 {
-			cpuScore = (node.UsedCpus() + config.CpuShares) * 100 / nodeCpus
+			cpuScore = (node.UsedCpus() + float64(config.CpuShares*nodeCpus/1024)) * 100 / float64(nodeCpus)
 		}
 		if config.Memory > 0 {
 			memoryScore = (node.UsedMemory() + config.Memory) * 100 / nodeMemory
 		}
 
 		if cpuScore <= 100 && memoryScore <= 100 {
-			weightedNodes = append(weightedNodes, &weightedNode{Node: node, Weight: cpuScore + memoryScore})
+			weightedNodes = append(weightedNodes, &weightedNode{Node: node, Weight: cpuScore + float64(memoryScore)})
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/docker/swarm/issues/475 
Memory is a very large value and applying overcommit ratio increases the total memory significantly  but the increase in total cpus after applying overcommit ratio is negligible. Hence I removed the overcommit ratio for Cpus
```
$ docker -H 172.17.8.101:2395 run --name some1-mysql -e MYSQL_ROOT_PASSWORD=mysecretpassword -c 512 -d mysql
e147f9aa38a35e3ba789e0f3171d50af206eb5aca906a56bc102ec238d4f8bf9
```
To show used Cpus in docker info , the cpu shares are normalized to total number of Cpus .

```
$docker -H 172.17.8.101:2395 info
Containers: 5
Nodes: 2
 deis-02: 172.17.8.101:2375
  └ Containers: 3
  └ Reserved CPUs: 0.500 / 1
  └ Reserved Memory: 0 B / 2.057 GiB
 deis-01: 172.17.8.100:2375
  └ Containers: 2
  └ Reserved CPUs: 1.000 / 1
  └ Reserved Memory: 0 B / 2.057 GiB
```

 