### PR TITLE
store: Zookeeper cas and consistent errors on failure

### DIFF
--- a/pkg/store/consul.go
+++ b/pkg/store/consul.go
@@ -343,7 +343,7 @@ func (l *consulLock) Unlock() error {
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *Consul) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error) {
-	if previous != nil {
+	if previous == nil {
 		return false, nil, ErrPreviousNotSpecified
 	}
 
@@ -372,7 +372,7 @@ func (s *Consul) AtomicPut(key string, value []byte, previous *KVPair, options *
 // AtomicDelete deletes a value at "key" if the key has not
 // been modified in the meantime, throws an error if this is the case
 func (s *Consul) AtomicDelete(key string, previous *KVPair) (bool, error) {
-	if previous != nil {
+	if previous == nil {
 		return false, ErrPreviousNotSpecified
 	}
 

--- a/pkg/store/consul.go
+++ b/pkg/store/consul.go
@@ -343,6 +343,10 @@ func (l *consulLock) Unlock() error {
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *Consul) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error) {
+	if previous != nil {
+		return false, nil, ErrPreviousNotSpecified
+	}
+
 	lock, err := s.NewLock(key, nil)
 	if err != nil {
 		return false, nil, err
@@ -368,6 +372,10 @@ func (s *Consul) AtomicPut(key string, value []byte, previous *KVPair, options *
 // AtomicDelete deletes a value at "key" if the key has not
 // been modified in the meantime, throws an error if this is the case
 func (s *Consul) AtomicDelete(key string, previous *KVPair) (bool, error) {
+	if previous != nil {
+		return false, ErrPreviousNotSpecified
+	}
+
 	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex}
 	if work, _, err := s.client.KV().DeleteCAS(p, nil); err != nil {
 		return false, err

--- a/pkg/store/etcd.go
+++ b/pkg/store/etcd.go
@@ -253,6 +253,10 @@ func (s *Etcd) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*KVPai
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *Etcd) AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error) {
+	if previous != nil {
+		return false, nil, ErrPreviousNotSpecified
+	}
+
 	meta, err := s.client.CompareAndSwap(normalize(key), string(value), 0, "", previous.LastIndex)
 	if err != nil {
 		return false, nil, err
@@ -263,6 +267,10 @@ func (s *Etcd) AtomicPut(key string, value []byte, previous *KVPair, options *Wr
 // AtomicDelete deletes a value at "key" if the key has not
 // been modified in the meantime, throws an error if this is the case
 func (s *Etcd) AtomicDelete(key string, previous *KVPair) (bool, error) {
+	if previous != nil {
+		return false, ErrPreviousNotSpecified
+	}
+
 	_, err := s.client.CompareAndDelete(normalize(key), "", previous.LastIndex)
 	if err != nil {
 		return false, err

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -39,6 +39,8 @@ var (
 	ErrKeyModified = errors.New("Unable to complete atomic operation, key modified")
 	// ErrKeyNotFound is exported
 	ErrKeyNotFound = errors.New("Key not found in store")
+	// ErrPreviousNotSpecified is exported
+	ErrPreviousNotSpecified = errors.New("Previous K/V pair should be provided for the Atomic operation")
 )
 
 // Config contains the options for a storage client


### PR DESCRIPTION
Add Compare and Swap for Zookeeper.

Tested primitively using:

```go
package main

import (
	log "github.com/Sirupsen/logrus"
	"github.com/docker/swarm/pkg/store"
)

func main() {
	store, err := store.NewStore(store.ZK, []string{"localhost:2181"}, nil)
	if err != nil {
		log.Fatal(nil)
	}

	err = store.Put("hello", []byte("world"), nil)
	if err != nil {
		log.Fatal(err)
	}

	pair, err := store.Get("hello")
	if err != nil {
		log.Error("Get error: ", err)
	}

	// This CAS should succeed
	success, _, err := store.AtomicPut("hello", []byte("WORLD"), pair, nil)
	if err != nil {
		log.Info("CAS failed: ", err)
	}

	if success {
		log.Info("CAS succeeded")
	}

	// This CAS should fail
	pair.LastIndex = 0
	success, _, err = store.AtomicPut("hello", []byte("WORLDWORLD"), pair, nil)
	if err != nil {
		log.Info("CAS failed: ", err)
	}

	if success {
		log.Info("CAS succeeded")
	}
}
```