### PR TITLE
Integration performance

### DIFF
--- a/test/integration/affinities.bats
+++ b/test/integration/affinities.bats
@@ -8,10 +8,10 @@ function teardown() {
 }
 
 @test "container affinty" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
-	run docker_swarm run --name c1 -e constraint:node==node-0 -d busybox:latest sh
+	run docker_swarm run --name c1 -e constraint:node==node-1 -d busybox:latest sh
 	[ "$status" -eq 0 ]
 	run docker_swarm run --name c2 -e affinity:container==c1 -d busybox:latest sh
 	[ "$status" -eq 0 ]
@@ -24,33 +24,35 @@ function teardown() {
 
 	run docker_swarm inspect c1
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c2
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c3
 	[ "$status" -eq 0 ]
-	[[ "${output}" != *'"Name": "node-0"'* ]]
+	[[ "${output}" != *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c4
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c5
 	[ "$status" -eq 0 ]
-	[[ "${output}" != *'"Name": "node-0"'* ]]
+	[[ "${output}" != *'"Name": "node-1"'* ]]
 }
 
 @test "image affinity" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
-	run docker -H ${HOSTS[0]}  build -t test $TESTDATA/build
+	# Create a new image just on the second host.
+	run docker -H ${HOSTS[1]} tag busybox test
 	[ "$status" -eq 0 ]
 
 	# pull busybox to force the refresh images
+	# FIXME: this is slow.
 	run docker_swarm pull busybox
 	[ "$status" -eq 0 ]
 
@@ -65,26 +67,26 @@ function teardown() {
 
 	run docker_swarm inspect c1
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c2
 	[ "$status" -eq 0 ]
-	[[ "${output}" != *'"Name": "node-0"'* ]]
+	[[ "${output}" != *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c3
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c4
 	[ "$status" -eq 0 ]
-	[[ "${output}" != *'"Name": "node-0"'* ]]
+	[[ "${output}" != *'"Name": "node-1"'* ]]
 }
 
 @test "label affinity" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
-	run docker_swarm run --name c1 --label test.label=true -e constraint:node==node-0 -d busybox:latest sh
+	run docker_swarm run --name c1 --label test.label=true -e constraint:node==node-1 -d busybox:latest sh
 	[ "$status" -eq 0 ]
 	run docker_swarm run --name c2 -e affinity:test.label==true -d busybox:latest sh
 	[ "$status" -eq 0 ]
@@ -97,21 +99,21 @@ function teardown() {
 
 	run docker_swarm inspect c1
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c2
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c3
 	[ "$status" -eq 0 ]
-	[[ "${output}" != *'"Name": "node-0"'* ]]
+	[[ "${output}" != *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c4
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect c5
 	[ "$status" -eq 0 ]
-	[[ "${output}" != *'"Name": "node-0"'* ]]
+	[[ "${output}" != *'"Name": "node-1"'* ]]
 }

--- a/test/integration/api/attach.bats
+++ b/test/integration/api/attach.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker attach" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# container run in background
@@ -27,7 +27,7 @@ function teardown() {
 
 @test "docker attach through websocket" {
 	CLIENT_API_VERSION="v1.17"
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
 	#create a container

--- a/test/integration/api/build.bats
+++ b/test/integration/api/build.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker build" {
-	start_docker 3
+	start_docker 2
 	swarm_manage
 
 	run docker_swarm images -q

--- a/test/integration/api/commit.bats
+++ b/test/integration/api/commit.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker commit" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/cp.bats
+++ b/test/integration/api/cp.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker cp" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	test_file="/bin/busybox"

--- a/test/integration/api/create.bats
+++ b/test/integration/api/create.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker create" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# make sure no contaienr exist

--- a/test/integration/api/diff.bats
+++ b/test/integration/api/diff.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker diff" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	run docker_swarm run -d --name test_container busybox sleep 500
 	[ "$status" -eq 0 ]

--- a/test/integration/api/events.bats
+++ b/test/integration/api/events.bats
@@ -9,7 +9,7 @@ function teardown() {
 
 @test "docker events" {
 	TEMP_FILE=$(mktemp)
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# start events, report real time events to TEMP_FILE

--- a/test/integration/api/exec.bats
+++ b/test/integration/api/exec.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker exec" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	run docker_swarm create --name test_container busybox sleep 100
 	[ "$status" -eq 0 ]

--- a/test/integration/api/export.bats
+++ b/test/integration/api/export.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker export" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	# run a container to export
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/export.bats
+++ b/test/integration/api/export.bats
@@ -27,8 +27,6 @@ function teardown() {
 	[ -s $temp_file_name ]
 	run file $temp_file_name
 	[ "$status" -eq 0 ]
-	echo ${lines[0]}
-	echo $output
 	[[ "$output" == *"tar archive"* ]]
 	
 	# after ok, delete exported tar file

--- a/test/integration/api/history.bats
+++ b/test/integration/api/history.bats
@@ -8,12 +8,11 @@ function teardown() {
 }
 
 @test "docker history" {
-	start_docker 3
+	# Start one empty host and one with busybox to ensure swarm selects the
+	# right one (and not one at random).
+	start_docker 1
+	start_docker_with_busybox 1
 	swarm_manage
-
-	# pull busybox image
-	run docker_swarm pull busybox
-	[ "$status" -eq 0 ]
 
 	# make sure the image of busybox exists
 	run docker_swarm images

--- a/test/integration/api/images.bats
+++ b/test/integration/api/images.bats
@@ -26,7 +26,6 @@ function teardown() {
 	
 	# Try with --filter.
 	run docker_swarm images --filter node=node-0
-	echo $output
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 1 ]
 

--- a/test/integration/api/info.bats
+++ b/test/integration/api/info.bats
@@ -12,7 +12,6 @@ function teardown() {
 	swarm_manage
 	run docker_swarm info
 	[ "$status" -eq 0 ]
-	echo $output
 	[[ "${output}" == *"Nodes: 1"* ]]
 	[[ "${output}" == *"└ Labels:"*"foo=bar"* ]]
 }

--- a/test/integration/api/inspect.bats
+++ b/test/integration/api/inspect.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker inspect" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	# run container
 	run docker_swarm run -d --name test_container busybox sleep 500
@@ -32,7 +32,7 @@ function teardown() {
 	# FIXME: Broken in docker master. See #717
 	skip
 
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	# run container
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/kill.bats
+++ b/test/integration/api/kill.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker kill" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	# run 
 	run docker_swarm run -d --name test_container busybox sleep 1000

--- a/test/integration/api/logs.bats
+++ b/test/integration/api/logs.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker logs" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# run a container with echo command

--- a/test/integration/api/pause.bats
+++ b/test/integration/api/pause.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker pause" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox sleep 1000

--- a/test/integration/api/port.bats
+++ b/test/integration/api/port.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker port" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	run docker_swarm run -d -p 8000 --name test_container busybox sleep 500
 	[ "$status" -eq 0 ]

--- a/test/integration/api/ps.bats
+++ b/test/integration/api/ps.bats
@@ -8,8 +8,9 @@ function teardown() {
 }
 
 @test "docker ps -n" {
-	start_docker 1
+	start_docker_with_busybox 2
 	swarm_manage
+
 	run docker_swarm run -d busybox sleep 42
 	run docker_swarm run -d busybox false
 	run docker_swarm ps -n 3
@@ -26,8 +27,9 @@ function teardown() {
 }
 
 @test "docker ps -l" {
-	start_docker 1
+	start_docker_with_busybox 2
 	swarm_manage
+
 	run docker_swarm run -d busybox sleep 42
 	sleep 1 #sleep so the 2 containers don't start at the same second
 	run docker_swarm run -d busybox true

--- a/test/integration/api/pull.bats
+++ b/test/integration/api/pull.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker pull" {
-	start_docker 3
+	start_docker 2
 	swarm_manage
 
 	# make sure no image exists
@@ -19,16 +19,16 @@ function teardown() {
 	run docker_swarm pull busybox
 	[ "$status" -eq 0 ]
 
-	# swarm verify
+	# we should get 2 busyboxes, plus the header.
 	run docker_swarm images
 	[ "$status" -eq 0 ]
-	[ "${#lines[@]}" -ge 4 ]
+	[ "${#lines[@]}" -eq 3 ]
 	# every line should contain "busybox" exclude the first head line 
 	for((i=1; i<${#lines[@]}; i++)); do
 		[[ "${lines[i]}" == *"busybox"* ]]
 	done
 
-	# node verify
+	# verify on the nodes
 	for host in ${HOSTS[@]}; do
 		run docker -H $host images
 		[ "$status" -eq 0 ]

--- a/test/integration/api/rename.bats
+++ b/test/integration/api/rename.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker rename" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/restart.bats
+++ b/test/integration/api/restart.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker restart" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	# run 
 	run docker_swarm run -d --name test_container busybox sleep 1000

--- a/test/integration/api/rm.bats
+++ b/test/integration/api/rm.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker rm" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox
@@ -28,7 +28,7 @@ function teardown() {
 }
 
 @test "docker rm -f" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/rmi.bats
+++ b/test/integration/api/rmi.bats
@@ -8,25 +8,31 @@ function teardown() {
 }
 
 @test "docker rmi" {
-	start_docker 3
+	# Start one empty host and two with busybox to ensure swarm selects the
+	# right ones and rmi doesn't fail if one host doesn't have the image.
+	start_docker 1
+	start_docker_with_busybox 2
 	swarm_manage
 
-	run docker_swarm pull busybox
-	[ "$status" -eq 0 ]
-
 	# make sure image exists
-	# swarm check image
 	run docker_swarm images
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"busybox"* ]]
-	# node check image
-	for host in ${HOSTS[@]}; do
-		run docker -H $host images
-		[ "$status" -eq 0 ]
-		[[ "${output}" == *"busybox"* ]]
-	done
 
-	# this test presupposition: do not run image
+	# verify the nodes: the first one shouldn't have the image while the other
+	# two yes.
+	run docker -H ${HOSTS[0]} images
+	[ "$status" -eq 0 ]
+	[[ "${output}" != *"busybox"* ]]
+	run docker -H ${HOSTS[1]} images
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"busybox"* ]]
+	run docker -H ${HOSTS[1]} images
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"busybox"* ]]
+
+
+	# wipe busybox.
 	run docker_swarm rmi busybox
 	[ "$status" -eq 0 ]
 
@@ -34,7 +40,8 @@ function teardown() {
 	run docker_swarm images -q
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 0 ]
-	# node verify
+
+	# verify the image was actually removed from every node.
 	for host in ${HOSTS[@]}; do
 		run docker -H $host images -q
 		[ "$status" -eq 0 ]

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker run" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# make sure no container exist

--- a/test/integration/api/save.bats
+++ b/test/integration/api/save.bats
@@ -8,18 +8,19 @@ function teardown() {
 }
 
 @test "docker save" {
-	start_docker 3
+	# Start one empty host and one with busybox to ensure swarm selects the
+	# right one (and not one at random).
+	start_docker 1
+	start_docker_with_busybox 1
 	swarm_manage
 
-	run docker_swarm pull busybox
-	[ "$status" -eq 0 ]
-
-	temp_file_name=$(mktemp)
-	temp_file_name_o=$(mktemp)
 	# make sure busybox image exists
 	run docker_swarm images 
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"busybox"* ]]
+
+	temp_file_name=$(mktemp)
+	temp_file_name_o=$(mktemp)
 
 	# save >, image->tar
 	docker_swarm save busybox > $temp_file_name

--- a/test/integration/api/search.bats
+++ b/test/integration/api/search.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker search" {
-	start_docker 3
+	start_docker 2
 	swarm_manage
 
 	# search image (not exist), the name of images only [a-z0-9-_.] are allowed

--- a/test/integration/api/start.bats
+++ b/test/integration/api/start.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker start" {
-	start_docker 3 
+	start_docker_with_busybox 2
 	swarm_manage
 	# create
 	run docker_swarm create --name test_container busybox sleep 1000

--- a/test/integration/api/stats.bats
+++ b/test/integration/api/stats.bats
@@ -9,7 +9,7 @@ function teardown() {
 
 @test "docker stats" {
 	TEMP_FILE=$(mktemp)
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# stats running container 

--- a/test/integration/api/stop.bats
+++ b/test/integration/api/stop.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker stop" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 	# run 
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/tag.bats
+++ b/test/integration/api/tag.bats
@@ -8,11 +8,11 @@ function teardown() {
 }
 
 @test "docker tag" {
-	start_docker 3
+	# Start one empty host and one with busybox to ensure swarm selects the
+	# right one (and not one at random).
+	start_docker 1
+	start_docker_with_busybox 1
 	swarm_manage
-
-	run docker_swarm pull busybox
-	[ "$status" -eq 0 ]
 
 	# make sure the image of busybox exists 
 	# the comming image of tag_busybox not exsit

--- a/test/integration/api/top.bats
+++ b/test/integration/api/top.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker top" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox sleep 500

--- a/test/integration/api/unpause.bats
+++ b/test/integration/api/unpause.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker unpause" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run -d --name test_container busybox sleep 1000

--- a/test/integration/api/version.bats
+++ b/test/integration/api/version.bats
@@ -8,7 +8,8 @@ function teardown() {
 }
 
 @test "docker version" {
-	start_docker 3
+	# FIXME: No reason here to start docker.
+	start_docker 1
 	swarm_manage
 
 	# version

--- a/test/integration/api/wait.bats
+++ b/test/integration/api/wait.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "docker wait" {
-	start_docker 3
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# run after 1 seconds, test_container will exit

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -2,12 +2,12 @@
 
 load helpers
 
-@test "create doesn't accept any arugments" {
+@test "swarm create doesn't accept any arguments" {
 	run swarm create derpderpderp
 	[ "$status" -ne 0 ]
 }
 
-@test "version string should contain a proper number with git commit" {
+@test "swarm version" {
 	run swarm -v
 
 	[ "$status" -eq 0 ]

--- a/test/integration/constraints.bats
+++ b/test/integration/constraints.bats
@@ -8,7 +8,7 @@ function teardown() {
 }
 
 @test "node constraint" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
 	run docker_swarm run --name c1 -e constraint:node==node-0 -d busybox:latest sh
@@ -38,8 +38,8 @@ function teardown() {
 }
 
 @test "label constraints" {
-	start_docker 1 --label foo=a
-	start_docker 1 --label foo=b
+	start_docker_with_busybox 1 --label foo=a
+	start_docker_with_busybox 1 --label foo=b
 	swarm_manage
 
 	run docker_swarm run --name c1 -e constraint:foo==a -d busybox:latest sh

--- a/test/integration/dependency.bats
+++ b/test/integration/dependency.bats
@@ -8,11 +8,11 @@ function teardown() {
 }
 
 @test "shared volumes dependency" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# Running the second container with shared volumes.
-	run docker_swarm run --name b1 -e constraint:node==node-0 -d busybox:latest sleep 500
+	run docker_swarm run --name b1 -e constraint:node==node-1 -d busybox:latest sleep 500
 	[ "$status" -eq 0 ]
 	run docker_swarm run --name b2 --volumes-from=/b1 -d busybox:latest sh
 	[ "$status" -eq 0 ]
@@ -25,15 +25,15 @@ function teardown() {
 	# check if both containers are started on the same node
 	run docker_swarm inspect b1
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect b2
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 }
 
 @test "links dependency" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# Running the second container with link dependency.
@@ -58,11 +58,11 @@ function teardown() {
 }
 
 @test "shared network stack dependency" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
 	# Running the second container with network stack dependency.
-	run docker_swarm run --name b1 -e constraint:node==node-0 -d busybox:latest sleep 500
+	run docker_swarm run --name b1 -e constraint:node==node-1 -d busybox:latest sleep 500
 	[ "$status" -eq 0 ]
 	run docker_swarm run --name b2 --net=container:/b1 -d busybox:latest sh
 	[ "$status" -eq 0 ]
@@ -75,9 +75,9 @@ function teardown() {
 	# check if both containers are started on the same node
 	run docker_swarm inspect b1
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 
 	run docker_swarm inspect b2
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"Name": "node-0"'* ]]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
 }

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -153,8 +153,8 @@ function swarm_join_cleanup() {
 
 function start_docker_with_busybox() {
 	# Preload busybox if not available.
-	[ "$(docker_host images -q busybox)" ] || docker_host pull busybox
-	[ -f "$BUSYBOX_IMAGE" ] || docker_host save -o "$BUSYBOX_IMAGE" busybox
+	[ "$(docker_host images -q busybox)" ] || docker_host pull busybox:latest
+	[ -f "$BUSYBOX_IMAGE" ] || docker_host save -o "$BUSYBOX_IMAGE" busybox:latest
 
 	# Start the docker instances.
 	local current=${#DOCKER_CONTAINERS[@]}

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -27,6 +27,8 @@ BASE_PORT=$(( ( RANDOM % 1000 )  + 5000 ))
 STORAGE_DRIVER=${STORAGE_DRIVER:-aufs}
 EXEC_DRIVER=${EXEC_DRIVER:-native}
 
+BUSYBOX_IMAGE="$BATS_TMPDIR/busybox.tgz"
+
 # Join an array with a given separator.
 function join() {
 	local IFS="$1"
@@ -146,6 +148,22 @@ function swarm_manage_cleanup() {
 function swarm_join_cleanup() {
 	for pid in ${SWARM_JOIN_PID[@]}; do
 		kill $pid || true
+	done
+}
+
+function start_docker_with_busybox() {
+	# Preload busybox if not available.
+	[ "$(docker_host images -q busybox)" ] || docker_host pull busybox
+	[ -f "$BUSYBOX_IMAGE" ] || docker_host save -o "$BUSYBOX_IMAGE" busybox
+
+	# Start the docker instances.
+	local current=${#DOCKER_CONTAINERS[@]}
+	start_docker "$@"
+	local new=${#DOCKER_CONTAINERS[@]}
+
+	# Load busybox on the new instances.
+	for ((i=current; i < new; i++)); do
+		docker -H ${HOSTS[$i]} load -i "$BUSYBOX_IMAGE"
 	done
 }
 

--- a/test/integration/port-filter.bats
+++ b/test/integration/port-filter.bats
@@ -8,28 +8,22 @@ function teardown() {
 }
 
 @test "docker should filter port in host mode correctly" {
-	start_docker 2
+	start_docker_with_busybox 2
 	swarm_manage
 
-	#
 	# Use busybox to save image pulling time for integration test.
 	# Running the first 2 containers, it should be fine.
-	#
 	run docker_swarm run -d --expose=80 --net=host busybox sh
 	[ "$status" -eq 0 ]
 	run docker_swarm run -d --expose=80 --net=host busybox sh
 	[ "$status" -eq 0 ]
 
-	#
 	# When trying to start the 3rd one, it should be error finding port 80.
-	#
 	run docker_swarm run -d --expose=80 --net=host busybox sh
 	[ "$status" -ne 0 ]
 	[[ "${lines[0]}" == *"unable to find a node with port 80/tcp available in the Host mode"* ]]
 
-	#
 	# And the number of running containers should be still 2.
-	#
 	run docker_swarm ps -n 2
 	[ "${#lines[@]}" -eq  3 ]
 }

--- a/test/stress/stress.bats
+++ b/test/stress/stress.bats
@@ -48,7 +48,7 @@ function wait_containers_exit {
 
 @test "spawning $CONTAINERS containers on $NODES nodes" {
 	# Start N engines.
-	start_docker $NODES
+	start_docker_with_busybox $NODES
 
 	# Start the manager and wait until all nodes join the cluster.
 	swarm_manage


### PR DESCRIPTION
- Added `start_docker_with_busybox` which starts an engine with a preloaded busybox without pulling (just like `docker/docker` integration-cli).
- Use `start_docker_with_busybox` everywhere it's possible.
- Start only what we need.
- Improved correctness of a few tests at the same time.