### PR TITLE
Simplify code using gofmt's simplify command

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -76,7 +76,7 @@ func (s *Discovery) Fetch() ([]*discovery.Entry, error) {
 
 // Watch is exported
 func (s *Discovery) Watch(callback discovery.WatchCallback) {
-	for _ = range s.waitForChange() {
+	for range s.waitForChange() {
 		log.WithField("name", "consul").Debug("Discovery watch triggered")
 		entries, err := s.Fetch()
 		if err == nil {

--- a/discovery/etcd/etcd.go
+++ b/discovery/etcd/etcd.go
@@ -73,7 +73,7 @@ func (s *Discovery) Fetch() ([]*discovery.Entry, error) {
 func (s *Discovery) Watch(callback discovery.WatchCallback) {
 	watchChan := make(chan *etcd.Response)
 	go s.client.Watch(s.path, 0, true, watchChan, nil)
-	for _ = range watchChan {
+	for range watchChan {
 		log.WithField("name", "etcd").Debug("Discovery watch triggered")
 		entries, err := s.Fetch()
 		if err == nil {

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -57,7 +57,7 @@ func (s *Discovery) Fetch() ([]*discovery.Entry, error) {
 
 // Watch is exported
 func (s *Discovery) Watch(callback discovery.WatchCallback) {
-	for _ = range time.Tick(time.Duration(s.heartbeat) * time.Second) {
+	for range time.Tick(time.Duration(s.heartbeat) * time.Second) {
 		entries, err := s.Fetch()
 		if err == nil {
 			callback(entries)

--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -68,7 +68,7 @@ func (s *Discovery) Fetch() ([]*discovery.Entry, error) {
 
 // Watch is exported
 func (s *Discovery) Watch(callback discovery.WatchCallback) {
-	for _ = range time.Tick(time.Duration(s.heartbeat) * time.Second) {
+	for range time.Tick(time.Duration(s.heartbeat) * time.Second) {
 		entries, err := s.Fetch()
 		if err == nil {
 			callback(entries)


### PR DESCRIPTION
This code was passed through `gofmt -s`, which simplifies code. The tool
removed the blank identifiers from these `for range` blocks.

More information: https://golang.org/cmd/gofmt/#hdr-The_simplify_command

Signed-off-by: Kushal Pisavadia <kushi.p@gmail.com>