### PR TITLE
Make container creation and destruction synchronous.

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"sync"
+
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/filter"
 	"github.com/docker/swarm/scheduler/strategy"
@@ -9,6 +11,8 @@ import (
 
 // Scheduler is exported
 type Scheduler struct {
+	sync.Mutex
+
 	strategy strategy.PlacementStrategy
 	filters  []filter.Filter
 }


### PR DESCRIPTION
This is in order to fix race conditions. Currently, container creation
can happen in parallel which means that the scheduler operates on stale
data.

Fixes #427

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>