### PR TITLE
integration: Use the brand new dind image.

### DIFF
--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -7,8 +7,8 @@ SWARM_ROOT=${SWARM_ROOT:-${BATS_TEST_DIRNAME}/../..}
 SWARM_BINARY=`mktemp`
 
 # Docker image and version to use for integration tests.
-DOCKER_IMAGE=${DOCKER_IMAGE:-dockerswarm/docker}
-DOCKER_VERSION=${DOCKER_VERSION:-1.6}
+DOCKER_IMAGE=${DOCKER_IMAGE:-dockerswarm/dind}
+DOCKER_VERSION=${DOCKER_VERSION:-1.6.0}
 
 # Host on which the manager will listen to (random port between 6000 and 7000).
 SWARM_HOST=127.0.0.1:$(( ( RANDOM % 1000 )  + 6000 ))


### PR DESCRIPTION
We now have dockerswarm/dind built using https://github.com/aluzzardi/dind:
- Much more lightweight.
- Exists in every version since Docker 1.0.0.

Depends on #700 as it cannot run on aufs.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>