### PR TITLE
store: Add node Ephemeral support

### DIFF
--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client_test.go
@@ -94,3 +94,15 @@ func TestPersistence(t *testing.T) {
 		t.Fatalf("The two configs should be equal!")
 	}
 }
+
+func TestClientRetry(t *testing.T) {
+	c := NewClient([]string{"http://strange", "http://127.0.0.1:4001"})
+	// use first endpoint as the picked url
+	c.cluster.picked = 0
+	if _, err := c.Set("foo", "bar", 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Delete("foo", true); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/cluster.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/cluster.go
@@ -30,5 +30,8 @@ func (cl *Cluster) pick() string { return cl.Machines[cl.picked] }
 
 func (cl *Cluster) updateFromStr(machines string) {
 	cl.Machines = strings.Split(machines, ",")
-	cl.picked = rand.Intn(len(machines))
+	for i := range cl.Machines {
+		cl.Machines[i] = strings.TrimSpace(cl.Machines[i])
+	}
+	cl.picked = rand.Intn(len(cl.Machines))
 }

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/error.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/error.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	ErrCodeEtcdNotReachable = 501
+	ErrCodeEtcdNotReachable    = 501
+	ErrCodeUnhandledHTTPStatus = 502
 )
 
 var (

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member.go
@@ -1,0 +1,30 @@
+package etcd
+
+import "encoding/json"
+
+type Member struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	PeerURLs   []string `json:"peerURLs"`
+	ClientURLs []string `json:"clientURLs"`
+}
+
+type memberCollection []Member
+
+func (c *memberCollection) UnmarshalJSON(data []byte) error {
+	d := struct {
+		Members []Member
+	}{}
+
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+
+	if d.Members == nil {
+		*c = make([]Member, 0)
+		return nil
+	}
+
+	*c = d.Members
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/member_test.go
@@ -1,0 +1,71 @@
+package etcd
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestMemberCollectionUnmarshal(t *testing.T) {
+	tests := []struct {
+		body []byte
+		want memberCollection
+	}{
+		{
+			body: []byte(`{"members":[]}`),
+			want: memberCollection([]Member{}),
+		},
+		{
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+			want: memberCollection(
+				[]Member{
+					{
+						ID:   "2745e2525fce8fe",
+						Name: "node3",
+						PeerURLs: []string{
+							"http://127.0.0.1:7003",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:4003",
+						},
+					},
+					{
+						ID:   "42134f434382925",
+						Name: "node1",
+						PeerURLs: []string{
+							"http://127.0.0.1:2380",
+							"http://127.0.0.1:7001",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:2379",
+							"http://127.0.0.1:4001",
+						},
+					},
+					{
+						ID:   "94088180e21eb87b",
+						Name: "node2",
+						PeerURLs: []string{
+							"http://127.0.0.1:7002",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:4002",
+						},
+					},
+				},
+			),
+		},
+	}
+
+	for i, tt := range tests {
+		var got memberCollection
+		err := json.Unmarshal(tt.body, &got)
+		if err != nil {
+			t.Errorf("#%d: unexpected error: %v", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("#%d: incorrect output: want=%#v, got=%#v", i, tt.want, got)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests.go
@@ -188,13 +188,19 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 
 		logger.Debug("Connecting to etcd: attempt ", attempt+1, " for ", rr.RelativePath)
 
-		httpPath = c.getHttpPath(rr.RelativePath)
+		// get httpPath if not set
+		if httpPath == "" {
+			httpPath = c.getHttpPath(rr.RelativePath)
+		}
 
 		// Return a cURL command if curlChan is set
 		if c.cURLch != nil {
 			command := fmt.Sprintf("curl -X %s %s", rr.Method, httpPath)
 			for key, value := range rr.Values {
 				command += fmt.Sprintf(" -d %s=%s", key, value[0])
+			}
+			if c.credentials != nil {
+				command += fmt.Sprintf(" -u %s", c.credentials.username)
 			}
 			c.sendCURL(command)
 		}
@@ -225,7 +231,13 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 			return nil, err
 		}
 
+		if c.credentials != nil {
+			req.SetBasicAuth(c.credentials.username, c.credentials.password)
+		}
+
 		resp, err = c.httpClient.Do(req)
+		// clear previous httpPath
+		httpPath = ""
 		defer func() {
 			if resp != nil {
 				resp.Body.Close()
@@ -280,6 +292,19 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 			}
 		}
 
+		if resp.StatusCode == http.StatusTemporaryRedirect {
+			u, err := resp.Location()
+
+			if err != nil {
+				logger.Warning(err)
+			} else {
+				// set httpPath for following redirection
+				httpPath = u.String()
+			}
+			resp.Body.Close()
+			continue
+		}
+
 		if checkErr := checkRetry(c.cluster, numReqs, *resp,
 			errors.New("Unexpected HTTP status code")); checkErr != nil {
 			return nil, checkErr
@@ -302,19 +327,38 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 func DefaultCheckRetry(cluster *Cluster, numReqs int, lastResp http.Response,
 	err error) error {
 
-	if numReqs >= 2*len(cluster.Machines) {
-		return newError(ErrCodeEtcdNotReachable,
-			"Tried to connect to each peer twice and failed", 0)
+	if numReqs > 2*len(cluster.Machines) {
+		errStr := fmt.Sprintf("failed to propose on members %v twice [last error: %v]", cluster.Machines, err)
+		return newError(ErrCodeEtcdNotReachable, errStr, 0)
 	}
 
-	code := lastResp.StatusCode
-	if code == http.StatusInternalServerError {
-		time.Sleep(time.Millisecond * 200)
-
+	if isEmptyResponse(lastResp) {
+		// always retry if it failed to get response from one machine
+		return nil
 	}
-
-	logger.Warning("bad response status code", code)
+	if !shouldRetry(lastResp) {
+		body := []byte("nil")
+		if lastResp.Body != nil {
+			if b, err := ioutil.ReadAll(lastResp.Body); err == nil {
+				body = b
+			}
+		}
+		errStr := fmt.Sprintf("unhandled http status [%s] with body [%s]", http.StatusText(lastResp.StatusCode), body)
+		return newError(ErrCodeUnhandledHTTPStatus, errStr, 0)
+	}
+	// sleep some time and expect leader election finish
+	time.Sleep(time.Millisecond * 200)
+	logger.Warning("bad response status code", lastResp.StatusCode)
 	return nil
+}
+
+func isEmptyResponse(r http.Response) bool { return r.StatusCode == 0 }
+
+// shouldRetry returns whether the reponse deserves retry.
+func shouldRetry(r http.Response) bool {
+	// TODO: only retry when the cluster is in leader election
+	// We cannot do it exactly because etcd doesn't support it well.
+	return r.StatusCode == http.StatusInternalServerError
 }
 
 func (c *Client) getHttpPath(s ...string) string {

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/version.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/version.go
@@ -1,3 +1,6 @@
 package etcd
 
-const version = "v2"
+const (
+	version        = "v2"
+	packageVersion = "v2.0.0+git"
+)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -65,7 +65,7 @@ func Run() {
 					log.Fatalf("the `create` command takes no arguments. See '%s create --help'.", c.App.Name)
 				}
 				discovery := &token.Discovery{}
-				discovery.Initialize("", 0)
+				discovery.Initialize("", 0, 0)
 				token, err := discovery.CreateCluster()
 				if err != nil {
 					log.Fatal(err)
@@ -88,7 +88,7 @@ func Run() {
 					log.Fatalf("invalid --timeout: %v", err)
 				}
 
-				d, err := discovery.New(dflag, timeout)
+				d, err := discovery.New(dflag, timeout, 0)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -122,8 +122,8 @@ func Run() {
 		{
 			Name:      "join",
 			ShortName: "j",
-			Usage:     "Join a docker cluster",
-			Flags:     []cli.Flag{flAddr, flHeartBeat},
+			Usage:     "join a docker cluster",
+			Flags:     []cli.Flag{flAddr, flHeartBeat, flTTL},
 			Action:    join,
 		},
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -49,13 +49,13 @@ var (
 		EnvVar: "SWARM_HOST",
 	}
 	flHeartBeat = cli.StringFlag{
-		Name:  "heartbeat, hb",
-		Value: "25s",
+		Name:  "heartbeat",
+		Value: "20s",
 		Usage: "period between each heartbeat",
 	}
 	flTTL = cli.StringFlag{
-		Name:  "time-to-live, ttl",
-		Value: "75s",
+		Name:  "ttl",
+		Value: "60s",
 		Usage: "sets the expiration of an ephemeral node",
 	}
 	flTimeout = cli.StringFlag{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -53,6 +53,11 @@ var (
 		Value: "25s",
 		Usage: "period between each heartbeat",
 	}
+	flTTL = cli.StringFlag{
+		Name:  "time-to-live, ttl",
+		Value: "75s",
+		Usage: "sets the expiration of an ephemeral node",
+	}
 	flTimeout = cli.StringFlag{
 		Name:  "timeout",
 		Value: "10s",

--- a/cli/help.go
+++ b/cli/help.go
@@ -45,7 +45,6 @@ Options:
    {{range .Flags}}{{.}}
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.discovery.heartbeat=25s\tperiod between each heartbeat"}}{{end}}{{ end }}
-                                    {{printf "\t * swarm.discovery.ttl=75s\ttime limit for a key to expire if ephemeral"}}{{end}}{{ end }}
 `
 
 }

--- a/cli/help.go
+++ b/cli/help.go
@@ -45,6 +45,7 @@ Options:
    {{range .Flags}}{{.}}
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.discovery.heartbeat=25s\tperiod between each heartbeat"}}{{end}}{{ end }}
+                                    {{printf "\t * swarm.discovery.ttl=75s\ttime limit for a key to expire if ephemeral"}}{{end}}{{ end }}
 `
 
 }

--- a/cli/join.go
+++ b/cli/join.go
@@ -27,7 +27,14 @@ func join(c *cli.Context) {
 	if hb < 1*time.Second {
 		log.Fatal("--heartbeat should be at least one second")
 	}
-	d, err := discovery.New(dflag, hb)
+	ttl, err := time.ParseDuration(c.String("ttl"))
+	if err != nil {
+		log.Fatalf("invalid --ttl: %v", err)
+	}
+	if ttl <= hb {
+		log.Fatal("--ttl must be strictly superior to the heartbeat value")
+	}
+	d, err := discovery.New(dflag, hb, ttl)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -56,7 +56,6 @@ func NewCluster(scheduler *scheduler.Scheduler, store *state.Store, TLSConfig *t
 	}
 
 	heartbeat := 25 * time.Second
-	ttl := 75 * time.Second
 	if opt, ok := options.String("swarm.discovery.heartbeat", ""); ok {
 		h, err := time.ParseDuration(opt)
 		if err != nil {
@@ -68,19 +67,8 @@ func NewCluster(scheduler *scheduler.Scheduler, store *state.Store, TLSConfig *t
 		heartbeat = h
 	}
 
-	if opt, ok := options.String("swarm.discovery.ttl", ""); ok {
-		t, err := time.ParseDuration(opt)
-		if err != nil {
-			return nil, err
-		}
-		if t <= heartbeat {
-			return nil, fmt.Errorf("invalid ttl %s: must be strictly superior to heartbeat value", opt)
-		}
-		ttl = t
-	}
-
 	// Set up discovery.
-	cluster.discovery, err = discovery.New(dflag, heartbeat, ttl)
+	cluster.discovery, err = discovery.New(dflag, heartbeat, 0)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -56,6 +56,7 @@ func NewCluster(scheduler *scheduler.Scheduler, store *state.Store, TLSConfig *t
 	}
 
 	heartbeat := 25 * time.Second
+	ttl := 75 * time.Second
 	if opt, ok := options.String("swarm.discovery.heartbeat", ""); ok {
 		h, err := time.ParseDuration(opt)
 		if err != nil {
@@ -67,8 +68,19 @@ func NewCluster(scheduler *scheduler.Scheduler, store *state.Store, TLSConfig *t
 		heartbeat = h
 	}
 
+	if opt, ok := options.String("swarm.discovery.ttl", ""); ok {
+		t, err := time.ParseDuration(opt)
+		if err != nil {
+			return nil, err
+		}
+		if t <= heartbeat {
+			return nil, fmt.Errorf("invalid ttl %s: must be strictly superior to heartbeat value", opt)
+		}
+		ttl = t
+	}
+
 	// Set up discovery.
-	cluster.discovery, err = discovery.New(dflag, heartbeat)
+	cluster.discovery, err = discovery.New(dflag, heartbeat, ttl)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -84,7 +84,7 @@ func (e Entries) Diff(cmp Entries) (Entries, Entries) {
 // The Discovery interface is implemented by Discovery backends which
 // manage swarm host entries.
 type Discovery interface {
-	// Initialize the discovery with URIs and a heartbeat.
+	// Initialize the discovery with URIs, a heartbeat and a ttl.
 	Initialize(string, time.Duration, time.Duration) error
 
 	// Watch the discovery for entry changes.
@@ -131,7 +131,7 @@ func parse(rawurl string) (string, string) {
 	return parts[0], parts[1]
 }
 
-// New returns a new Discovery given a URL and heartbeat settings.
+// New returns a new Discovery given a URL, heartbeat and ttl settings.
 // Returns an error if the URL scheme is not supported.
 func New(rawurl string, heartbeat time.Duration, ttl time.Duration) (Discovery, error) {
 	scheme, uri := parse(rawurl)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -85,7 +85,7 @@ func (e Entries) Diff(cmp Entries) (Entries, Entries) {
 // manage swarm host entries.
 type Discovery interface {
 	// Initialize the discovery with URIs and a heartbeat.
-	Initialize(string, time.Duration) error
+	Initialize(string, time.Duration, time.Duration) error
 
 	// Watch the discovery for entry changes.
 	// Returns a channel that will receive changes or an error.
@@ -133,12 +133,12 @@ func parse(rawurl string) (string, string) {
 
 // New returns a new Discovery given a URL and heartbeat settings.
 // Returns an error if the URL scheme is not supported.
-func New(rawurl string, heartbeat time.Duration) (Discovery, error) {
+func New(rawurl string, heartbeat time.Duration, ttl time.Duration) (Discovery, error) {
 	scheme, uri := parse(rawurl)
 
 	if discovery, exists := discoveries[scheme]; exists {
 		log.WithFields(log.Fields{"name": scheme, "uri": uri}).Debug("Initializing discovery service")
-		err := discovery.Initialize(uri, heartbeat)
+		err := discovery.Initialize(uri, heartbeat, ttl)
 		return discovery, err
 	}
 

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 // Initialize is exported
-func (s *Discovery) Initialize(path string, heartbeat time.Duration) error {
+func (s *Discovery) Initialize(path string, heartbeat time.Duration, ttl time.Duration) error {
 	s.path = path
 	s.heartbeat = heartbeat
 	return nil

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestInitialize(t *testing.T) {
 	d := &Discovery{}
-	d.Initialize("/path/to/file", 0)
+	d.Initialize("/path/to/file", 0, 0)
 	assert.Equal(t, d.path, "/path/to/file")
 }
 
 func TestNew(t *testing.T) {
-	d, err := discovery.New("file:///path/to/file", 0)
+	d, err := discovery.New("file:///path/to/file", 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, d.(*Discovery).path, "/path/to/file")
 }
@@ -73,7 +73,7 @@ func TestWatch(t *testing.T) {
 
 	// Set up file discovery.
 	d := &Discovery{}
-	d.Initialize(tmp.Name(), 1)
+	d.Initialize(tmp.Name(), 1, 0)
 	stopCh := make(chan struct{})
 	ch, errCh := d.Watch(stopCh)
 

--- a/discovery/kv/kv.go
+++ b/discovery/kv/kv.go
@@ -53,7 +53,6 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 		s.backend,
 		addrs,
 		&store.Config{
-			Heartbeat:    s.heartbeat,
 			EphemeralTTL: s.ttl,
 		},
 	)
@@ -124,6 +123,6 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 
 // Register is exported
 func (s *Discovery) Register(addr string) error {
-	opts := &store.WriteOptions{Ephemeral: true}
+	opts := &store.WriteOptions{Ephemeral: true, Heartbeat: s.heartbeat}
 	return s.store.Put(path.Join(s.prefix, addr), []byte(addr), opts)
 }

--- a/discovery/kv/kv.go
+++ b/discovery/kv/kv.go
@@ -47,13 +47,7 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration) error {
 
 	// Creates a new store, will ignore options given
 	// if not supported by the chosen store
-	s.store, err = store.CreateStore(
-		s.backend,
-		addrs,
-		&store.Config{
-			Timeout: s.heartbeat,
-		},
-	)
+	s.store, err = store.CreateStore(s.backend, addrs, nil)
 	return err
 }
 
@@ -121,5 +115,14 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 
 // Register is exported
 func (s *Discovery) Register(addr string) error {
-	return s.store.Put(path.Join(s.prefix, addr), []byte(addr))
+	opts := &store.WriteOptions{Ephemeral: true}
+	err := s.store.Put(path.Join(s.prefix, addr), []byte(addr), opts)
+	return err
+}
+
+func convertToStringArray(entries []*store.KVPair) (addrs []string) {
+	for _, entry := range entries {
+		addrs = append(addrs, string(entry.Value))
+	}
+	return addrs
 }

--- a/discovery/kv/kv_test.go
+++ b/discovery/kv/kv_test.go
@@ -13,17 +13,17 @@ import (
 
 func TestInitialize(t *testing.T) {
 	d := &Discovery{backend: store.MOCK}
-	assert.EqualError(t, d.Initialize("127.0.0.1", 0), "invalid format \"127.0.0.1\", missing <path>")
+	assert.EqualError(t, d.Initialize("127.0.0.1", 0, 0), "invalid format \"127.0.0.1\", missing <path>")
 
 	d = &Discovery{backend: store.MOCK}
-	assert.NoError(t, d.Initialize("127.0.0.1:1234/path", 0))
+	assert.NoError(t, d.Initialize("127.0.0.1:1234/path", 0, 0))
 	s := d.store.(*store.Mock)
 	assert.Len(t, s.Endpoints, 1)
 	assert.Equal(t, s.Endpoints[0], "127.0.0.1:1234")
 	assert.Equal(t, d.prefix, "path")
 
 	d = &Discovery{backend: store.MOCK}
-	assert.NoError(t, d.Initialize("127.0.0.1:1234,127.0.0.2:1234,127.0.0.3:1234/path", 0))
+	assert.NoError(t, d.Initialize("127.0.0.1:1234,127.0.0.2:1234,127.0.0.3:1234/path", 0, 0))
 	s = d.store.(*store.Mock)
 	assert.Len(t, s.Endpoints, 3)
 	assert.Equal(t, s.Endpoints[0], "127.0.0.1:1234")
@@ -34,7 +34,7 @@ func TestInitialize(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	d := &Discovery{backend: store.MOCK}
-	assert.NoError(t, d.Initialize("127.0.0.1:1234/path", 0))
+	assert.NoError(t, d.Initialize("127.0.0.1:1234/path", 0, 0))
 	s := d.store.(*store.Mock)
 
 	mockCh := make(chan []*store.KVPair)

--- a/discovery/nodes/nodes.go
+++ b/discovery/nodes/nodes.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 // Initialize is exported
-func (s *Discovery) Initialize(uris string, _ time.Duration) error {
+func (s *Discovery) Initialize(uris string, _ time.Duration, _ time.Duration) error {
 	for _, input := range strings.Split(uris, ",") {
 		for _, ip := range discovery.Generate(input) {
 			entry, err := discovery.NewEntry(ip)

--- a/discovery/nodes/nodes_test.go
+++ b/discovery/nodes/nodes_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInitialize(t *testing.T) {
 	d := &Discovery{}
-	d.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0)
+	d.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0, 0)
 	assert.Equal(t, len(d.entries), 2)
 	assert.Equal(t, d.entries[0].String(), "1.1.1.1:1111")
 	assert.Equal(t, d.entries[1].String(), "2.2.2.2:2222")
@@ -17,7 +17,7 @@ func TestInitialize(t *testing.T) {
 
 func TestInitializeWithPattern(t *testing.T) {
 	d := &Discovery{}
-	d.Initialize("1.1.1.[1:2]:1111,2.2.2.[2:4]:2222", 0)
+	d.Initialize("1.1.1.[1:2]:1111,2.2.2.[2:4]:2222", 0, 0)
 	assert.Equal(t, len(d.entries), 5)
 	assert.Equal(t, d.entries[0].String(), "1.1.1.1:1111")
 	assert.Equal(t, d.entries[1].String(), "1.1.1.2:1111")
@@ -28,7 +28,7 @@ func TestInitializeWithPattern(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	d := &Discovery{}
-	d.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0)
+	d.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0, 0)
 	expected := discovery.Entries{
 		&discovery.Entry{Host: "1.1.1.1", Port: "1111"},
 		&discovery.Entry{Host: "2.2.2.2", Port: "2222"},

--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -18,6 +18,7 @@ const DiscoveryURL = "https://discovery-stage.hub.docker.com/v1"
 // Discovery is exported
 type Discovery struct {
 	heartbeat time.Duration
+	ttl       time.Duration
 	url       string
 	token     string
 }
@@ -27,7 +28,7 @@ func init() {
 }
 
 // Initialize is exported
-func (s *Discovery) Initialize(urltoken string, heartbeat time.Duration) error {
+func (s *Discovery) Initialize(urltoken string, heartbeat time.Duration, ttl time.Duration) error {
 	if i := strings.LastIndex(urltoken, "/"); i != -1 {
 		s.url = "https://" + urltoken[:i]
 		s.token = urltoken[i+1:]
@@ -40,6 +41,7 @@ func (s *Discovery) Initialize(urltoken string, heartbeat time.Duration) error {
 		return errors.New("token is empty")
 	}
 	s.heartbeat = heartbeat
+	s.ttl = ttl
 
 	return nil
 }

--- a/discovery/token/token_test.go
+++ b/discovery/token/token_test.go
@@ -10,17 +10,17 @@ import (
 
 func TestInitialize(t *testing.T) {
 	discovery := &Discovery{}
-	err := discovery.Initialize("token", 0)
+	err := discovery.Initialize("token", 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, discovery.token, "token")
 	assert.Equal(t, discovery.url, DiscoveryURL)
 
-	err = discovery.Initialize("custom/path/token", 0)
+	err = discovery.Initialize("custom/path/token", 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, discovery.token, "token")
 	assert.Equal(t, discovery.url, "https://custom/path")
 
-	err = discovery.Initialize("", 0)
+	err = discovery.Initialize("", 0, 0)
 	assert.Error(t, err)
 }
 

--- a/pkg/store/consul.go
+++ b/pkg/store/consul.go
@@ -144,23 +144,13 @@ func (s *Consul) Put(key string, value []byte, opts *WriteOptions) error {
 
 			s.sessions[key] = session
 			p.Session = session
+		}
 
-			// Renew the session periodically if heartbeat set
-			if opts.Heartbeat != 0 {
-				go func() {
-					ticker := time.NewTicker(opts.Heartbeat)
-					for {
-						select {
-						case <-ticker.C:
-							_, _, err := s.client.Session().Renew(p.Session, nil)
-							if err != nil {
-								delete(s.sessions, key)
-								return
-							}
-						}
-					}
-				}()
-			}
+		// Renew the session
+		_, _, err := s.client.Session().Renew(p.Session, nil)
+		if err != nil {
+			delete(s.sessions, key)
+			return err
 		}
 	}
 

--- a/pkg/store/consul.go
+++ b/pkg/store/consul.go
@@ -162,6 +162,7 @@ func (s *Consul) Put(key string, value []byte, opts *WriteOptions) error {
 		// Renew the session
 		_, _, err := s.client.Session().Renew(p.Session, nil)
 		if err != nil {
+			s.ephemeralSession = ""
 			return err
 		}
 	}

--- a/pkg/store/mock.go
+++ b/pkg/store/mock.go
@@ -21,8 +21,8 @@ func InitializeMock(endpoints []string, options *Config) (Store, error) {
 }
 
 // Put mock
-func (s *Mock) Put(key string, value []byte) error {
-	args := s.Mock.Called(key, value)
+func (s *Mock) Put(key string, value []byte, opts *WriteOptions) error {
+	args := s.Mock.Called(key, value, opts)
 	return args.Error(0)
 }
 
@@ -75,8 +75,8 @@ func (s *Mock) DeleteTree(prefix string) error {
 }
 
 // AtomicPut mock
-func (s *Mock) AtomicPut(key string, value []byte, previous *KVPair) (bool, error) {
-	args := s.Mock.Called(key, value, previous)
+func (s *Mock) AtomicPut(key string, value []byte, previous *KVPair, opts *WriteOptions) (bool, error) {
+	args := s.Mock.Called(key, value, previous, opts)
 	return args.Bool(0), args.Error(1)
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -41,8 +41,8 @@ var (
 
 // Config contains the options for a storage client
 type Config struct {
-	TLS     *tls.Config
-	Timeout time.Duration
+	TLS               *tls.Config
+	ConnectionTimeout time.Duration
 }
 
 // Store represents the backend K/V storage
@@ -51,7 +51,7 @@ type Config struct {
 // backend for libkv
 type Store interface {
 	// Put a value at the specified key
-	Put(key string, value []byte) error
+	Put(key string, value []byte, options *WriteOptions) error
 
 	// Get a value given its key
 	Get(key string) (*KVPair, error)
@@ -86,17 +86,34 @@ type Store interface {
 	DeleteTree(prefix string) error
 
 	// Atomic operation on a single value
-	AtomicPut(key string, value []byte, previous *KVPair) (bool, error)
+	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, error)
 
 	// Atomic delete of a single value
 	AtomicDelete(key string, previous *KVPair) (bool, error)
 }
+
+const (
+	// DefaultTTL is the default time used for a node
+	// to be removed, it is set to 0 to explain
+	// that there is no expiration
+	DefaultTTL = 0
+
+	// EphemeralTTL is used for the ephemeral node
+	// behavior. If the node session is not renewed
+	// before the ttl expires, the node is removed
+	EphemeralTTL = 60
+)
 
 // KVPair represents {Key, Value, Lastindex} tuple
 type KVPair struct {
 	Key       string
 	Value     []byte
 	LastIndex uint64
+}
+
+// WriteOptions contains optional request parameters
+type WriteOptions struct {
+	Ephemeral bool
 }
 
 // WatchCallback is used for watch methods on keys

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -43,7 +43,6 @@ var (
 type Config struct {
 	TLS               *tls.Config
 	ConnectionTimeout time.Duration
-	Heartbeat         time.Duration
 	EphemeralTTL      time.Duration
 }
 
@@ -99,11 +98,6 @@ const (
 	// to be removed, it is set to 0 to explain
 	// that there is no expiration
 	DefaultTTL = 0
-
-	// EphemeralTTL is used for the ephemeral node
-	// behavior. If the node session is not renewed
-	// before the ttl expires, the node is removed
-	EphemeralTTL = 60
 )
 
 // KVPair represents {Key, Value, Lastindex} tuple
@@ -115,6 +109,7 @@ type KVPair struct {
 
 // WriteOptions contains optional request parameters
 type WriteOptions struct {
+	Heartbeat time.Duration
 	Ephemeral bool
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -43,6 +43,8 @@ var (
 type Config struct {
 	TLS               *tls.Config
 	ConnectionTimeout time.Duration
+	Heartbeat         time.Duration
+	EphemeralTTL      time.Duration
 }
 
 // Store represents the backend K/V storage

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -93,13 +93,6 @@ type Store interface {
 	AtomicDelete(key string, previous *KVPair) (bool, error)
 }
 
-const (
-	// DefaultTTL is the default time used for a node
-	// to be removed, it is set to 0 to explain
-	// that there is no expiration
-	DefaultTTL = 0
-)
-
 // KVPair represents {Key, Value, Lastindex} tuple
 type KVPair struct {
 	Key       string

--- a/pkg/store/zookeeper.go
+++ b/pkg/store/zookeeper.go
@@ -22,7 +22,7 @@ type zookeeperLock struct {
 // given a list of endpoints and optional tls config
 func InitializeZookeeper(endpoints []string, options *Config) (Store, error) {
 	s := &Zookeeper{}
-	s.timeout = 5 * time.Second // default timeout
+	s.timeout = 10 * time.Second // default timeout
 
 	// Set options
 	if options != nil {

--- a/pkg/store/zookeeper.go
+++ b/pkg/store/zookeeper.go
@@ -8,6 +8,8 @@ import (
 	zk "github.com/samuel/go-zookeeper/zk"
 )
 
+const defaultTimeout = 10 * time.Second
+
 // Zookeeper embeds the zookeeper client
 type Zookeeper struct {
 	timeout time.Duration
@@ -22,7 +24,7 @@ type zookeeperLock struct {
 // given a list of endpoints and optional tls config
 func InitializeZookeeper(endpoints []string, options *Config) (Store, error) {
 	s := &Zookeeper{}
-	s.timeout = 10 * time.Second // default timeout
+	s.timeout = defaultTimeout
 
 	// Set options
 	if options != nil {

--- a/test/integration/discovery/consul.bats
+++ b/test/integration/discovery/consul.bats
@@ -59,6 +59,31 @@ function teardown() {
 	retry 5 1 discovery_check_swarm_info
 }
 
+@test "consul discovery: check for engines departure" {
+	# The goal of this test is to ensure swarm can detect engines that
+	# are removed from the discovery and refresh info accordingly
+
+	# Start the store
+	start_store
+
+	# Start a manager with no engines.
+	swarm_manage "$DISCOVERY"
+	retry 10 1 discovery_check_swarm_info
+
+	# Add Engines to the cluster and make sure it's picked by swarm
+	start_docker 2
+	swarm_join "$DISCOVERY"
+	retry 5 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 5 1 discovery_check_swarm_info
+
+	# Removes all the swarm agents
+	swarm_join_cleanup
+
+	# Check if previously registered engines are all gone
+	retry 5 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 30 1 discovery_check_swarm_info_empty
+}
+
 @test "consul discovery: failure" {
 	# The goal of this test is to simulate a store failure and ensure discovery
 	# is resilient to it.

--- a/test/integration/discovery/consul.bats
+++ b/test/integration/discovery/consul.bats
@@ -59,7 +59,7 @@ function teardown() {
 	retry 5 1 discovery_check_swarm_info
 }
 
-@test "consul discovery: check for engines departure" {
+@test "consul discovery: node removal" {
 	# The goal of this test is to ensure swarm can detect engines that
 	# are removed from the discovery and refresh info accordingly
 
@@ -80,8 +80,7 @@ function teardown() {
 	swarm_join_cleanup
 
 	# Check if previously registered engines are all gone
-	retry 5 1 discovery_check_swarm_list "$DISCOVERY"
-	retry 30 1 discovery_check_swarm_info_empty
+	retry 30 1 discovery_check_swarm_info 0
 }
 
 @test "consul discovery: failure" {

--- a/test/integration/discovery/discovery_helpers.bash
+++ b/test/integration/discovery/discovery_helpers.bash
@@ -10,6 +10,11 @@ function discovery_check_swarm_info() {
 	docker_swarm info | grep -q "Nodes: $count"
 }
 
+# Returns true if swarm info outputs is empty (0 nodes).
+function discovery_check_swarm_info_empty() {
+	docker_swarm info | grep -q "Nodes: 0"
+}
+
 # Returns true if all nodes have joined the discovery.
 function discovery_check_swarm_list() {
 	local joined=`swarm list "$1" | wc -l`

--- a/test/integration/discovery/discovery_helpers.bash
+++ b/test/integration/discovery/discovery_helpers.bash
@@ -7,7 +7,7 @@ function discovery_check_swarm_info() {
 	local total="$1"
 	[ -z "$total" ] && total="${#HOSTS[@]}"
 
-	docker_swarm info | grep -q "Nodes: $count"
+	docker_swarm info | grep -q "Nodes: $total"
 }
 
 # Returns true if swarm info outputs is empty (0 nodes).

--- a/test/integration/discovery/etcd.bats
+++ b/test/integration/discovery/etcd.bats
@@ -12,7 +12,11 @@ DISCOVERY="etcd://${STORE_HOST}/test"
 CONTAINER_NAME=swarm_etcd
 
 function start_store() {
-	docker_host run -p $STORE_HOST:4001 --name=$CONTAINER_NAME -d coreos/etcd
+	docker_host run -p $STORE_HOST:4001 \
+		--name=$CONTAINER_NAME -d \
+		quay.io/coreos/etcd:v2.0.11 \
+		--listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 \
+		--advertise-client-urls=http://$STORE_HOST
 }
 
 function stop_store() {

--- a/test/integration/discovery/etcd.bats
+++ b/test/integration/discovery/etcd.bats
@@ -64,7 +64,7 @@ function teardown() {
 	retry 5 1 discovery_check_swarm_info
 }
 
-@test "etcd discovery: check for engines departure" {
+@test "etcd discovery: node removal" {
 	# The goal of this test is to ensure swarm can detect engines that
 	# are removed from the discovery and refresh info accordingly
 
@@ -84,9 +84,8 @@ function teardown() {
 	# Removes all the swarm agents
 	swarm_join_cleanup
 
-	# Check if nodes are all gone
-	retry 5 1 discovery_check_swarm_list "$DISCOVERY"
-	retry 15 1 discovery_check_swarm_info_empty
+	# Check if previously registered engines are all gone
+	retry 15 1 discovery_check_swarm_info 0
 }
 
 @test "etcd discovery: failure" {

--- a/test/integration/discovery/zk.bats
+++ b/test/integration/discovery/zk.bats
@@ -59,7 +59,7 @@ function teardown() {
 	retry 10 1 discovery_check_swarm_info
 }
 
-@test "zk discovery: check for engines departure" {
+@test "zk discovery: node removal" {
 	# The goal of this test is to ensure swarm can detect engines that
 	# are removed from the discovery and refresh info accordingly
 
@@ -80,8 +80,7 @@ function teardown() {
 	swarm_join_cleanup
 
 	# Check if previously registered engines are all gone
-	retry 10 1 discovery_check_swarm_list "$DISCOVERY"
-	retry 20 1 discovery_check_swarm_info_empty
+	retry 20 1 discovery_check_swarm_info 0
 }
 
 @test "zk discovery: failure" {

--- a/test/integration/discovery/zk.bats
+++ b/test/integration/discovery/zk.bats
@@ -59,6 +59,31 @@ function teardown() {
 	retry 10 1 discovery_check_swarm_info
 }
 
+@test "zk discovery: check for engines departure" {
+	# The goal of this test is to ensure swarm can detect engines that
+	# are removed from the discovery and refresh info accordingly
+
+	# Start the store
+	start_store
+
+	# Start 2 engines and make them join the cluster.
+	swarm_manage "$DISCOVERY"
+	retry 10 1 discovery_check_swarm_info
+
+	# Add Engines to the cluster and make sure it's picked by swarm
+	start_docker 2
+	swarm_join "$DISCOVERY"
+	retry 10 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 10 1 discovery_check_swarm_info
+
+	# Removes all the swarm agents
+	swarm_join_cleanup
+
+	# Check if previously registered engines are all gone
+	retry 10 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 20 1 discovery_check_swarm_info_empty
+}
+
 @test "zk discovery: failure" {
 	# The goal of this test is to simulate a store failure and ensure discovery
 	# is resilient to it.

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -117,7 +117,7 @@ function swarm_join() {
 	for ((i=current; i < nodes; i++)); do
 		local h="${HOSTS[$i]}"
 		echo "Swarm join #${i}: $h $addr"
-		"$SWARM_BINARY" -l debug join --heartbeat=1s --addr="$h" "$addr" &
+		"$SWARM_BINARY" -l debug join --heartbeat=1s --ttl=10s --addr="$h" "$addr" &
 		SWARM_JOIN_PID[$i]=$!
 	done
 }


### PR DESCRIPTION
Adds an `Ephemeral` flag to Consul, Zookeeper and Etcd for usage with Discovery.

This PR is mostly made to discuss about what is the best approach: rely on TTLs or use an Ephemeral flag. In both cases there are trade-offs to be made on the semantics of both operations:

- If we use an Ephemeral flag, we hide etcd's lack of support for Ephemeral by the use of a periodic `Set` that renews the TTL (What this PR does)
- If we use a TTL, we must hide zookeeper's lack of support for TTL behind the use of an Ephemeral flag.