### PR TITLE
Validate value by checking for whitespace in constraint expression

### DIFF
--- a/scheduler/filter/expr.go
+++ b/scheduler/filter/expr.go
@@ -52,7 +52,7 @@ func parseExprs(key string, env []string) ([]expr, error) {
 						// allow leading = in case of using ==
 						// allow * for globbing
 						// allow regexp
-						matched, err := regexp.MatchString(`^(?i)[=!\/]?(~)?[a-z0-9:\-_\.\*/\(\)\?\+\[\]\\\^\$]+$`, parts[1])
+						matched, err := regexp.MatchString(`^(?i)[=!\/]?(~)?[a-z0-9:\-_\s\.\*/\(\)\?\+\[\]\\\^\$]+$`, parts[1])
 						if err != nil {
 							return nil, err
 						}

--- a/scheduler/filter/expr_test.go
+++ b/scheduler/filter/expr_test.go
@@ -34,6 +34,10 @@ func TestParseExprs(t *testing.T) {
 	// Allow regexp in value
 	_, err = parseExprs("constraint", []string{"constraint:node==/(?i)^[a-b]+c*$/"})
 	assert.NoError(t, err)
+
+	// Allow space in value
+	_, err = parseExprs("constraint", []string{"constraint:node==node 1"})
+	assert.NoError(t, err)
 }
 
 func TestMatch(t *testing.T) {


### PR DESCRIPTION
When using operatingsystem standard constraint, it fails when we use the value shown in docker info. For example, if I try to create the following for ubuntu OS, 
docker run -d -e constraint:operatingsystem=="Ubuntu 14.04.1 LTS" --name snort glanf/snort 
swarm returns
FATA[0000] Error response from daemon: Value 'Ubuntu 14.04.1 LTS' is invalid

however, if I use 
docker run -d -e constraint:operatingsystem=="Ubuntu*" --name snort glanf/snort 
it identifies the host and creates the container.

This is because while checking for the expression in expr.go, the matchstring does not check for whitespaces. This PR fixes this issue.