### PR TITLE
Fixed url of Docker Hub discovery service

### DIFF
--- a/discovery/token/README.md
+++ b/discovery/token/README.md
@@ -1,4 +1,4 @@
-#discovery.hub.docker.com
+#discovery-stage.hub.docker.com
 
 Docker Swarm comes with a simple discovery service built into the [Docker Hub](http://hub.docker.com)
 


### PR DESCRIPTION
In the readme, we need to s/discovery.hub.docker.com/discovery-stage.hub.docker.com/

PR #549 from yesterday fixes this issue, but he forgot to replace one occurrence of discovery.hub.docker.com.  This commit fixes that last occurrence.

Signed-off-by: Mike Goelzer <mike@goelzer.com>