### PR TITLE
fix the panic when docker event emitted after engine removal (#836)

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -26,12 +26,13 @@ const (
 // NewEngine is exported
 func NewEngine(addr string, overcommitRatio float64) *Engine {
 	e := &Engine{
-		Addr:            addr,
-		Labels:          make(map[string]string),
-		stopCh:          make(chan struct{}),
-		containers:      make(map[string]*Container),
-		healthy:         true,
-		overcommitRatio: int64(overcommitRatio * 100),
+		Addr:                addr,
+		Labels:              make(map[string]string),
+		stopCh:              make(chan struct{}),
+		containers:          make(map[string]*Container),
+		healthy:             true,
+		overcommitRatio:     int64(overcommitRatio * 100),
+		stopMonitorEventsCh: make(chan struct{}),
 	}
 	return e
 }
@@ -48,13 +49,14 @@ type Engine struct {
 	Memory int64
 	Labels map[string]string
 
-	stopCh          chan struct{}
-	containers      map[string]*Container
-	images          []*Image
-	client          dockerclient.Client
-	eventHandler    EventHandler
-	healthy         bool
-	overcommitRatio int64
+	stopCh              chan struct{}
+	containers          map[string]*Container
+	images              []*Image
+	client              dockerclient.Client
+	eventHandler        EventHandler
+	stopMonitorEventsCh chan struct{}
+	healthy             bool
+	overcommitRatio     int64
 }
 
 // Connect will initialize a connection to the Docker daemon running on the
@@ -104,10 +106,45 @@ func (e *Engine) ConnectWithClient(client dockerclient.Client) error {
 	go e.refreshLoop()
 
 	// Start monitoring events from the engine.
-	e.client.StartMonitorEvents(e.handler, nil)
+	go e.startMonitorEvents()
 	e.emitEvent("engine_connect")
 
 	return nil
+}
+
+func (e *Engine) startMonitorEvents() {
+	stopCh := make(chan struct{})
+	ch, err := e.client.MonitorEvents(nil, stopCh)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"engine_id": e.ID,
+			"engine_ip": e.IP,
+		}).Warning("Start event monitor failed")
+		e.healthy = false
+		return
+	}
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Error == nil {
+				go e.handler(&ev.Event)
+			} else {
+				log.WithFields(log.Fields{
+					"engine_id": e.ID,
+					"engine_ip": e.IP,
+				}).Warning("Receive event failed: ", ev.Error)
+				// Perhaps we can set e.healthy = false here?
+				return
+			}
+		case <-e.stopMonitorEventsCh:
+			stopCh <- struct{}{}
+			return
+		}
+	}
+}
+
+func (e *Engine) stopMonitorEvents() {
+	e.stopMonitorEventsCh <- struct{}{}
 }
 
 // Disconnect will stop all monitoring of the engine.
@@ -115,7 +152,7 @@ func (e *Engine) ConnectWithClient(client dockerclient.Client) error {
 func (e *Engine) Disconnect() {
 	// do not close the chan, so it wait until the refreshLoop goroutine stops
 	e.stopCh <- struct{}{}
-	e.client.StopAllMonitorEvents()
+	e.stopMonitorEvents()
 	e.client = nil
 	e.emitEvent("engine_disconnect")
 }
@@ -306,8 +343,8 @@ func (e *Engine) refreshLoop() {
 		} else {
 			if !e.healthy {
 				log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Info("Engine came back to life. Hooray!")
-				e.client.StopAllMonitorEvents()
-				e.client.StartMonitorEvents(e.handler, nil)
+				e.stopMonitorEvents()
+				go e.startMonitorEvents()
 				e.emitEvent("engine_reconnect")
 				if err := e.updateSpecs(); err != nil {
 					log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Update engine specs failed: %v", err)
@@ -513,7 +550,7 @@ func (e *Engine) String() string {
 	return fmt.Sprintf("engine %s addr %s", e.ID, e.Addr)
 }
 
-func (e *Engine) handler(ev *dockerclient.Event, _ chan error, args ...interface{}) {
+func (e *Engine) handler(ev *dockerclient.Event) {
 	// Something changed - refresh our internal state.
 	switch ev.Status {
 	case "pull", "untag", "delete":

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/test/utils"
 	"github.com/samalba/dockerclient"
 	"github.com/samalba/dockerclient/mockclient"
 	"github.com/stretchr/testify/assert"
@@ -119,7 +120,7 @@ func TestImportImage(t *testing.T) {
 	// create mock client
 	client := mockclient.NewMockClient()
 	client.On("Info").Return(mockInfo, nil)
-	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
+	utils.NewMockEvent(client, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages").Return([]*dockerclient.Image{}, nil)
 
@@ -166,8 +167,8 @@ func TestLoadImage(t *testing.T) {
 	// create mock client
 	client := mockclient.NewMockClient()
 	client.On("Info").Return(mockInfo, nil)
-	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
+	utils.NewMockEvent(client, nil)
 	client.On("ListImages").Return([]*dockerclient.Image{}, nil)
 
 	// connect client

--- a/test/utils/mock_event.go
+++ b/test/utils/mock_event.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"github.com/samalba/dockerclient"
+	"github.com/samalba/dockerclient/mockclient"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockEvent mock a docker event emitter for testing.
+type MockEvent struct {
+	retCh  chan dockerclient.EventOrError
+	buf    chan dockerclient.EventOrError
+	stopCh chan struct{}
+}
+
+// NewMockEvent create a new instance of MockEvent and stub MonitorEvents API.
+func NewMockEvent(client *mockclient.MockClient, stopCh chan struct{}) *MockEvent {
+	m := &MockEvent{
+		retCh:  make(chan dockerclient.EventOrError),
+		buf:    make(chan dockerclient.EventOrError),
+		stopCh: stopCh,
+	}
+	func(ret <-chan dockerclient.EventOrError) {
+		client.On("MonitorEvents", mock.Anything, mock.Anything).Return(ret, nil)
+	}(m.retCh)
+	go m.dispatchEvents()
+	return m
+}
+
+// Emit an event for testing.
+func (m *MockEvent) Emit(ev dockerclient.EventOrError) {
+	m.buf <- ev
+}
+
+func (m *MockEvent) dispatchEvents() {
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case m.retCh <- <-m.buf:
+		}
+	}
+}


### PR DESCRIPTION
I think #836  should be reopen because #897 didn't really fix the panic.
The problem can still be reproduced by
```
docker run -itd --name=test busybox sh
echo 127.0.0.1:2375 >/tmp/discovery.txt
./swarm m -H :8888 file:///tmp/discovery.txt &
sleep 5
echo >/tmp/discovery.txt
sleep 60
docker rm -f test
```
 
This panic is caused by the event monitor. When calling `StopAllMonitorEvents`, dockerclient just set `client.monitorEvents` to 0, but this doesn't prevent the json decoder from decoding new events.
When new events are emitted after engine removal, the event will be passed to `engine.handler` as usual. But at this time the `e.client` is set to nil by `engine.Disconnect`, so the panic happens.

This PR leverages the `MonitorEvents` API of dockerclient, which accepts a `stopChan`. When the stopChan is readable, new events won't be returned to the calling procedure any more. 

Signed-off-by: Shijiang Wei <mountkin@gmail.com>