### PR TITLE
Cleanup: regression for 0.2.0

### DIFF
--- a/test/integration/api.bats
+++ b/test/integration/api.bats
@@ -12,7 +12,7 @@ function teardown() {
 	start_manager
 	run docker_swarm info
 	[ "$status" -eq 0 ]
-	[[ "${lines[1]}" == *"Nodes: 3" ]]
+	[[ "${lines[3]}" == *"Nodes: 3" ]]
 }
 
 @test "docker ps -n 3 should return the 3 last containers, including non running one" {


### PR DESCRIPTION
An integration test failed because `docker info` via `swarm` displays extra information before printing `Nodes: \d+`. This PR fixed it.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

cc @aluzzardi 