### PR TITLE
strip quotes to allow chaining with docker-machine

### DIFF
--- a/cli/manage.go
+++ b/cli/manage.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path"
 	"strconv"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -78,9 +79,9 @@ func manage(c *cli.Context) {
 			log.Fatal("--tlscacert must be provided when using --tlsverify")
 		}
 		tlsConfig, err = loadTLSConfig(
-			c.String("tlscacert"),
-			c.String("tlscert"),
-			c.String("tlskey"),
+			strings.Trim(c.String("tlscacert"), `"`),
+			strings.Trim(c.String("tlscert"), `"`),
+			strings.Trim(c.String("tlskey"), `"`),
 			c.Bool("tlsverify"))
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
We have some scenario that uses `swarm manage $(machine config ...)` and machine returns quotes around TLS-related files. Docker cli consumes these strings normally, but Swarm does not. This is a trivial fix to remove quotes from the filenames to allow that. 

The problem occurs when chaining `machine config` to `swarm`, both on Windows/Cygwin and Linux.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>