### PR TITLE
store: Implement locking mechanisms with Etcd

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -108,7 +108,8 @@ type WriteOptions struct {
 
 // LockOptions contains optional request parameters
 type LockOptions struct {
-	Value []byte // Optional, value to associate with the lock
+	Value []byte        // Optional, value to associate with the lock
+	TTL   time.Duration // Optional, expiration ttl associated with the lock
 }
 
 // WatchCallback is used for watch methods on keys


### PR DESCRIPTION
Its seems that F.Underwood can now run for the `Etcd` State ;)

Tested using the `leadership` package documentation example.

Signed-off-by: Alexandre Beslic <abronan@docker.com>