### PR TITLE
fix panic is disconnect

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -112,7 +112,8 @@ func (e *Engine) ConnectWithClient(client dockerclient.Client) error {
 // Disconnect will stop all monitoring of the engine.
 // The Engine object cannot be further used without reconnecting it first.
 func (e *Engine) Disconnect() {
-	close(e.stopCh)
+	// do not close the chan, so it wait until the refreshLoop goroutine stops
+	e.stopCh <- struct{}{}
 	e.client.StopAllMonitorEvents()
 	e.client = nil
 	e.emitEvent("engine_disconnect")


### PR DESCRIPTION
this PR fix a bug in the disconnect that can lead to a panic (I can reproduce easily)

If we close the `stopCh` while the `refreshLoop` goroutine is not in the `select` it's going to panic, because we set the engine to nil and the refreshImages/refreshContainers uses the engine.

We need to wait on the goroutine the finish before setting the client to nil.

close #836