### PR TITLE
DO NOT MERGE: fix #762 - check Names length in affinity filter

### DIFF
--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -34,7 +34,10 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 			case "container":
 				containers := []string{}
 				for _, container := range node.Containers {
-					containers = append(containers, container.Id, strings.TrimPrefix(container.Names[0], "/"))
+					containers = append(containers, container.Id)
+					if len(container.Names) > 0 {
+						containers = append(containers, strings.TrimPrefix(container.Names[0], "/"))
+					}
 				}
 				if affinity.Match(containers...) {
 					candidates = append(candidates, node)


### PR DESCRIPTION
This PR is trying to fix #762 by checking length of `container.Names` just in case it's not available.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>