### PR TITLE
Fix 404 Error in Filter and Strategy README files

### DIFF
--- a/scheduler/filter/README.md
+++ b/scheduler/filter/README.md
@@ -291,7 +291,7 @@ This filter will prevent scheduling containers on unhealthy nodes.
 
 ## Docker Swarm documentation index
 
-- [User guide](./../index.md)
-- [Discovery options](./../discovery.md)
-- [Sheduler strategies](./strategy.md)
-- [Swarm API](./../API.md)
+- [User guide](https://docs.docker.com/swarm/)
+- [Discovery options](https://docs.docker.com/swarm/discovery/)
+- [Sheduler strategies](https://docs.docker.com/swarm/scheduler/strategy/)
+- [Swarm API](https://docs.docker.com/swarm/API/)

--- a/scheduler/strategy/README.md
+++ b/scheduler/strategy/README.md
@@ -57,8 +57,7 @@ The Random strategy, as it's name says, chooses a random node, it's used mainly 
 
 ## Docker Swarm documentation index
 
-
-- [User guide](./../index.md)
-- [Discovery options](./../discovery.md)
-- [Scheduler filters](./filter.md)
-- [Swarm API](./../API.md)
+- [User guide](https://docs.docker.com/swarm/)
+- [Discovery options](https://docs.docker.com/swarm/discovery/)
+- [Scheduler filters](https://docs.docker.com/swarm/scheduler/filter/)
+- [Swarm API](https://docs.docker.com/swarm/API/)


### PR DESCRIPTION
Update README files under filter and scheduler with correct documentation links