### PR TITLE
integration: Use aufs by default.

### DIFF
--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -17,7 +17,7 @@ SWARM_HOST=127.0.0.1:$(( ( RANDOM % 1000 )  + 6000 ))
 BASE_PORT=$(( ( RANDOM % 1000 )  + 5000 ))
 
 # Drivers to use for Docker engines the tests are going to create.
-STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
+STORAGE_DRIVER=${STORAGE_DRIVER:-aufs}
 EXEC_DRIVER=${EXEC_DRIVER:-native}
 
 # Join an array with a given separator.


### PR DESCRIPTION
The problem has been fixed in the dind images.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>