### PR TITLE
add images to docker info

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -26,11 +26,13 @@ const APIVERSION = "1.16"
 func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 	info := struct {
 		Containers      int
+		Images          int
 		DriverStatus    [][2]string
 		NEventsListener int
 		Debug           bool
 	}{
 		len(c.cluster.Containers()),
+		len(c.cluster.Images()),
 		c.cluster.Info(),
 		c.eventsHandler.Size(),
 		c.debug,


### PR DESCRIPTION
docker1.7-rc1 info against a swarm cluster is kinda broken,
https://github.com/docker/docker/pull/13607 will fix most of the issue for docker1.7-rc2

Although, the `Images:` field isn't optional anymore so we need tu return it.