### PR TITLE
Adding export Init method for the exported discovery components

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -16,6 +16,11 @@ type Discovery struct {
 }
 
 func init() {
+	Init()
+}
+
+// Init is exported
+func Init() {
 	discovery.Register("file", &Discovery{})
 }
 

--- a/discovery/kv/kv.go
+++ b/discovery/kv/kv.go
@@ -21,6 +21,11 @@ type Discovery struct {
 }
 
 func init() {
+	Init()
+}
+
+// Init is exported
+func Init() {
 	discovery.Register("zk", &Discovery{backend: store.ZK})
 	discovery.Register("consul", &Discovery{backend: store.CONSUL})
 	discovery.Register("etcd", &Discovery{backend: store.ETCD})

--- a/discovery/nodes/nodes.go
+++ b/discovery/nodes/nodes.go
@@ -13,6 +13,11 @@ type Discovery struct {
 }
 
 func init() {
+	Init()
+}
+
+// Init is exported
+func Init() {
 	discovery.Register("nodes", &Discovery{})
 }
 

--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -24,6 +24,11 @@ type Discovery struct {
 }
 
 func init() {
+	Init()
+}
+
+// Init is exported
+func Init() {
 	discovery.Register("token", &Discovery{})
 }
 


### PR DESCRIPTION
Since Swarm discovery is used by libnetwork without the swarm main(), it
is forced to use annonymous import in order to force-trigger the
unexported init() methods. Using annonymous import is highly discouraged
in a Non-Main and Non-Test packages.

Introducing exported Init() methods on these files so that libnetwork
can use Discovery as a library without having a main package.

Signed-off-by: Madhu Venugopal <madhu@docker.com>