### PR TITLE
Proposal : Optimize locking for create container request

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"container/list"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -30,6 +31,7 @@ func NewEngine(addr string, overcommitRatio float64) *Engine {
 		containers:      make(map[string]*Container),
 		healthy:         true,
 		overcommitRatio: int64(overcommitRatio * 100),
+		ScheduleQueue:   list.New(),
 	}
 	return e
 }
@@ -53,6 +55,14 @@ type Engine struct {
 	eventHandler    EventHandler
 	healthy         bool
 	overcommitRatio int64
+	ScheduleQueue   *list.List
+}
+
+//ScheduledItem FIX ME : works for affinities as it needs the conatainer name and Image
+//Need to add more types to support all filters
+type ScheduledItem struct {
+	Image     string
+	Container string
 }
 
 // Connect will initialize a connection to the Docker daemon running on the
@@ -347,6 +357,23 @@ func (e *Engine) TotalCpus() int64 {
 	return e.Cpus + (e.Cpus * e.overcommitRatio / 100)
 }
 
+//AddtoQueue adds a scheduled item to scheduled queue
+func (e *Engine) AddtoQueue(config *dockerclient.ContainerConfig, name string) {
+	item := &ScheduledItem{
+		Image:     config.Image,
+		Container: name,
+	}
+	e.ScheduleQueue.PushFront(*item)
+}
+
+func (e *Engine) removeFromQueue(config *dockerclient.ContainerConfig, name string) {
+	for i := e.ScheduleQueue.Back(); i != nil; i = i.Prev() {
+		if i.Value.(ScheduledItem).Container == name && i.Value.(ScheduledItem).Image == config.Image {
+			e.ScheduleQueue.Remove(i)
+		}
+	}
+}
+
 // Create a new container
 func (e *Engine) Create(config *dockerclient.ContainerConfig, name string, pullImage bool) (*Container, error) {
 	var (
@@ -356,7 +383,7 @@ func (e *Engine) Create(config *dockerclient.ContainerConfig, name string, pullI
 	)
 
 	newConfig := *config
-
+	defer e.removeFromQueue(config, name)
 	// nb of CPUs -> real CpuShares
 	newConfig.CpuShares = config.CpuShares * 1024 / e.Cpus
 
@@ -378,7 +405,6 @@ func (e *Engine) Create(config *dockerclient.ContainerConfig, name string, pullI
 	// Register the container immediately while waiting for a state refresh.
 	// Force a state refresh to pick up the newly created container.
 	e.refreshContainer(id, true)
-
 	e.RLock()
 	defer e.RUnlock()
 

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -36,6 +36,9 @@ func (f *AffinityFilter) Filter(config *dockerclient.ContainerConfig, nodes []*n
 				for _, container := range node.Containers {
 					containers = append(containers, container.Id, strings.TrimPrefix(container.Names[0], "/"))
 				}
+				for _, container := range node.ScheduledList("container") {
+					containers = append(containers, container)
+				}
 				if affinity.Match(containers...) {
 					candidates = append(candidates, node)
 				}
@@ -47,6 +50,9 @@ func (f *AffinityFilter) Filter(config *dockerclient.ContainerConfig, nodes []*n
 					for _, tag := range image.RepoTags {
 						images = append(images, strings.Split(tag, ":")[0])
 					}
+				}
+				for _, image := range node.ScheduledList("images") {
+					images = append(images, image)
 				}
 				if affinity.Match(images...) {
 					candidates = append(candidates, node)


### PR DESCRIPTION
Signed-off-by: sivaram mothiki <sivaram@opdemand.com>
fixes https://github.com/docker/swarm/issues/555
As discussed in https://github.com/docker/swarm/pull/545 node selection for scheduling a container is the only operation that has to be atomic in the create container call. We have optimized this by 
1. Defined Scheduled item struct which takes image and container names can be implemented to add more items in the struct w.r.t other filters.
2. Before node.create call add the image and container to the scheduled queue
3. Once the create call is successful remove the scheduled item i,e container along with the image from the queue.
Tested for filter ``affinity:container!=~pulsar-quacking*`` by creating pulsar-quacking_v2.web.4 , pulsar-quacking_v2.web.2 , pulsar-quacking_v2.web.3 containers simultaneously whose images are not present on any host  
Sample Logs 
```
Apr 03 01:10:54 deis-04 sh[17973]: time="2015-04-03T01:10:54Z" level=info msg="HTTP request received" method=POST uri="/v1.17/containers/create?name=pulsar-quacking_v2.web.4"
Apr 03 01:10:54 deis-04 sh[17973]: time="2015-04-03T01:10:54Z" level=info msg="affinity container:" id=0 name=affinity
Apr 03 01:10:54 deis-04 sh[17973]: time="2015-04-03T01:10:54Z" level=info msg="affinity container:pulsar-quacking_v2.web.2" id=1 name=affinity
Apr 03 01:10:54 deis-04 sh[17973]: time="2015-04-03T01:10:54Z" level=info msg="affinity container:" id=0 name=affinity
Apr 03 01:10:54 deis-04 sh[17973]: time="2015-04-03T01:10:54Z" level=info msg="affinity container:pulsar-quacking_v2.web.3" id=1 name=affinity
Apr 03 01:10:54 deis-04 sh[17973]: time="2015-04-03T01:10:54Z" level=info msg="addtoqueue image:172.17.8.103:5000/pulsar-quacking:v2 container:pulsar-quacking_v2.web.4" id="3NQ5:GL5P:WGZV:Z5ZN:ZENF:BSQH:4VFJ:SFIL:MKDO:CRGK:2OUC:JHFY" name=deis-02
``` 
To avoid race condition for pulsar-quacking_v2.web.4 while selecting a node , while applying filters it checks that pulsar-quacking_v2.web.2 , pulsar-quacking_v2.web.3 are already present in the queue. 
```
$docker ps 
2017b63bd0d3        172.17.8.103:5000/pulsar-quacking:v2              "/runner/init start    7 seconds ago       Up 6 seconds            172.17.8.102:49153->5000/tcp                                                      deis-03/pulsar-quacking_v2.web.2   
71e0243d2805        172.17.8.103:5000/pulsar-quacking:v2              "/runner/init start    9 seconds ago       Up Less than a second   172.17.8.100:49153->5000/tcp                                                      deis-01/pulsar-quacking_v2.web.3   
b27cb3ac0ee0        172.17.8.103:5000/pulsar-quacking:v2              "/runner/init start    10 seconds ago      Up 6 seconds            172.17.8.101:49153->5000/tcp                                                      deis-02/pulsar-quacking_v2.web.4   
6bcbf8cfab1f        172.17.8.103:5000/pulsar-quacking:v2              "/runner/init start    2 minutes ago       Up 2 minutes            172.17.8.103:49153->5000/tcp                                                      deis-04/pulsar-quacking_v2.web.1  
```

This is a proposal and it works for affinities and PR is open for discussions and Design suggestions. 