### PR TITLE
Change to make Travis CI run correctly on forks of docker/swarm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ go:
 sudo: false
 
 install:
+  # Symlink below is needed for Travis CI to work correctly on personal forks of swarm
+  - ln -s $HOME/gopath/src/github.com/${TRAVIS_REPO_SLUG///swarm/} $HOME/gopath/src/github.com/docker
   - export GOPATH=${TRAVIS_BUILD_DIR}/Godeps/_workspace:$GOPATH
   - export PATH=${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH
   - go get code.google.com/p/go.tools/cmd/vet


### PR DESCRIPTION
This change to .travis.yml allows Travis to run correctly on anybody's personal fork of Swarm if he has turned on the Travis CI hook for his fork.

Why is this needed?  Our Go imports hardcode "github.com/docker/swarm/whatever-package," but a fork will have a different directory structure such as src/github.com/username/swarm/.  Because of this, Travis can not find imports because the directory github.com/docker will not exist inside the Travis container.  For an example of exactly how this causes Travis to fail on personal forks, look at https://travis-ci.org/mgoelzer/swarm/builds/58082730

Signed-off-by: Mike Goelzer <mike@goelzer.com>