### PR TITLE
scheduler/random: Use private instance of rand

### DIFF
--- a/scheduler/strategy/random.go
+++ b/scheduler/strategy/random.go
@@ -10,11 +10,13 @@ import (
 )
 
 // RandomPlacementStrategy randomly places the container into the cluster.
-type RandomPlacementStrategy struct{}
+type RandomPlacementStrategy struct {
+	r *rand.Rand
+}
 
 // Initialize is exported
 func (p *RandomPlacementStrategy) Initialize() error {
-	rand.Seed(time.Now().UTC().UnixNano())
+	p.r = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	return nil
 }
 
@@ -26,7 +28,7 @@ func (p *RandomPlacementStrategy) Name() string {
 // PlaceContainer is exported
 func (p *RandomPlacementStrategy) PlaceContainer(config *cluster.ContainerConfig, nodes []*node.Node) (*node.Node, error) {
 	if size := len(nodes); size > 0 {
-		return nodes[rand.Intn(size)], nil
+		return nodes[p.r.Intn(size)], nil
 	}
 
 	return nil, errors.New("No nodes running in the cluster")


### PR DESCRIPTION
This does not pollute the global rand instance. It's good for
predictability and determinism in the tests and behavior. Reduces
program state laying outside the swarm code.

Signed-off-by: Ahmet Alp Balkan