### PR TITLE
fix matching image name with private repo

### DIFF
--- a/cluster/image.go
+++ b/cluster/image.go
@@ -13,6 +13,35 @@ type Image struct {
 	Engine *Engine
 }
 
+func toImageName(repo string, name string, tag string) string {
+	fullname := name
+	if tag != "" {
+		fullname = name + ":" + tag
+	}
+	if repo != "" {
+		fullname = repo + "/" + fullname
+	}
+	return fullname
+}
+
+func parseImageName(fullname string) (repo string, name string, tag string) {
+	parts := strings.SplitN(fullname, "/", 2)
+
+	nameAndTag := parts[0]
+	if len(parts) == 2 {
+		repo = parts[0]
+		nameAndTag = parts[1]
+	}
+
+	parts = strings.SplitN(nameAndTag, ":", 2)
+	name = parts[0]
+	if len(parts) == 2 {
+		tag = parts[1]
+	}
+
+	return
+}
+
 // Match is exported
 func (image *Image) Match(IDOrName string, matchTag bool) bool {
 	size := len(IDOrName)
@@ -21,33 +50,22 @@ func (image *Image) Match(IDOrName string, matchTag bool) bool {
 		return true
 	}
 
-	repo := ""
-	name := IDOrName
-	if strings.Contains(IDOrName, "/") {
-		parts := strings.SplitN(IDOrName, "/", 2)
-		repo = parts[0] + "/"
-		name = parts[1]
-	}
+	imageName := IDOrName
+	repo, name, tag := parseImageName(imageName)
 	if matchTag {
-		if len(strings.SplitN(name, ":", 2)) == 1 {
-			name = repo + name + ":latest"
-		} else {
-			name = repo + name
+		if tag == "" {
+			imageName = toImageName(repo, name, "latest")
 		}
 	} else {
-		name = repo + strings.SplitN(name, ":", 2)[0]
+		imageName = toImageName(repo, name, "")
 	}
 
 	for _, repoTag := range image.RepoTags {
 		if matchTag == false {
-			if strings.Contains(repoTag, "/") {
-				parts := strings.SplitN(repoTag, "/", 2)
-				repoTag = parts[0] + "/" + strings.SplitN(parts[1], ":", 2)[0]
-			} else {
-				repoTag = strings.SplitN(repoTag, ":", 2)[0]
-			}
+			r, n, _ := parseImageName(repoTag)
+			repoTag = toImageName(r, n, "")
 		}
-		if repoTag == name {
+		if repoTag == imageName {
 			return true
 		}
 	}

--- a/cluster/image.go
+++ b/cluster/image.go
@@ -21,18 +21,31 @@ func (image *Image) Match(IDOrName string, matchTag bool) bool {
 		return true
 	}
 
+	repo := ""
 	name := IDOrName
+	if strings.Contains(IDOrName, "/") {
+		parts := strings.SplitN(IDOrName, "/", 2)
+		repo = parts[0] + "/"
+		name = parts[1]
+	}
 	if matchTag {
-		if len(strings.SplitN(IDOrName, ":", 2)) == 1 {
-			name = IDOrName + ":latest"
+		if len(strings.SplitN(name, ":", 2)) == 1 {
+			name = repo + name + ":latest"
+		} else {
+			name = repo + name
 		}
 	} else {
-		name = strings.SplitN(IDOrName, ":", 2)[0]
+		name = repo + strings.SplitN(name, ":", 2)[0]
 	}
 
 	for _, repoTag := range image.RepoTags {
 		if matchTag == false {
-			repoTag = strings.SplitN(repoTag, ":", 2)[0]
+			if strings.Contains(repoTag, "/") {
+				parts := strings.SplitN(repoTag, "/", 2)
+				repoTag = parts[0] + "/" + strings.SplitN(parts[1], ":", 2)[0]
+			} else {
+				repoTag = strings.SplitN(repoTag, ":", 2)[0]
+			}
 		}
 		if repoTag == name {
 			return true

--- a/cluster/image_test.go
+++ b/cluster/image_test.go
@@ -32,3 +32,19 @@ func TestMatch(t *testing.T) {
 	assert.False(t, img.Match("nam", false))
 	assert.False(t, img.Match("na", false))
 }
+
+func TestMatchPrivateRepo(t *testing.T) {
+	img := Image{}
+
+	img.Id = "378954456789"
+	img.RepoTags = []string{"private.registry.com:5000/name:latest"}
+
+	assert.True(t, img.Match("private.registry.com:5000/name:latest", true))
+	assert.True(t, img.Match("private.registry.com:5000/name", true))
+	assert.False(t, img.Match("private.registry.com:5000/nam", true))
+	assert.False(t, img.Match("private.registry.com:5000/na", true))
+
+	assert.True(t, img.Match("private.registry.com:5000/name", false))
+	assert.False(t, img.Match("private.registry.com:5000/nam", false))
+	assert.False(t, img.Match("private.registry.com:5000/na", false))
+}

--- a/cluster/image_test.go
+++ b/cluster/image_test.go
@@ -33,6 +33,35 @@ func TestMatch(t *testing.T) {
 	assert.False(t, img.Match("na", false))
 }
 
+func TestParseImage(t *testing.T) {
+	repo, name, tag := parseImageName("private.registry.com:5000/name:latest")
+	assert.Equal(t, repo, "private.registry.com:5000")
+	assert.Equal(t, name, "name")
+	assert.Equal(t, tag, "latest")
+
+	repo, name, tag = parseImageName("name:latest")
+	assert.Equal(t, repo, "")
+	assert.Equal(t, name, "name")
+	assert.Equal(t, tag, "latest")
+
+	repo, name, tag = parseImageName("name")
+	assert.Equal(t, repo, "")
+	assert.Equal(t, name, "name")
+	assert.Equal(t, tag, "")
+
+	repo, name, tag = parseImageName("")
+	assert.Equal(t, repo, "")
+	assert.Equal(t, name, "")
+	assert.Equal(t, tag, "")
+}
+
+func TestToImage(t *testing.T) {
+	assert.Equal(t, toImageName("", "name", ""), "name")
+	assert.Equal(t, toImageName("", "name", "latest"), "name:latest")
+	assert.Equal(t, toImageName("a", "name", ""), "a/name")
+	assert.Equal(t, toImageName("private.registry.com:5000", "name", "latest"), "private.registry.com:5000/name:latest")
+}
+
 func TestMatchPrivateRepo(t *testing.T) {
 	img := Image{}
 


### PR DESCRIPTION
This PR fixes (issue #876) image matching in case of image name containing a private repository path, like:
```
private.repo.com:5000/name:latest
```

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>