### PR TITLE
Fix types for store.Backend list

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -15,11 +15,11 @@ const (
 	// MOCK backend
 	MOCK Backend = "mock"
 	// CONSUL backend
-	CONSUL = "consul"
+	CONSUL Backend = "consul"
 	// ETCD backend
-	ETCD = "etcd"
+	ETCD Backend = "etcd"
 	// ZK backend
-	ZK = "zk"
+	ZK Backend = "zk"
 )
 
 var (


### PR DESCRIPTION
Unless explicitly specified these consts will be of type `string`; not `Backend`: http://play.golang.org/p/AcP-8qFsii

Signed-off-by: Ahmet Alp Balkan