### PR TITLE
store: Fix CAS returning ErrKeyModified because of Lock in Consul

### DIFF
--- a/pkg/store/consul.go
+++ b/pkg/store/consul.go
@@ -125,6 +125,7 @@ func (s *Consul) normalize(key string) string {
 // to use in conjunction to CAS calls
 func (s *Consul) Get(key string) (*KVPair, error) {
 	options := &api.QueryOptions{
+		AllowStale:        false,
 		RequireConsistent: true,
 	}
 	pair, meta, err := s.client.KV().Get(s.normalize(key), options)


### PR DESCRIPTION
Fixes #875 

I removed the lock and enforced the *consistency* parameter for the `Get` operation. This is to make sure that we get back the last value and index for the `Get` during a CAS operation. Now I'm not sure if we enforce it for every `Get` or just the one in the `CAS` (this is part of a larger question: should we ensure a strong consistency for every store supported in the *lib* if possible, or offer the choice of consistency in `Options`? etc.)

Signed-off-by: Alexandre Beslic <abronan@docker.com>