### PR TITLE
Fast exit from create on invalid command-line

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -60,12 +60,12 @@ func Run() {
 			ShortName: "c",
 			Usage:     "create a cluster",
 			Action: func(c *cli.Context) {
-				discovery := &token.Discovery{}
-				discovery.Initialize("", 0)
-				token, err := discovery.CreateCluster()
 				if len(c.Args()) != 0 {
 					log.Fatalf("the `create` command takes no arguments. See '%s create --help'.", c.App.Name)
 				}
+				discovery := &token.Discovery{}
+				discovery.Initialize("", 0)
+				token, err := discovery.CreateCluster()
 				if err != nil {
 					log.Fatal(err)
 				}


### PR DESCRIPTION
The `create` command now fails immediately when invoked with an invalid command-line rather than going as far as initializing discovery and creating a cluster.