### PR TITLE
pretty print mesos offers

### DIFF
--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -259,18 +259,6 @@ func (c *Cluster) RenameContainer(container *cluster.Container, newName string) 
 	return nil
 }
 
-func scalarResourceValue(offers map[string]*mesosproto.Offer, name string) float64 {
-	var value float64
-	for _, offer := range offers {
-		for _, resource := range offer.Resources {
-			if *resource.Name == name {
-				value += *resource.Scalar.Value
-			}
-		}
-	}
-	return value
-}
-
 // listNodes returns all the nodess in the cluster.
 func (c *Cluster) listNodes() []*node.Node {
 	c.RLock()
@@ -280,9 +268,9 @@ func (c *Cluster) listNodes() []*node.Node {
 	for _, s := range c.slaves {
 		n := node.NewNode(s.engine)
 		n.ID = s.id
-		n.TotalCpus = int64(scalarResourceValue(s.offers, "cpus"))
+		n.TotalCpus = int64(sumScalarResourceValue(s.offers, "cpus"))
 		n.UsedCpus = 0
-		n.TotalMemory = int64(scalarResourceValue(s.offers, "mem")) * 1024 * 1024
+		n.TotalMemory = int64(sumScalarResourceValue(s.offers, "mem")) * 1024 * 1024
 		n.UsedMemory = 0
 		out = append(out, n)
 	}
@@ -328,7 +316,7 @@ func (c *Cluster) Info() [][]string {
 	for _, offer := range offers {
 		info = append(info, []string{" Offer", offer.Id.GetValue()})
 		for _, resource := range offer.Resources {
-			info = append(info, []string{"  └ " + *resource.Name, fmt.Sprintf("%v", resource)})
+			info = append(info, []string{"  └ " + resource.GetName(), formatResource(resource)})
 		}
 	}
 

--- a/cluster/mesos/utils.go
+++ b/cluster/mesos/utils.go
@@ -1,0 +1,39 @@
+package mesos
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/pkg/units"
+	"github.com/mesos/mesos-go/mesosproto"
+)
+
+func formatResource(resource *mesosproto.Resource) string {
+	switch resource.GetType() {
+	case mesosproto.Value_SCALAR:
+		if resource.GetName() == "disk" || resource.GetName() == "mem" {
+			return units.BytesSize(resource.GetScalar().GetValue() * 1024 * 1024)
+		}
+		return fmt.Sprintf("%d", int(resource.GetScalar().GetValue()))
+
+	case mesosproto.Value_RANGES:
+		var ranges []string
+		for _, r := range resource.GetRanges().GetRange() {
+			ranges = append(ranges, fmt.Sprintf("%d-%d", r.GetBegin(), r.GetEnd()))
+		}
+		return strings.Join(ranges, ", ")
+	}
+	return "?"
+}
+
+func sumScalarResourceValue(offers map[string]*mesosproto.Offer, name string) float64 {
+	var value float64
+	for _, offer := range offers {
+		for _, resource := range offer.Resources {
+			if *resource.Name == name {
+				value += *resource.Scalar.Value
+			}
+		}
+	}
+	return value
+}


### PR DESCRIPTION
from

```
Containers: 0
Images: 12
Strategy: spread
Filters: affinity, health, constraint, port, dependency
Offers: 3
  Offer: 20150609-222929-1327399946-5050-14390-O5970
   └ cpus: &Resource{Name:*cpus,Type:*SCALAR,Scalar:&Value_Scalar{Value:*2,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ mem: &Resource{Name:*mem,Type:*SCALAR,Scalar:&Value_Scalar{Value:*1006,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ disk: &Resource{Name:*disk,Type:*SCALAR,Scalar:&Value_Scalar{Value:*35195,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ ports: &Resource{Name:*ports,Type:*RANGES,Scalar:nil,Ranges:&Value_Ranges{Range:[&Value_Range{Begin:*31000,End:*32000,XXX_unrecognized:[],}],XXX_unrecognized:[],},Set:nil,Role:**,XXX_unrecognized:[],}
  Offer: 20150609-222929-1327399946-5050-14390-O5971
   └ cpus: &Resource{Name:*cpus,Type:*SCALAR,Scalar:&Value_Scalar{Value:*2,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ mem: &Resource{Name:*mem,Type:*SCALAR,Scalar:&Value_Scalar{Value:*1006,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ disk: &Resource{Name:*disk,Type:*SCALAR,Scalar:&Value_Scalar{Value:*35195,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ ports: &Resource{Name:*ports,Type:*RANGES,Scalar:nil,Ranges:&Value_Ranges{Range:[&Value_Range{Begin:*31000,End:*32000,XXX_unrecognized:[],}],XXX_unrecognized:[],},Set:nil,Role:**,XXX_unrecognized:[],}
  Offer: 20150609-222929-1327399946-5050-14390-O5972
   └ cpus: &Resource{Name:*cpus,Type:*SCALAR,Scalar:&Value_Scalar{Value:*2,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ mem: &Resource{Name:*mem,Type:*SCALAR,Scalar:&Value_Scalar{Value:*1006,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ disk: &Resource{Name:*disk,Type:*SCALAR,Scalar:&Value_Scalar{Value:*35195,XXX_unrecognized:[],},Ranges:nil,Set:nil,Role:**,XXX_unrecognized:[],}
   └ ports: &Resource{Name:*ports,Type:*RANGES,Scalar:nil,Ranges:&Value_Ranges{Range:[&Value_Range{Begin:*31000,End:*32000,XXX_unrecognized:[],}],XXX_unrecognized:[],},Set:nil,Role:**,XXX_unrecognized:[],}
```

to

```
Containers: 0
Images: 12
Strategy: spread
Filters: affinity, health, constraint, port, dependency
Offers: 3
  Offer: 20150609-222929-1327399946-5050-14390-O6286
   └ cpus: 2
   └ mem: 1006 MiB
   └ disk: 34.37 GiB
   └ ports: 31000-32000
  Offer: 20150609-222929-1327399946-5050-14390-O6287
   └ cpus: 2
   └ mem: 1006 MiB
   └ disk: 34.37 GiB
   └ ports: 31000-32000
  Offer: 20150609-222929-1327399946-5050-14390-O6288
   └ cpus: 2
   └ mem: 1006 MiB
   └ disk: 34.37 GiB
   └ ports: 31000-32000
```