### PR TITLE
Return last index on CAS operation

### DIFF
--- a/pkg/store/etcd.go
+++ b/pkg/store/etcd.go
@@ -252,12 +252,12 @@ func (s *Etcd) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*KVPai
 
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
-func (s *Etcd) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, error) {
-	_, err := s.client.CompareAndSwap(normalize(key), string(value), 0, "", previous.LastIndex)
+func (s *Etcd) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error) {
+	meta, err := s.client.CompareAndSwap(normalize(key), string(value), 0, "", previous.LastIndex)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return true, nil
+	return true, &KVPair{Key: key, Value: value, LastIndex: meta.Node.ModifiedIndex}, nil
 }
 
 // AtomicDelete deletes a value at "key" if the key has not

--- a/pkg/store/mock.go
+++ b/pkg/store/mock.go
@@ -75,9 +75,9 @@ func (s *Mock) DeleteTree(prefix string) error {
 }
 
 // AtomicPut mock
-func (s *Mock) AtomicPut(key string, value []byte, previous *KVPair, opts *WriteOptions) (bool, error) {
+func (s *Mock) AtomicPut(key string, value []byte, previous *KVPair, opts *WriteOptions) (bool, *KVPair, error) {
 	args := s.Mock.Called(key, value, previous, opts)
-	return args.Bool(0), args.Error(1)
+	return args.Bool(0), args.Get(1).(*KVPair), args.Error(2)
 }
 
 // AtomicDelete mock

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -87,7 +87,7 @@ type Store interface {
 	DeleteTree(prefix string) error
 
 	// Atomic operation on a single value
-	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, error)
+	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
 
 	// Atomic delete of a single value
 	AtomicDelete(key string, previous *KVPair) (bool, error)

--- a/pkg/store/zookeeper.go
+++ b/pkg/store/zookeeper.go
@@ -214,9 +214,9 @@ func (s *Zookeeper) DeleteTree(prefix string) error {
 
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
-func (s *Zookeeper) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, error) {
+func (s *Zookeeper) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error) {
 	// Use index of Set method to implement CAS
-	return false, ErrNotImplemented
+	return false, nil, ErrNotImplemented
 }
 
 // AtomicDelete deletes a value at "key" if the key has not


### PR DESCRIPTION
Returns the last index on CAS operations for Consul and Etcd.

Fixes #843 

Signed-off-by: Alexandre Beslic <abronan@docker.com>