### PR TITLE
store: Improved Lock support.

### DIFF
--- a/pkg/store/etcd.go
+++ b/pkg/store/etcd.go
@@ -252,12 +252,8 @@ func (s *Etcd) CancelWatchRange(prefix string) error {
 	return s.CancelWatch(format(prefix))
 }
 
-// Acquire the lock for "key"/"directory"
-func (s *Etcd) Acquire(key string, value []byte) (string, error) {
-	return "", ErrNotImplemented
-}
-
-// Release the lock for "key"/"directory"
-func (s *Etcd) Release(session string) error {
-	return ErrNotImplemented
+// CreateLock returns a handle to a lock struct which can be used
+// to acquire and release the mutex.
+func (s *Etcd) CreateLock(key string, value []byte) (Locker, error) {
+	return nil, ErrNotImplemented
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,11 +36,10 @@ type Store interface {
 	// Cancel watch key
 	CancelWatch(key string) error
 
-	// Acquire the lock at key
-	Acquire(key string, value []byte) (string, error)
-
-	// Release the lock at key
-	Release(session string) error
+	// CreateLock for a given key.
+	// The returned Locker is not held and must be acquired with `.Lock`.
+	// value is optional.
+	CreateLock(key string, value []byte) (Locker, error)
 
 	// Get range of keys based on prefix
 	GetRange(prefix string) ([]KVEntry, error)
@@ -66,6 +65,13 @@ type KVEntry interface {
 	Key() string
 	Value() []byte
 	LastIndex() uint64
+}
+
+// Locker provides locking mechanism on top of the store.
+// Similar to `sync.Lock` except it may return errors.
+type Locker interface {
+	Lock() error
+	Unlock() error
 }
 
 var (


### PR DESCRIPTION
- New interface: `store.CreateLock` returns a `Locker` interface with
  `Lock` and `Unlock` functions.
- Consul: New locking implementation leveraging helper lock
  implementation that comes with the go library.
- ZK: Lock support using the library helpers.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>