### PR TITLE
integration: API tests split

### DIFF
--- a/test/integration/affinities.bats
+++ b/test/integration/affinities.bats
@@ -47,7 +47,7 @@ function teardown() {
 	start_docker 2
 	swarm_manage
 
-	run docker -H ${HOSTS[0]}  build -t test $BATS_TEST_DIRNAME/testdata/build
+	run docker -H ${HOSTS[0]}  build -t test $TESTDATA/build
 	[ "$status" -eq 0 ]
 
 	# pull busybox to force the refresh images

--- a/test/integration/api/attach.bats
+++ b/test/integration/api/attach.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker attach" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/build.bats
+++ b/test/integration/api/build.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker build" {
 	start_docker 3
 	swarm_manage
@@ -6,7 +15,7 @@
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 0 ]
 
-	run docker_swarm build -t test $BATS_TEST_DIRNAME/testdata/build
+	run docker_swarm build -t test $TESTDATA/build
 	[ "$status" -eq 0 ]
 
 	run docker_swarm images -q

--- a/test/integration/api/commit.bats
+++ b/test/integration/api/commit.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker commit" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/cp.bats
+++ b/test/integration/api/cp.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker cp" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/create.bats
+++ b/test/integration/api/create.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker create" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/diff.bats
+++ b/test/integration/api/diff.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker diff" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/events.bats
+++ b/test/integration/api/events.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker events" {
 	TEMP_FILE=$(mktemp)
 	start_docker 3

--- a/test/integration/api/exec.bats
+++ b/test/integration/api/exec.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker exec" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/export.bats
+++ b/test/integration/api/export.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker export" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/history.bats
+++ b/test/integration/api/history.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker history" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/images.bats
+++ b/test/integration/api/images.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker images" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/import.bats
+++ b/test/integration/api/import.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 # FIXME
 @test "docker import" {
 	skip

--- a/test/integration/api/info.bats
+++ b/test/integration/api/info.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker info" {
 	start_docker 1 --label foo=bar
 	swarm_manage

--- a/test/integration/api/inspect.bats
+++ b/test/integration/api/inspect.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker inspect" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/kill.bats
+++ b/test/integration/api/kill.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker kill" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/load.bats
+++ b/test/integration/api/load.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker load" {
 	# temp file for saving image
 	IMAGE_FILE=$(mktemp)

--- a/test/integration/api/login.bats
+++ b/test/integration/api/login.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 # FIXME
 @test "docker login" {
 	skip

--- a/test/integration/api/logout.bats
+++ b/test/integration/api/logout.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 # FIXME
 @test "docker logout" {
 	skip

--- a/test/integration/api/logs.bats
+++ b/test/integration/api/logs.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker logs" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/pause.bats
+++ b/test/integration/api/pause.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker pause" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/port.bats
+++ b/test/integration/api/port.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker port" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/ps.bats
+++ b/test/integration/api/ps.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker ps -n" {
 	start_docker 1
 	swarm_manage

--- a/test/integration/api/pull.bats
+++ b/test/integration/api/pull.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker pull" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/push.bats
+++ b/test/integration/api/push.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 # FIXME
 @test "docker push" {
 	skip

--- a/test/integration/api/rename.bats
+++ b/test/integration/api/rename.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker rename" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/restart.bats
+++ b/test/integration/api/restart.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker restart" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/rm.bats
+++ b/test/integration/api/rm.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker rm" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/rmi.bats
+++ b/test/integration/api/rmi.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker rmi" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker run" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/save.bats
+++ b/test/integration/api/save.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker save" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/search.bats
+++ b/test/integration/api/search.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker search" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/start.bats
+++ b/test/integration/api/start.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker start" {
 	start_docker 3 
 	swarm_manage

--- a/test/integration/api/stats.bats
+++ b/test/integration/api/stats.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker stats" {
 	TEMP_FILE=$(mktemp)
 	start_docker 3

--- a/test/integration/api/stop.bats
+++ b/test/integration/api/stop.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker stop" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/tag.bats
+++ b/test/integration/api/tag.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker tag" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/top.bats
+++ b/test/integration/api/top.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker top" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/unpause.bats
+++ b/test/integration/api/unpause.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker unpause" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/version.bats
+++ b/test/integration/api/version.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker version" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api/wait.bats
+++ b/test/integration/api/wait.bats
@@ -1,3 +1,12 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+}
+
 @test "docker wait" {
 	start_docker 3
 	swarm_manage

--- a/test/integration/api_version.bats
+++ b/test/integration/api_version.bats
@@ -3,11 +3,13 @@
 load helpers
 
 function teardown() {
-	swarm_manage_cleanup
 	stop_docker
 }
 
 # Ensure that the client and server are running the same version.
+#
+# If this test is failing, it means that your test environment is misconfigured
+# and your host CLI version differs from DOCKER_VERSION.
 @test "api version" {
 	start_docker 1
 	run docker -H "${HOSTS[0]}" version

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# Root directory of integration tests.
+INTEGRATION_ROOT=$(dirname "$(readlink -f "$BASH_SOURCE")")
+
+# Test data path.
+TESTDATA="${INTEGRATION_ROOT}/testdata"
+
 # Root directory of the repository.
-SWARM_ROOT=${SWARM_ROOT:-${BATS_TEST_DIRNAME}/../..}
+SWARM_ROOT=${SWARM_ROOT:-$(cd "$INTEGRATION_ROOT/../.."; pwd -P)}
 
 # Path of the Swarm binary.
 SWARM_BINARY=${SWARM_BINARY:-${SWARM_ROOT}/swarm}

--- a/test/integration/test_runner.sh
+++ b/test/integration/test_runner.sh
@@ -12,7 +12,7 @@ function execute() {
 }
 
 # Tests to run. Defaults to all.
-TESTS=${@:-.}
+TESTS=${@:-. api}
 
 # Generate a temporary binary for the tests.
 export SWARM_BINARY=`mktemp`


### PR DESCRIPTION
Note: `test/integration/run.sh` as well as jenkins are going to run all tests.

However, `bats test/integration` is **not** as it doesn't do recursive directories.

You will have to `bats test/integration test/integration/api` if you want to test everything.

I don't think it's a problem, the direction we are going I guess is to use `bats` to run an individual test and rely on `run.sh` to run everything (since it already takes close to 10 minutes for the entire suite, it's not a big deal if it takes 30 extra seconds)