### PR TITLE
add dockerfile and scripts to make buildable and testable on jenkins

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,58 @@
+# Dockerfile for testing swarm
+# How to use:
+#   docker build --rm --force-rm -f Dockerfile.test -t swarm-test .
+#   docker run --rm -it --privileged swarm-test script/testall
+FROM debian:jessie
+
+# compile and runtime deps
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#build-dependencies
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        e2fsprogs \
+        gcc \
+        git \
+        iptables \
+        libsqlite3-dev \
+        make \
+        mercurial \
+        procps \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# install golang
+ENV GO_VERSION 1.4.2
+RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
+    && mkdir -p /go/bin
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
+RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
+
+# install bats
+RUN cd /usr/local/src/ \
+    && git clone https://github.com/sstephenson/bats.git \
+    && cd bats \
+    && ./install.sh /usr/local
+
+# install go tools
+RUN go get golang.org/x/tools/cmd/vet
+RUN go get golang.org/x/tools/cmd/cover
+RUN go get github.com/mattn/goveralls
+RUN go get github.com/golang/lint/golint
+RUN go get github.com/GeertJohan/fgt
+
+ENV DOCKER_VERSION 1.6.0
+RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} > /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+COPY . /go/src/github.com/docker/swarm
+WORKDIR /go/src/github.com/docker/swarm
+
+ENV GOPATH /go/src/github.com/docker/swarm/Godeps/_workspace:$GOPATH
+RUN CGO_ENABLED=0 go install -v -a -tags netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD`"
+
+ENV SWARM_HOST :2375
+EXPOSE 2375
+
+ENTRYPOINT ["script/dind"]

--- a/script/.integration-daemon-start
+++ b/script/.integration-daemon-start
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if ! command -v docker &> /dev/null; then
+	echo >&2 'error: cannot find a docker binary in path'
+	false
+fi
+
+# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
+exec 41>&1 42>&2
+
+export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+export DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
+
+if [ -z "$DOCKER_TEST_HOST" ]; then
+	export DOCKER_HOST="unix://$(cd "$DEST" && pwd)/docker.sock" # "pwd" tricks to make sure $DEST is an absolute path, not a relative one
+	( set -x; exec \
+		docker --daemon --debug \
+		--host "$DOCKER_HOST" \
+		--storage-driver "$DOCKER_GRAPHDRIVER" \
+		--exec-driver "$DOCKER_EXECDRIVER" \
+		--pidfile "$DEST/docker.pid" \
+		&> "$DEST/docker.log"
+	) &
+else
+	export DOCKER_HOST="$DOCKER_TEST_HOST"
+fi
+
+# give it a second to come up so it's "ready"
+tries=10
+while ! docker version &> /dev/null; do
+	(( tries-- ))
+	if [ $tries -le 0 ]; then
+		if [ -z "$DOCKER_HOST" ]; then
+			echo >&2 "error: daemon failed to start"
+			echo >&2 "  check $DEST/docker.log for details"
+		else
+			echo >&2 "error: daemon at $DOCKER_HOST fails to 'docker version':"
+			docker version >&2 || true
+		fi
+		false
+	fi
+	sleep 2
+done

--- a/script/.integration-daemon-stop
+++ b/script/.integration-daemon-stop
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for pidFile in $(find "$DEST" -name docker.pid); do
+	pid=$(set -x; cat "$pidFile")
+	( set -x; kill $pid )
+	if ! wait $pid; then
+		echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
+	fi
+done

--- a/script/dind
+++ b/script/dind
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+# DinD: a wrapper script which allows docker to be run inside a docker container.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+# See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+#
+# This script should be executed inside a docker container in privilieged mode
+# ('docker run --privileged', introduced in docker 0.6).
+
+# Usage: dind CMD [ARG...]
+
+# apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+export container=docker
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/cgroup
+
+mkdir -p "$CGROUP"
+
+if ! mountpoint -q "$CGROUP"; then
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo >&2 'Could not make a tmpfs mount. Did you use --privileged?'
+		exit 1
+	}
+fi
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+	mount -t securityfs none /sys/kernel/security || {
+		echo >&2 'Could not mount /sys/kernel/security.'
+		echo >&2 'AppArmor detection and -privileged mode might break.'
+	}
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for HIER in $(cut -d: -f2 /proc/1/cgroup); do
+
+	# The following sections address a bug which manifests itself
+	# by a cryptic "lxc-start: no ns_cgroup option specified" when
+	# trying to start containers within a container.
+	# The bug seems to appear when the cgroup hierarchies are not
+	# mounted on the exact same directories in the host, and in the
+	# container.
+
+	SUBSYSTEMS="${HIER%name=*}"
+
+	# If cgroup hierarchy is named(mounted with "-o name=foo") we
+	# need to mount it in $CGROUP/foo to create exect same
+	# directoryes as on host. Else we need to mount it as is e.g.
+	# "subsys1,subsys2" if it has two subsystems
+
+	# Named, control-less cgroups are mounted with "-o name=foo"
+	# (and appear as such under /proc/<pid>/cgroup) but are usually
+	# mounted on a directory named "foo" (without the "name=" prefix).
+	# Systemd and OpenRC (and possibly others) both create such a
+	# cgroup. So just mount them on directory $CGROUP/foo.
+
+	OHIER=$HIER
+	HIER="${HIER#*name=}"
+
+	mkdir -p "$CGROUP/$HIER"
+
+	if ! mountpoint -q $CGROUP/$HIER; then
+		mount -n -t cgroup -o "$OHIER" cgroup "$CGROUP/$HIER"
+	fi
+
+	# Likewise, on at least one system, it has been reported that
+	# systemd would mount the CPU and CPU accounting controllers
+	# (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+	# but on a directory called "cpu,cpuacct" (note the inversion
+	# in the order of the groups). This tries to work around it.
+
+	if [ "$HIER" = 'cpuacct,cpu' ]; then
+		ln -s "$HIER" "$CGROUP/cpu,cpuacct"
+	fi
+
+	# If hierarchy has multiple subsystems, in /proc/<pid>/cgroup
+	# we will see ":subsys1,subsys2,subsys3,name=foo:" substring,
+	# we need to mount it to "$CGROUP/foo" and if there were no
+	# name to "$CGROUP/subsys1,subsys2,subsys3", so we must create
+	# symlinks for docker daemon to find these subsystems:
+	# ln -s $CGROUP/foo $CGROUP/subsys1
+	# ln -s $CGROUP/subsys1,subsys2,subsys3 $CGROUP/subsys1
+
+	if [ "$SUBSYSTEMS" != "${SUBSYSTEMS//,/ }" ]; then
+		SUBSYSTEMS="${SUBSYSTEMS//,/ }"
+		for SUBSYS in $SUBSYSTEMS
+		do
+			ln -s "$CGROUP/$HIER" "$CGROUP/$SUBSYS"
+		done
+	fi
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+if ! grep -q :devices: /proc/1/cgroup; then
+	echo >&2 'WARNING: the "devices" cgroup should be in its own hierarchy.'
+fi
+if ! grep -qw devices /proc/1/cgroup; then
+	echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
+fi
+
+# Mount /tmp
+mount -t tmpfs none /tmp
+
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi
+
+echo >&2 'ERROR: No command specified.'
+echo >&2 'You probably want to run hack/make.sh, or maybe a shell?'

--- a/script/integration-test
+++ b/script/integration-test
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+DEST=$1
+
+# subshell so that we can export PATH without breaking other things
+(
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start")
+	
+	# we need to wrap up everything in between integration-daemon-start and
+	# integration-daemon-stop to make sure we kill the daemon and don't hang,
+	# even and especially on test failures
+	didFail=
+	if ! {
+
+		# run bats tests
+		bats test/integration
+	}; then
+		didFail=1
+	fi
+
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-stop"
+
+	[ -z "$didFail" ] # "set -e" ftw
+) 2>&1 | tee -a $DEST/test.log

--- a/script/testall
+++ b/script/testall
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+CURDIR=$(dirname "$BASH_SOURCE")
+
+# validate dco
+${CURDIR}/validate-dco
+
+# validate gofmt
+${CURDIR}/validate-gofmt
+
+# run go vet/ golint
+go vet ./...
+fgt golint ./...
+
+# go test
+go test -v -race ./...
+
+# run bats tests
+mkdir -p ${CURDIR}/results
+${CURDIR}/integration-test ${CURDIR}/results
+
+# test coverage
+${CURDIR}/coverage
+# send to goveralls
+# goveralls -service=jenkins -coverprofile=goverage.report


### PR DESCRIPTION
This doesn't work yet but the goal would be to have it run the integration tests w docker in docker.

you can try with:
```
docker build --rm --force-rm -f Dockerfile.test -t swarmtest .
docker run --rm -it --privileged swarmtest script/testall
```

I think you all will know better how the bats test needs the daemon started so I am opening this now, so hopefully you all will be able to spot the fix easily :)