### PR TITLE
Cleanup: Move CLI related files to a subpackage.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/docker/swarm/discovery"
+	"github.com/docker/swarm/discovery/token"
+	"github.com/docker/swarm/version"
+)
+
+// Run the Swarm CLI.
+func Run() {
+	app := cli.NewApp()
+	app.Name = path.Base(os.Args[0])
+	app.Usage = "a Docker-native clustering system"
+	app.Version = version.VERSION + " (" + version.GITCOMMIT + ")"
+
+	app.Author = ""
+	app.Email = ""
+
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:   "debug",
+			Usage:  "debug mode",
+			EnvVar: "DEBUG",
+		},
+
+		cli.StringFlag{
+			Name:  "log-level, l",
+			Value: "info",
+			Usage: fmt.Sprintf("Log level (options: debug, info, warn, error, fatal, panic)"),
+		},
+	}
+
+	// logs
+	app.Before = func(c *cli.Context) error {
+		log.SetOutput(os.Stderr)
+		level, err := log.ParseLevel(c.String("log-level"))
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+		log.SetLevel(level)
+
+		// If a log level wasn't specified and we are running in debug mode,
+		// enforce log-level=debug.
+		if !c.IsSet("log-level") && !c.IsSet("l") && c.Bool("debug") {
+			log.SetLevel(log.DebugLevel)
+		}
+
+		return nil
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:      "create",
+			ShortName: "c",
+			Usage:     "create a cluster",
+			Action: func(c *cli.Context) {
+				discovery := &token.Discovery{}
+				discovery.Initialize("", 0)
+				token, err := discovery.CreateCluster()
+				if len(c.Args()) != 0 {
+					log.Fatalf("the `create` command takes no arguments. See '%s create --help'.", c.App.Name)
+				}
+				if err != nil {
+					log.Fatal(err)
+				}
+				fmt.Println(token)
+			},
+		},
+		{
+			Name:      "list",
+			ShortName: "l",
+			Usage:     "list nodes in a cluster",
+			Action: func(c *cli.Context) {
+				dflag := getDiscovery(c)
+				if dflag == "" {
+					log.Fatalf("discovery required to list a cluster. See '%s list --help'.", c.App.Name)
+				}
+
+				d, err := discovery.New(dflag, 0)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				nodes, err := d.Fetch()
+				if err != nil {
+					log.Fatal(err)
+				}
+				for _, node := range nodes {
+					fmt.Println(node)
+				}
+			},
+		},
+		{
+			Name:      "manage",
+			ShortName: "m",
+			Usage:     "manage a docker cluster",
+			Flags: []cli.Flag{
+				flStore,
+				flStrategy, flFilter,
+				flHosts, flHeartBeat, flOverCommit,
+				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
+				flEnableCors},
+			Action: manage,
+		},
+		{
+			Name:      "join",
+			ShortName: "j",
+			Usage:     "join a docker cluster",
+			Flags:     []cli.Flag{flAddr, flHeartBeat},
+			Action:    join,
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"os"

--- a/cli/help.go
+++ b/cli/help.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"os"

--- a/cli/join.go
+++ b/cli/join.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"regexp"

--- a/cli/join_test.go
+++ b/cli/join_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"testing"

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"crypto/tls"

--- a/main.go
+++ b/main.go
@@ -1,127 +1,16 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"path"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/codegangsta/cli"
-	"github.com/docker/swarm/discovery"
 	_ "github.com/docker/swarm/discovery/consul"
 	_ "github.com/docker/swarm/discovery/etcd"
 	_ "github.com/docker/swarm/discovery/file"
 	_ "github.com/docker/swarm/discovery/nodes"
-	"github.com/docker/swarm/discovery/token"
+	_ "github.com/docker/swarm/discovery/token"
 	_ "github.com/docker/swarm/discovery/zookeeper"
-	"github.com/docker/swarm/version"
+
+	"github.com/docker/swarm/cli"
 )
 
 func main() {
-	app := cli.NewApp()
-	app.Name = path.Base(os.Args[0])
-	app.Usage = "a Docker-native clustering system"
-	app.Version = version.VERSION + " (" + version.GITCOMMIT + ")"
-
-	app.Author = ""
-	app.Email = ""
-
-	app.Flags = []cli.Flag{
-		cli.BoolFlag{
-			Name:   "debug",
-			Usage:  "debug mode",
-			EnvVar: "DEBUG",
-		},
-
-		cli.StringFlag{
-			Name:  "log-level, l",
-			Value: "info",
-			Usage: fmt.Sprintf("Log level (options: debug, info, warn, error, fatal, panic)"),
-		},
-	}
-
-	// logs
-	app.Before = func(c *cli.Context) error {
-		log.SetOutput(os.Stderr)
-		level, err := log.ParseLevel(c.String("log-level"))
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-		log.SetLevel(level)
-
-		// If a log level wasn't specified and we are running in debug mode,
-		// enforce log-level=debug.
-		if !c.IsSet("log-level") && !c.IsSet("l") && c.Bool("debug") {
-			log.SetLevel(log.DebugLevel)
-		}
-
-		return nil
-	}
-
-	app.Commands = []cli.Command{
-		{
-			Name:      "create",
-			ShortName: "c",
-			Usage:     "create a cluster",
-			Action: func(c *cli.Context) {
-				discovery := &token.Discovery{}
-				discovery.Initialize("", 0)
-				token, err := discovery.CreateCluster()
-				if len(c.Args()) != 0 {
-					log.Fatalf("the `create` command takes no arguments. See '%s create --help'.", c.App.Name)
-				}
-				if err != nil {
-					log.Fatal(err)
-				}
-				fmt.Println(token)
-			},
-		},
-		{
-			Name:      "list",
-			ShortName: "l",
-			Usage:     "list nodes in a cluster",
-			Action: func(c *cli.Context) {
-				dflag := getDiscovery(c)
-				if dflag == "" {
-					log.Fatalf("discovery required to list a cluster. See '%s list --help'.", c.App.Name)
-				}
-
-				d, err := discovery.New(dflag, 0)
-				if err != nil {
-					log.Fatal(err)
-				}
-
-				nodes, err := d.Fetch()
-				if err != nil {
-					log.Fatal(err)
-				}
-				for _, node := range nodes {
-					fmt.Println(node)
-				}
-			},
-		},
-		{
-			Name:      "manage",
-			ShortName: "m",
-			Usage:     "manage a docker cluster",
-			Flags: []cli.Flag{
-				flStore,
-				flStrategy, flFilter,
-				flHosts, flHeartBeat, flOverCommit,
-				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
-				flEnableCors},
-			Action: manage,
-		},
-		{
-			Name:      "join",
-			ShortName: "j",
-			Usage:     "join a docker cluster",
-			Flags:     []cli.Flag{flAddr, flHeartBeat},
-			Action:    join,
-		},
-	}
-
-	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
-	}
+	cli.Run()
 }

--- a/script/coverage
+++ b/script/coverage
@@ -4,8 +4,8 @@ MODE="mode: count"
 ROOT=${TRAVIS_BUILD_DIR:-.}/../../..
 
 # Grab the list of packages.
-# Exclude the API from coverage as it will be covered by integration tests.
-PACKAGES=`go list ./... | grep -v github.com/docker/swarm/api`
+# Exclude the API and CLI from coverage as it will be covered by integration tests.
+PACKAGES=`go list ./... | grep -v github.com/docker/swarm/api | grep -v github.com/docker/swarm/cli`
 
 # Create the empty coverage file.
 echo $MODE > goverage.report

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -21,12 +21,6 @@ Start by [installing]
 (https://github.com/sstephenson/bats#installing-bats-from-source) *bats* on
 your system.
 
-The tests expect the *swarm* binary to be built and located at the root
-directory of the repo:
-```
-$ godep go build
-```
-
 In order to run all integration tests, pass *bats* the test path:
 ```
 $ bats test/integration

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -22,7 +22,7 @@ function join() {
 
 # Run the swarm binary.
 function swarm() {
-	${SWARM_ROOT}/swarm "$@"
+	godep go run "${SWARM_ROOT}/main.go" "$@"
 }
 
 # Waits until the given docker engine API becomes reachable.


### PR DESCRIPTION
Bonus points: `godep go run main.go` works.

Integration tests could actually use `go run` instead of assuming the swarm binary was already compiled.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>