### PR TITLE
Remove prefixes from DiscoveryService implementations

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -11,8 +11,8 @@ import (
 	consul "github.com/hashicorp/consul/api"
 )
 
-// ConsulDiscoveryService is exported
-type ConsulDiscoveryService struct {
+// DiscoveryService is exported
+type DiscoveryService struct {
 	heartbeat time.Duration
 	client    *consul.Client
 	prefix    string
@@ -20,11 +20,11 @@ type ConsulDiscoveryService struct {
 }
 
 func init() {
-	discovery.Register("consul", &ConsulDiscoveryService{})
+	discovery.Register("consul", &DiscoveryService{})
 }
 
 // Initialize is exported
-func (s *ConsulDiscoveryService) Initialize(uris string, heartbeat uint64) error {
+func (s *DiscoveryService) Initialize(uris string, heartbeat uint64) error {
 	parts := strings.SplitN(uris, "/", 2)
 	if len(parts) < 2 {
 		return fmt.Errorf("invalid format %q, missing <path>", uris)
@@ -56,7 +56,7 @@ func (s *ConsulDiscoveryService) Initialize(uris string, heartbeat uint64) error
 }
 
 // Fetch is exported
-func (s *ConsulDiscoveryService) Fetch() ([]*discovery.Entry, error) {
+func (s *DiscoveryService) Fetch() ([]*discovery.Entry, error) {
 	kv := s.client.KV()
 	pairs, _, err := kv.List(s.prefix, nil)
 	if err != nil {
@@ -75,7 +75,7 @@ func (s *ConsulDiscoveryService) Fetch() ([]*discovery.Entry, error) {
 }
 
 // Watch is exported
-func (s *ConsulDiscoveryService) Watch(callback discovery.WatchCallback) {
+func (s *DiscoveryService) Watch(callback discovery.WatchCallback) {
 	for _ = range s.waitForChange() {
 		log.WithField("name", "consul").Debug("Discovery watch triggered")
 		entries, err := s.Fetch()
@@ -86,14 +86,14 @@ func (s *ConsulDiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 // Register is exported
-func (s *ConsulDiscoveryService) Register(addr string) error {
+func (s *DiscoveryService) Register(addr string) error {
 	kv := s.client.KV()
 	p := &consul.KVPair{Key: path.Join(s.prefix, addr), Value: []byte(addr)}
 	_, err := kv.Put(p, nil)
 	return err
 }
 
-func (s *ConsulDiscoveryService) waitForChange() <-chan uint64 {
+func (s *DiscoveryService) waitForChange() <-chan uint64 {
 	c := make(chan uint64)
 	go func() {
 		for {

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
-	discovery := &ConsulDiscoveryService{}
+	discovery := &DiscoveryService{}
 
 	assert.Equal(t, discovery.Initialize("127.0.0.1", 0).Error(), "invalid format \"127.0.0.1\", missing <path>")
 

--- a/discovery/etcd/etcd.go
+++ b/discovery/etcd/etcd.go
@@ -10,19 +10,19 @@ import (
 	"github.com/docker/swarm/discovery"
 )
 
-// EtcdDiscoveryService is exported
-type EtcdDiscoveryService struct {
+// DiscoveryService is exported
+type DiscoveryService struct {
 	ttl    uint64
 	client *etcd.Client
 	path   string
 }
 
 func init() {
-	discovery.Register("etcd", &EtcdDiscoveryService{})
+	discovery.Register("etcd", &DiscoveryService{})
 }
 
 // Initialize is exported
-func (s *EtcdDiscoveryService) Initialize(uris string, heartbeat uint64) error {
+func (s *DiscoveryService) Initialize(uris string, heartbeat uint64) error {
 	var (
 		// split here because uris can contain multiples ips
 		// like `etcd://192.168.0.1,192.168.0.2,192.168.0.3/path`
@@ -56,7 +56,7 @@ func (s *EtcdDiscoveryService) Initialize(uris string, heartbeat uint64) error {
 }
 
 // Fetch is exported
-func (s *EtcdDiscoveryService) Fetch() ([]*discovery.Entry, error) {
+func (s *DiscoveryService) Fetch() ([]*discovery.Entry, error) {
 	resp, err := s.client.Get(s.path, true, true)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (s *EtcdDiscoveryService) Fetch() ([]*discovery.Entry, error) {
 }
 
 // Watch is exported
-func (s *EtcdDiscoveryService) Watch(callback discovery.WatchCallback) {
+func (s *DiscoveryService) Watch(callback discovery.WatchCallback) {
 	watchChan := make(chan *etcd.Response)
 	go s.client.Watch(s.path, 0, true, watchChan, nil)
 	for _ = range watchChan {
@@ -83,7 +83,7 @@ func (s *EtcdDiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 // Register is exported
-func (s *EtcdDiscoveryService) Register(addr string) error {
+func (s *DiscoveryService) Register(addr string) error {
 	_, err := s.client.Set(path.Join(s.path, addr), addr, s.ttl)
 	return err
 }

--- a/discovery/etcd/etcd_test.go
+++ b/discovery/etcd/etcd_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
-	discovery := &EtcdDiscoveryService{}
+	discovery := &DiscoveryService{}
 
 	assert.Equal(t, discovery.Initialize("127.0.0.1", 0).Error(), "invalid format \"127.0.0.1\", missing <path>")
 

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -8,18 +8,18 @@ import (
 	"github.com/docker/swarm/discovery"
 )
 
-// FileDiscoveryService is exported
-type FileDiscoveryService struct {
+// DiscoveryService is exported
+type DiscoveryService struct {
 	heartbeat uint64
 	path      string
 }
 
 func init() {
-	discovery.Register("file", &FileDiscoveryService{})
+	discovery.Register("file", &DiscoveryService{})
 }
 
 // Initialize is exported
-func (s *FileDiscoveryService) Initialize(path string, heartbeat uint64) error {
+func (s *DiscoveryService) Initialize(path string, heartbeat uint64) error {
 	s.path = path
 	s.heartbeat = heartbeat
 	return nil
@@ -47,7 +47,7 @@ func parseFileContent(content []byte) []string {
 }
 
 // Fetch is exported
-func (s *FileDiscoveryService) Fetch() ([]*discovery.Entry, error) {
+func (s *DiscoveryService) Fetch() ([]*discovery.Entry, error) {
 	fileContent, err := ioutil.ReadFile(s.path)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (s *FileDiscoveryService) Fetch() ([]*discovery.Entry, error) {
 }
 
 // Watch is exported
-func (s *FileDiscoveryService) Watch(callback discovery.WatchCallback) {
+func (s *DiscoveryService) Watch(callback discovery.WatchCallback) {
 	for _ = range time.Tick(time.Duration(s.heartbeat) * time.Second) {
 		entries, err := s.Fetch()
 		if err == nil {
@@ -66,6 +66,6 @@ func (s *FileDiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 // Register is exported
-func (s *FileDiscoveryService) Register(addr string) error {
+func (s *DiscoveryService) Register(addr string) error {
 	return discovery.ErrNotImplemented
 }

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
-	discovery := &FileDiscoveryService{}
+	discovery := &DiscoveryService{}
 	discovery.Initialize("/path/to/file", 0)
 	assert.Equal(t, discovery.path, "/path/to/file")
 }
@@ -26,7 +26,7 @@ func TestContent(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	discovery := &FileDiscoveryService{path: "/path/to/file"}
+	discovery := &DiscoveryService{path: "/path/to/file"}
 	assert.Error(t, discovery.Register("0.0.0.0"))
 }
 

--- a/discovery/nodes/nodes.go
+++ b/discovery/nodes/nodes.go
@@ -6,17 +6,17 @@ import (
 	"github.com/docker/swarm/discovery"
 )
 
-// NodesDiscoveryService is exported
-type NodesDiscoveryService struct {
+// DiscoveryService is exported
+type DiscoveryService struct {
 	entries []*discovery.Entry
 }
 
 func init() {
-	discovery.Register("nodes", &NodesDiscoveryService{})
+	discovery.Register("nodes", &DiscoveryService{})
 }
 
 // Initialize is exported
-func (s *NodesDiscoveryService) Initialize(uris string, _ uint64) error {
+func (s *DiscoveryService) Initialize(uris string, _ uint64) error {
 	for _, input := range strings.Split(uris, ",") {
 		for _, ip := range discovery.Generate(input) {
 			entry, err := discovery.NewEntry(ip)
@@ -31,15 +31,15 @@ func (s *NodesDiscoveryService) Initialize(uris string, _ uint64) error {
 }
 
 // Fetch is exported
-func (s *NodesDiscoveryService) Fetch() ([]*discovery.Entry, error) {
+func (s *DiscoveryService) Fetch() ([]*discovery.Entry, error) {
 	return s.entries, nil
 }
 
 // Watch is exported
-func (s *NodesDiscoveryService) Watch(callback discovery.WatchCallback) {
+func (s *DiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 // Register is exported
-func (s *NodesDiscoveryService) Register(addr string) error {
+func (s *DiscoveryService) Register(addr string) error {
 	return discovery.ErrNotImplemented
 }

--- a/discovery/nodes/nodes_test.go
+++ b/discovery/nodes/nodes_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInitialise(t *testing.T) {
-	discovery := &NodesDiscoveryService{}
+	discovery := &DiscoveryService{}
 	discovery.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0)
 	assert.Equal(t, len(discovery.entries), 2)
 	assert.Equal(t, discovery.entries[0].String(), "1.1.1.1:1111")
@@ -15,7 +15,7 @@ func TestInitialise(t *testing.T) {
 }
 
 func TestInitialiseWithPattern(t *testing.T) {
-	discovery := &NodesDiscoveryService{}
+	discovery := &DiscoveryService{}
 	discovery.Initialize("1.1.1.[1:2]:1111,2.2.2.[2:4]:2222", 0)
 	assert.Equal(t, len(discovery.entries), 5)
 	assert.Equal(t, discovery.entries[0].String(), "1.1.1.1:1111")
@@ -26,6 +26,6 @@ func TestInitialiseWithPattern(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	discovery := &NodesDiscoveryService{}
+	discovery := &DiscoveryService{}
 	assert.Error(t, discovery.Register("0.0.0.0"))
 }

--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -15,19 +15,19 @@ import (
 // DiscoveryUrl is exported
 const DiscoveryURL = "https://discovery-stage.hub.docker.com/v1"
 
-// TokenDiscoveryService is exported
-type TokenDiscoveryService struct {
+// DiscoveryService is exported
+type DiscoveryService struct {
 	heartbeat uint64
 	url       string
 	token     string
 }
 
 func init() {
-	discovery.Register("token", &TokenDiscoveryService{})
+	discovery.Register("token", &DiscoveryService{})
 }
 
 // Initialize is exported
-func (s *TokenDiscoveryService) Initialize(urltoken string, heartbeat uint64) error {
+func (s *DiscoveryService) Initialize(urltoken string, heartbeat uint64) error {
 	if i := strings.LastIndex(urltoken, "/"); i != -1 {
 		s.url = "https://" + urltoken[:i]
 		s.token = urltoken[i+1:]
@@ -45,7 +45,7 @@ func (s *TokenDiscoveryService) Initialize(urltoken string, heartbeat uint64) er
 }
 
 // Fetch returns the list of entries for the discovery service at the specified endpoint
-func (s *TokenDiscoveryService) Fetch() ([]*discovery.Entry, error) {
+func (s *DiscoveryService) Fetch() ([]*discovery.Entry, error) {
 
 	resp, err := http.Get(fmt.Sprintf("%s/%s/%s", s.url, "clusters", s.token))
 	if err != nil {
@@ -67,7 +67,7 @@ func (s *TokenDiscoveryService) Fetch() ([]*discovery.Entry, error) {
 }
 
 // Watch is exported
-func (s *TokenDiscoveryService) Watch(callback discovery.WatchCallback) {
+func (s *DiscoveryService) Watch(callback discovery.WatchCallback) {
 	for _ = range time.Tick(time.Duration(s.heartbeat) * time.Second) {
 		entries, err := s.Fetch()
 		if err == nil {
@@ -77,7 +77,7 @@ func (s *TokenDiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 // Register adds a new entry identified by the into the discovery service
-func (s *TokenDiscoveryService) Register(addr string) error {
+func (s *DiscoveryService) Register(addr string) error {
 	buf := strings.NewReader(addr)
 
 	resp, err := http.Post(fmt.Sprintf("%s/%s/%s", s.url,
@@ -92,7 +92,7 @@ func (s *TokenDiscoveryService) Register(addr string) error {
 }
 
 // CreateCluster returns a unique cluster token
-func (s *TokenDiscoveryService) CreateCluster() (string, error) {
+func (s *DiscoveryService) CreateCluster() (string, error) {
 	resp, err := http.Post(fmt.Sprintf("%s/%s", s.url, "clusters"), "", nil)
 	if err != nil {
 		return "", err

--- a/discovery/token/token_test.go
+++ b/discovery/token/token_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
-	discovery := &TokenDiscoveryService{}
+	discovery := &DiscoveryService{}
 	err := discovery.Initialize("token", 0)
 	assert.NoError(t, err)
 	assert.Equal(t, discovery.token, "token")
@@ -23,7 +23,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	discovery := &TokenDiscoveryService{token: "TEST_TOKEN", url: DiscoveryURL}
+	discovery := &DiscoveryService{token: "TEST_TOKEN", url: DiscoveryURL}
 	expected := "127.0.0.1:2675"
 	assert.NoError(t, discovery.Register(expected))
 

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -11,22 +11,22 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 )
 
-// ZkDiscoveryService is exported
-type ZkDiscoveryService struct {
+// DiscoveryService is exported
+type DiscoveryService struct {
 	conn      *zk.Conn
 	path      []string
 	heartbeat uint64
 }
 
 func init() {
-	discovery.Register("zk", &ZkDiscoveryService{})
+	discovery.Register("zk", &DiscoveryService{})
 }
 
-func (s *ZkDiscoveryService) fullpath() string {
+func (s *DiscoveryService) fullpath() string {
 	return "/" + strings.Join(s.path, "/")
 }
 
-func (s *ZkDiscoveryService) createFullpath() error {
+func (s *DiscoveryService) createFullpath() error {
 	for i := 1; i <= len(s.path); i++ {
 		newpath := "/" + strings.Join(s.path[:i], "/")
 		_, err := s.conn.Create(newpath, []byte{1}, 0, zk.WorldACL(zk.PermAll))
@@ -41,7 +41,7 @@ func (s *ZkDiscoveryService) createFullpath() error {
 }
 
 // Initialize is exported
-func (s *ZkDiscoveryService) Initialize(uris string, heartbeat uint64) error {
+func (s *DiscoveryService) Initialize(uris string, heartbeat uint64) error {
 	var (
 		// split here because uris can contain multiples ips
 		// like `zk://192.168.0.1,192.168.0.2,192.168.0.3/path`
@@ -75,7 +75,7 @@ func (s *ZkDiscoveryService) Initialize(uris string, heartbeat uint64) error {
 }
 
 // Fetch is exported
-func (s *ZkDiscoveryService) Fetch() ([]*discovery.Entry, error) {
+func (s *DiscoveryService) Fetch() ([]*discovery.Entry, error) {
 	addrs, _, err := s.conn.Children(s.fullpath())
 
 	if err != nil {
@@ -86,7 +86,7 @@ func (s *ZkDiscoveryService) Fetch() ([]*discovery.Entry, error) {
 }
 
 // Watch is exported
-func (s *ZkDiscoveryService) Watch(callback discovery.WatchCallback) {
+func (s *DiscoveryService) Watch(callback discovery.WatchCallback) {
 
 	addrs, _, eventChan, err := s.conn.ChildrenW(s.fullpath())
 	if err != nil {
@@ -112,7 +112,7 @@ func (s *ZkDiscoveryService) Watch(callback discovery.WatchCallback) {
 }
 
 // Register is exported
-func (s *ZkDiscoveryService) Register(addr string) error {
+func (s *DiscoveryService) Register(addr string) error {
 	nodePath := path.Join(s.fullpath(), addr)
 
 	// check existing for the parent path first

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
-	service := &ZkDiscoveryService{}
+	service := &DiscoveryService{}
 
 	assert.Equal(t, service.Initialize("127.0.0.1", 0).Error(), "invalid format \"127.0.0.1\", missing <path>")
 

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 			ShortName: "c",
 			Usage:     "create a cluster",
 			Action: func(c *cli.Context) {
-				discovery := &token.TokenDiscoveryService{}
+				discovery := &token.DiscoveryService{}
 				discovery.Initialize("", 0)
 				token, err := discovery.CreateCluster()
 				if len(c.Args()) != 0 {


### PR DESCRIPTION
All of these structs are public. Previously when they were used, they'd
look like the following:

 - `consul.ConsulDiscoveryService`
 - `etcd.EtcdDiscoveryService`
 - `file.FileDiscoveryService`
 - `nodes.NodesDiscoveryService`
 - `token.TokenDiscoveryService`
 - `zookeeper.ZkDiscoveryService`

As a result, they stuttered when read. This commit removes the
duplication of the package names on the struct so that they read better.

See also: https://golang.org/ref/spec#Import_declarations

Signed-off-by: Kushal Pisavadia <kushi.p@gmail.com>