### PR TITLE
Proposal Node failover

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -274,9 +274,9 @@ func (e *Engine) refreshLoop() {
 		var err error
 		select {
 		case <-e.ch:
-			err = e.refreshContainers(false)
+			err = e.refreshContainers(true)
 		case <-time.After(stateRefreshPeriod):
-			err = e.refreshContainers(false)
+			err = e.refreshContainers(true)
 		}
 
 		if err == nil {
@@ -391,6 +391,14 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool) (*
 	defer e.RUnlock()
 
 	return e.containers[id], nil
+}
+
+//Start starts a docker container
+func (e *Engine) Start(name string) error {
+	if err := e.client.StartContainer(name, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Destroy and remove a container from the engine.

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/units"
@@ -22,11 +23,19 @@ import (
 type Cluster struct {
 	sync.RWMutex
 
-	eventHandler cluster.EventHandler
-	engines      map[string]*cluster.Engine
-	scheduler    *scheduler.Scheduler
-	options      *cluster.Options
-	store        *state.Store
+	eventHandler   cluster.EventHandler
+	engines        map[string]*cluster.Engine
+	scheduler      *scheduler.Scheduler
+	options        *cluster.Options
+	store          *state.Store
+	metaContainers map[string]*metaContainer
+}
+
+type metaContainer struct {
+	Name    string
+	Config  cluster.ContainerConfig
+	Current *cluster.Engine
+	Prev    *cluster.Engine
 }
 
 // NewCluster is exported
@@ -53,6 +62,7 @@ func NewCluster(scheduler *scheduler.Scheduler, store *state.Store, options *clu
 
 		}
 		cluster.newEntries(entries)
+		go cluster.monitor()
 
 		go d.Watch(cluster.newEntries)
 	}()
@@ -96,6 +106,18 @@ func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string) 
 	}
 
 	if nn, ok := c.engines[n.ID]; ok {
+		if meta, ok := c.metaContainers[name]; !ok {
+			c.metaContainers[name] = &metaContainer{
+				Name:    name,
+				Config:  *config,
+				Current: nn,
+				Prev:    nn,
+			}
+		} else {
+			meta.Prev = meta.Current
+			meta.Current = nn
+			c.metaContainers[name] = meta
+		}
 		container, err := nn.Create(config, name, true)
 		if err != nil {
 			return nil, err
@@ -121,7 +143,7 @@ func (c *Cluster) RemoveContainer(container *cluster.Container, force bool) erro
 	if err := container.Engine.Destroy(container, force); err != nil {
 		return err
 	}
-
+	delete(c.metaContainers, strings.TrimPrefix(container.Names[0], "/"))
 	if err := c.store.Remove(container.Id); err != nil {
 		if err == state.ErrNotFound {
 			log.Debugf("Container %s not found in the store", container.Id)
@@ -370,6 +392,84 @@ func (c *Cluster) listEngines() []*cluster.Engine {
 		out = append(out, n)
 	}
 	return out
+}
+
+func (c *Cluster) start(name string) error {
+	c.Lock()
+	defer c.Unlock()
+	//container := c.Container(name)
+	meta, ok := c.metaContainers[name]
+	if !ok {
+		return nil
+	}
+	c.metaContainers[name] = meta
+	return meta.Current.Start(meta.Name)
+}
+
+func (c *Cluster) monitor() {
+	healthy := make(map[string]*cluster.Engine)
+	time.Sleep(5 * time.Second)
+
+	unhealthy := make(map[string]*cluster.Engine)
+	for {
+		for _, n := range c.engines {
+			if n.IsHealthy() {
+				healthy[n.ID] = n
+			} else {
+				unhealthy[n.ID] = n
+			}
+		}
+		time.Sleep(5 * time.Second)
+		for _, n := range healthy {
+			if !n.IsHealthy() {
+				delete(healthy, n.ID)
+				unhealthy[n.ID] = n
+				log.WithFields(log.Fields{"Node": n.ID}).Info("failing over")
+				go c.failover(n)
+			}
+		}
+		for _, n := range unhealthy {
+			log.WithFields(log.Fields{"unhealthy": len(unhealthy)}).Info("unhealthy nodes")
+			if n.IsHealthy() {
+				delete(unhealthy, n.ID)
+				healthy[n.ID] = n
+				log.WithFields(log.Fields{"Node": n.ID}).Info("adjusting after failover over")
+				go c.adjust(n)
+			}
+		}
+	}
+}
+
+func (c *Cluster) adjust(e *cluster.Engine) {
+	for _, container := range e.Containers() {
+		if meta, ok := c.metaContainers[strings.TrimPrefix(container.Names[0], "/")]; ok {
+			if meta.Prev != meta.Current {
+				meta.Prev.Destroy(meta.Prev.Container(meta.Name), true)
+			}
+			log.WithFields(log.Fields{"Node": e.ID, "container": meta.Name}).Info("deleteing in reschedule container")
+		}
+	}
+}
+
+func (c *Cluster) failover(e *cluster.Engine) {
+	i := 1
+	for ; i <= 2; i++ {
+		time.Sleep(time.Duration(5*i) * time.Second)
+		if e.IsHealthy() {
+			break
+		}
+	}
+	if !e.IsHealthy() {
+		for _, container := range e.Containers() {
+			if container.Info.State.Running {
+				if meta, ok := c.metaContainers[strings.TrimPrefix(container.Names[0], "/")]; ok {
+					c.CreateContainer(&meta.Config, meta.Name)
+					c.start(meta.Name)
+					log.WithFields(log.Fields{"Node": e.ID, "container": meta.Name}).Info("rescheduling container")
+				}
+			}
+		}
+	}
 }
 
 // Info is exported


### PR DESCRIPTION
Signed-off-by: sivaram mothiki <smothiki@engineyard.com>

When a node fails Swarm has to reschedule the running containers from the failed node.
Considerations:
1. A cluster should know which container is running on which node so created meta container type struct in cluster. meta container stores container config which is used to create containers and current engine its running on and previous engine it ran on. For the first time creation of container Current and previous are same.
2. Created start method in cluster which in-turn calls start method in engine to start containers after creation.
3. Only Running containers should be started. So refreshloop always calls  refreshContainers(true) which updates containers info every time.
4. Cluster maintains a map of healthy and unhealthy nodes. when a healthy node becomes unhealthy cluster moves the healthy node to unhealthy nodes and calls failover which reschedules the containers to different nodes.
5. when an unhealthy node becomes healthy. calls adjust method which removes the containers that are rescheduled to avoid conflict.

This is a proposal PR and is open for discussions and Design suggestions. 