### PR TITLE
Make TTL > heartbeat interval so that keys do not disappear

### DIFF
--- a/discovery/etcd/etcd.go
+++ b/discovery/etcd/etcd.go
@@ -40,7 +40,8 @@ func (s *EtcdDiscoveryService) Initialize(uris string, heartbeat int) error {
 	}
 
 	s.client = etcd.NewClient(entries)
-	s.ttl = uint64(heartbeat * 3 / 2)
+	// ttl should always be > heartbeat, even if heartbeat = 1 or 0
+	s.ttl = uint64(heartbeat*3/2) + 1
 	s.path = "/" + parts[1] + "/"
 	if _, err := s.client.CreateDir(s.path, s.ttl); err != nil {
 		if etcdError, ok := err.(*etcd.EtcdError); ok {


### PR DESCRIPTION
Fixes issue #564 by ensuring that TTL is always greater than heartbeat, even for short heartbeat intervals

The race condition described in #564 is won't have any real world effect as long as etcd is only being used for discovery, since the brief disappearance of a key doesn't harm an already discovered node.  However, I don't see any harm in applying this fix.

Signed-off-by: Mike Goelzer <mike@goelzer.com>