### PR TITLE
Fix etcd SyncCluster and Integration tests

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -32,8 +32,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
-			"Comment": "v2.0.0-8-g2698e87",
-			"Rev": "2698e87871614d7f376775409c701dd538f0b50e"
+			"Comment": "v2.0.0-11-gcc90c7b",
+			"Rev": "cc90c7b091275e606ad0ca7102a23fb2072f3f5e"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/ioutils",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -32,8 +32,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
-			"Comment": "v2.0.0-7-g73a8ef7",
-			"Rev": "73a8ef737e8ea002281a28b4cb92a1de121ad4c6"
+			"Comment": "v2.0.0-8-g2698e87",
+			"Rev": "2698e87871614d7f376775409c701dd538f0b50e"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/ioutils",

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client.go
@@ -306,6 +306,7 @@ func (c *Client) GetCluster() []string {
 }
 
 // SyncCluster updates the cluster information using the internal machine list.
+// If no members are found, the intenral machine list is left untouched.
 func (c *Client) SyncCluster() bool {
 	return c.internalSyncCluster(c.cluster.Machines)
 }
@@ -356,7 +357,6 @@ func (c *Client) internalSyncCluster(machines []string) bool {
 				urls = append(urls, m.ClientURLs...)
 			}
 
-			// update Machines List
 			members = strings.Join(urls, ",")
 		}
 

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/response.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/response.go
@@ -28,6 +28,7 @@ var (
 		http.StatusNotFound:           true,
 		http.StatusPreconditionFailed: true,
 		http.StatusForbidden:          true,
+		http.StatusUnauthorized:       true,
 	}
 )
 

--- a/pkg/store/etcd.go
+++ b/pkg/store/etcd.go
@@ -51,6 +51,7 @@ func InitializeEtcd(addrs []string, options *Config) (Store, error) {
 		}
 	}
 
+	s.client.SyncCluster()
 	return s, nil
 }
 

--- a/pkg/store/etcd.go
+++ b/pkg/store/etcd.go
@@ -28,6 +28,9 @@ type etcdLock struct {
 const (
 	defaultLockTTL    = 20 * time.Second
 	defaultUpdateTime = 5 * time.Second
+
+	// periodicSync is the time between each call to SyncCluster
+	periodicSync = 10 * time.Minute
 )
 
 // InitializeEtcd creates a new Etcd client given
@@ -51,7 +54,12 @@ func InitializeEtcd(addrs []string, options *Config) (Store, error) {
 		}
 	}
 
-	s.client.SyncCluster()
+	go func() {
+		for {
+			s.client.SyncCluster()
+			time.Sleep(periodicSync)
+		}
+	}()
 	return s, nil
 }
 

--- a/test/integration/discovery/etcd.bats
+++ b/test/integration/discovery/etcd.bats
@@ -19,8 +19,6 @@ function start_store() {
 		quay.io/coreos/etcd:v2.0.11 \
 		--listen-client-urls="http://0.0.0.0:${PORT}" \
 		--advertise-client-urls="http://${STORE_HOST}"
-
-	sleep 3
 }
 
 function stop_store() {

--- a/test/integration/discovery/etcd.bats
+++ b/test/integration/discovery/etcd.bats
@@ -2,8 +2,9 @@
 
 load discovery_helpers
 
-# Address on which the store will listen (random port between 8000 and 9000).
-STORE_HOST=127.0.0.1:$(( ( RANDOM % 1000 )  + 9000 ))
+# Port and Address on which the store will listen (random port between 8000 and 9000).
+PORT=$((RANDOM % 1000 + 9000))
+STORE_HOST=127.0.0.1:$PORT
 
 # Discovery parameter for Swarm
 DISCOVERY="etcd://${STORE_HOST}/test"
@@ -12,11 +13,14 @@ DISCOVERY="etcd://${STORE_HOST}/test"
 CONTAINER_NAME=swarm_etcd
 
 function start_store() {
-	docker_host run -p $STORE_HOST:4001 \
-		--name=$CONTAINER_NAME -d \
+	docker_host run -d \
+		--net=host \
+		--name=$CONTAINER_NAME \
 		quay.io/coreos/etcd:v2.0.11 \
-		--listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 \
-		--advertise-client-urls=http://$STORE_HOST
+		--listen-client-urls="http://0.0.0.0:${PORT}" \
+		--advertise-client-urls="http://${STORE_HOST}"
+
+	sleep 3
 }
 
 function stop_store() {


### PR DESCRIPTION
Fixes `SyncCluster` with Integration tests. We need to wait for etcd to bootstrap its single node cluster properly or the `SyncCluster` leaves us with an empty *members* list..

Signed-off-by: Alexandre Beslic <abronan@docker.com>