### PR TITLE
Improve Error message in cluster to show node's Name and IP

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -130,7 +130,7 @@ func (c *Cluster) newEntries(entries []*discovery.Entry) {
 					if old.IP != engine.IP {
 						log.Errorf("ID duplicated. %s shared by %s and %s", engine.ID, old.IP, engine.IP)
 					} else {
-						log.Errorf("node %q is already registered", engine.ID)
+						log.Errorf("node %q with IP %q is  already registered", engine.Name, engine.IP)
 					}
 					return
 				}


### PR DESCRIPTION
While running my swarm cluster, I noticed an error message which provided node's engine ID for registered nodes as below:

swarm manage -H tcp://192.168.111.77:3000 zk://192.168.111.77/clusterz &
[1] 1880
root@manager:/home/ubuntu# INFO[0000] Listening for HTTP                            addr=192.168.111.77:3000 proto=tcp
ERRO[0000] node "5G4B:IJUU:Z4TG:MWTC:JMZS:OKNB:JNTQ:CGH2:7TIB:RPP4:YS3I:T47H" is already registered
ERRO[0000] node "3SP7:YPBQ:IPFG:CSFL:LWQ7:H3VJ:U2IB:RPXR:EFWR:5NG7:S2SN:DPRP" is already registered
ERRO[0000] node "T6LP:AC7K:Z3GC:MWTE:FBDT:CXI4:OR5O:7IXR:H2MC:EMFI:WPVC:FY6P" is already registered

This was difficult to debug which nodes were already registered. In this PR, I updated the error message to print the node name and node IP so that we get:

swarm manage -H tcp://192.168.111.77:3000 zk://192.168.111.77/clusterz
INFO[0000] Listening for HTTP                            addr=192.168.111.77:3000 proto=tcp
ERRO[0000] node "host1" with IP "192.168.111.78" is already registered
ERRO[0000] node "host2" with IP "192.168.111.79" is already registered
ERRO[0000] node "host3" with IP "192.168.111.80" is already registered

Hope this helps.

Thanks,
Sriram