### PR TITLE
Add `$GOPATH/bin` setup export path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ go get github.com/tools/godep
 ```
 
 You may need to set `$GOPATH`, e.g `mkdir ~/gocode; export GOPATH=~/gocode`.
+You may also need to set `$GOPATH/bin` folder in your path environment, e.g `export PATH="${PATH}:${GOPATH}/bin"`
+
 
 **For example, on Mac OS X you'd run:**
 


### PR DESCRIPTION
I've seen that I also needed to set `$GOPATH/bin` folder in my Linux path environment, e.g `export PATH="${PATH}:${GOPATH}/bin"`
Otherwise the command godep go install . would not work properly.