### PR TITLE
Check if network address in "swarm join" is a valid network interface

### DIFF
--- a/cli/join_test.go
+++ b/cli/join_test.go
@@ -25,3 +25,9 @@ func TestCheckAddrFormat(t *testing.T) {
 	assert.True(t, checkAddrFormat("hostname:1111"))
 	assert.True(t, checkAddrFormat("host-name_42:1111"))
 }
+
+func TestCheckAddrValidity(t *testing.T) {
+	assert.False(t, checkAddrValidity("a.b.c.d:1234"))
+	assert.True(t, checkAddrValidity("localhost:1234"))
+	assert.True(t, checkAddrValidity("127.0.0.1:1234"))
+}


### PR DESCRIPTION
This pull request addresses https://github.com/docker/swarm/issues/692

I am re-stating the problem here:

Here is my setup:

host1: 192.168.111.78, host2: 192.168.111.79, host3: 192.168.111.80

If by mistake I join host2 with host1's IP into my swarm cluster with swarm join --addr=192.168.111.78:2375 token://4432db3c4617b18655632bf091d9dfc7 (I used host1's address in host2), there is no error in host2 to indicate that I have started my swarm join with a wrong IP address nor there is any log in the master node to indicate this error.

When docker or swarm manage is started with such misconfig, the agent catches this error. However swarm join doesnt catch this error. This PR checks if the IP (currently only IPv4, since in IPv6 it doesn't check for IPs like ::1/128) is a valid network interface in the host. Kindly let me know if this works.
