### PR TITLE
Add attach-ws api integration test

### DIFF
--- a/test/integration/api.bats
+++ b/test/integration/api.bats
@@ -12,6 +12,26 @@ function teardown() {
 	skip
 }
 
+@test "docker attach through websocket" {
+	CLIENT_API_VERSION="v1.17"
+	start_docker 2
+	swarm_manage
+
+	#create a container
+        run docker_swarm run -d --name test_container busybox sleep 1000
+
+	# test attach-ws api
+	# jimmyxian/centos7-wssh is an image with websocket CLI(WSSH) wirtten in Nodejs
+	# if connected successfull, it returns two lines, "Session Open" and "Session Closed"
+	# Note: with stdout=1&stdin=1&stream=1: it can be used as SSH
+	URL="ws://${SWARM_HOST}/${CLIENT_API_VERSION}/containers/test_container/attach/ws?stderr=1"
+	run docker run --rm --net=host jimmyxian/centos7-wssh wssh $URL
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 2 ]
+	[[ "${lines[0]}" == *"Session Open"* ]]
+	[[ "${lines[1]}" == *"Session Closed"* ]]
+}
+
 @test "docker build" {
       start_docker 3
       swarm_manage


### PR DESCRIPTION
https://github.com/docker/swarm/pull/586 Add test for attach-ws api
I build a docker image with websocket CLI(WSSH) wirtten in Nodejs to test attatch-ws api. if connected successfull, it returns two lines.
```
Session Open
Session Closed
```
ping @aluzzardi @vieux @abronan 
Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>