### PR TITLE
Fix test for file watch

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -64,7 +64,7 @@ func (s *Discovery) fetch() (discovery.Entries, error) {
 func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
 	ch := make(chan discovery.Entries)
 	errCh := make(chan error)
-	ticker := time.NewTicker(s.heartbeat * time.Second)
+	ticker := time.NewTicker(s.heartbeat)
 
 	go func() {
 		defer close(errCh)

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -64,7 +64,7 @@ func (s *Discovery) fetch() (discovery.Entries, error) {
 func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
 	ch := make(chan discovery.Entries)
 	errCh := make(chan error)
-	ticker := time.NewTicker(s.heartbeat)
+	ticker := time.NewTicker(s.heartbeat * time.Second)
 
 	go func() {
 		defer close(errCh)


### PR DESCRIPTION
Apparently ` ioutil.WriteFile` erase the file before writing into it, that why the test sometime saw an empty array.