### PR TITLE
Add Node Labels to Info 

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -310,6 +311,12 @@ func (c *Cluster) Info() [][2]string {
 		info = append(info, [2]string{" └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
 		info = append(info, [2]string{" └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})
 		info = append(info, [2]string{" └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(engine.UsedMemory())), units.BytesSize(float64(engine.TotalMemory())))})
+		labels := make([]string, 0, len(engine.Labels))
+		for k, v := range engine.Labels {
+			labels = append(labels, k+"="+v)
+		}
+		sort.Strings(labels)
+		info = append(info, [2]string{" └ Labels", fmt.Sprintf("%s", strings.Join(labels, ", "))})
 	}
 
 	return info

--- a/test/integration/api.bats
+++ b/test/integration/api.bats
@@ -114,11 +114,12 @@ function teardown() {
 }
 
 @test "docker info" {
-	start_docker 3
+	start_docker 1 --label foo=bar
 	swarm_manage
 	run docker_swarm info
 	[ "$status" -eq 0 ]
-	[[ "${lines[3]}" == *"Nodes: 3" ]]
+	[[ "${lines[3]}" == *"Nodes: 1" ]]
+	[[ "${output}" == *"└ Labels:"*"foo=bar"* ]]
 }
 
 # FIXME


### PR DESCRIPTION
This pull request addresses https://github.com/docker/swarm/issues/625

The goal is to include the label values in the "/info" API. This is helpful for an external application which interacts with swarm via REST APIs to get the constraint values from each host and to schedule the containers based on labels.

Just to highlight: This update however changes the "docker info" output to show as following:

Containers: 16
Strategy: spread
Filters: affinity, health, constraint, port, dependency
Nodes: 3
 host1: 192.168.111.78:2375
  └ Containers: 5
  └ Reserved CPUs: 0 / 1
  └ Reserved Memory: 0 B / 2.053 GiB
  └ Labels: storagedriver=aufs, executiondriver=native-0.2, kernelversion=3.13.0-39-generic, operatingsystem=Ubuntu 14.04.1 LTS, service=security
 host2: 192.168.111.79:2375
  └ Containers: 5
  └ Reserved CPUs: 0 / 1
  └ Reserved Memory: 0 B / 2.053 GiB
  └ Labels: storagedriver=aufs, executiondriver=native-0.2, kernelversion=3.13.0-39-generic, operatingsystem=Ubuntu 14.04.1 LTS, service=perf
 host3: 192.168.111.80:2375
  └ Containers: 6
  └ Reserved CPUs: 0 / 1
  └ Reserved Memory: 0 B / 2.053 GiB
  └ Labels: storagedriver=aufs, executiondriver=native-0.2, kernelversion=3.13.0-39-generic, operatingsystem=Ubuntu 14.04.1 LTS, service=monitor