### PR TITLE
fix #589 - allow pipe in constraint regexp

### DIFF
--- a/scheduler/filter/expr.go
+++ b/scheduler/filter/expr.go
@@ -52,7 +52,7 @@ func parseExprs(key string, env []string) ([]expr, error) {
 						// allow leading = in case of using ==
 						// allow * for globbing
 						// allow regexp
-						matched, err := regexp.MatchString(`^(?i)[=!\/]?(~)?[a-z0-9:\-_\s\.\*/\(\)\?\+\[\]\\\^\$]+$`, parts[1])
+						matched, err := regexp.MatchString(`^(?i)[=!\/]?(~)?[a-z0-9:\-_\s\.\*/\(\)\?\+\[\]\\\^\$\|]+$`, parts[1])
 						if err != nil {
 							return nil, err
 						}

--- a/scheduler/filter/expr_test.go
+++ b/scheduler/filter/expr_test.go
@@ -32,7 +32,7 @@ func TestParseExprs(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Allow regexp in value
-	_, err = parseExprs("constraint", []string{"constraint:node==/(?i)^[a-b]+c*$/"})
+	_, err = parseExprs("constraint", []string{"constraint:node==/(?i)^[a-b]+c*(n|b)$/"})
 	assert.NoError(t, err)
 
 	// Allow space in value


### PR DESCRIPTION
This PR fixes missing pipe ( | ) for the `or` operation in constraint expressions, reported in #589.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>