### PR TITLE
integration tests: Support for running within Docker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ script:
   - script/validate-gofmt
   - go vet ./...
   - fgt golint ./...
-  # Lint our test files and make sure they are not space indented.
-  - fgt find test -type f -exec grep -Hn -e "^ " {} \;
+  # Lint shell files and make sure they are not space indented.
+  - fgt find test/ -type f \( -name "*.sh" -or -name "*.bash" -or -name "*.bats" \) -exec grep -Hn -e "^ " {} \;
   - go test -v -race ./...
   - script/coverage
   - goveralls -service=travis-ci -coverprofile=goverage.report

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,0 +1,33 @@
+# Dockerfile for swarm integration test environment.
+# Use with run_in_docker.sh
+
+FROM dockerswarm/dind:1.6.0
+
+# Install dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        file \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install golang
+ENV GO_VERSION 1.4.2
+RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
+    && mkdir -p /go/bin
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
+RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
+
+# Go dependencies
+RUN go get github.com/tools/godep
+
+# install bats
+RUN cd /usr/local/src/ \
+    && git clone https://github.com/sstephenson/bats.git \
+    && cd bats \
+    && ./install.sh /usr/local
+
+RUN mkdir -p /go/src/github.com/docker/swarm
+WORKDIR /go/src/github.com/docker/swarm/test/integration
+ENV GOPATH /go/src/github.com/docker/swarm/Godeps/_workspace:$GOPATH
+
+ENTRYPOINT ["/dind"]

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -17,14 +17,19 @@ Integration tests are written in *bash* using the
 
 ## Running integration tests
 
-Start by [installing]
-(https://github.com/sstephenson/bats#installing-bats-from-source) *bats* on
-your system.
+The easiest way to run integration tests is with Docker:
+```
+$ test/integration/run.sh
+```
 
-In order to run all integration tests, pass *bats* the test path:
+Alternatively, you can run integration tests directly on your host:
+
 ```
 $ bats test/integration
 ```
+
+In order to do that, you will need to setup a full development environmnet plus
+[bats](https://github.com/sstephenson/bats#installing-bats-from-source)
 
 > **Note**: There are known issues running the integration tests using 
 > **devicemapper** as a storage driver, make sure that your docker daemon 

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+# Root directory of Swarm.
+SWARM_ROOT=$(cd ../..; pwd -P)
+
+# Image containing the integration tests environment.
+INTEGRATION_IMAGE=${INTEGRATION_IMAGE:-dockerswarm/swarm-test-env}
+
+# Make sure we upgrade the integration environment.
+#docker pull $INTEGRATION_IMAGE
+
+# Start the integration tests in a Docker container.
+ID=$(docker run -d -t --privileged \
+	-v ${SWARM_ROOT}:/go/src/github.com/docker/swarm \
+	-e "DOCKER_IMAGE=$DOCKER_IMAGE" \
+	-e "DOCKER_VERSION=$DOCKER_VERSION" \
+	-e "STORAGE_DRIVER=$STORAGE_DRIVER" \
+	-e "EXEC_DRIVER=$EXEC_DRIVER" \
+	${INTEGRATION_IMAGE} \
+	./test_runner.sh "$@")
+
+# Clean it up when we exit.
+trap "docker rm -f -v $ID > /dev/null" EXIT
+
+docker logs -f $ID

--- a/test/integration/test_runner.sh
+++ b/test/integration/test_runner.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+# Load the helpers.
+. helpers.bash
+
+function execute() {
+	>&2 echo "++ $@"
+	eval "$@"
+}
+
+# Tests to run. Defaults to all.
+TESTS=${@:-.}
+
+# Start the docker engine.
+execute docker --daemon --log-level=panic \
+	--storage-driver="$STORAGE_DRIVER" --exec-driver="$EXEC_DRIVER" &
+DOCKER_PID=$!
+
+# Wait for it to become reachable.
+tries=10
+until docker version &> /dev/null; do
+	(( tries-- ))
+	if [ $tries -le 0 ]; then
+		echo >&2 "error: daemon failed to start"
+		exit 1
+	fi
+	sleep 1
+done
+
+# Pre-fetch the test image.
+execute time docker pull ${DOCKER_IMAGE}:${DOCKER_VERSION} > /dev/null
+
+# Run the tests.
+execute time bats -p $TESTS
+
+# Cleanup.
+execute kill $DOCKER_PID
+execute wait $DOCKER_PID
+execute ps faxw

--- a/test/integration/test_runner.sh
+++ b/test/integration/test_runner.sh
@@ -14,6 +14,12 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
+# Generate a temporary binary for the tests.
+export SWARM_BINARY=`mktemp`
+
+# Build Swarm.
+execute go build -o "$SWARM_BINARY" ../..
+
 # Start the docker engine.
 execute docker --daemon --log-level=panic \
 	--storage-driver="$STORAGE_DRIVER" --exec-driver="$EXEC_DRIVER" &


### PR DESCRIPTION
With this change, integration tests can run using Docker with zero dependencies:

```
$ git clone https://github.com/docker/swarm.git
$ swarm/test/integration/run.sh
```

The environment to run the tests (containing docker, go and bats) is pulled and the code+tests are injected through a volume.

The environment was built with `test/integration/Dockerfile`

By default `run.sh` will run all tests but you can specify which tests to run, for instance:
```
$ test/integration/run.sh constraints.bats affinities.bats
```