### PR TITLE
defer RUnlock in swarm/cluster#Pull()

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -303,6 +303,7 @@ func (c *Cluster) Pull(name string, authConfig *dockerclient.AuthConfig, callbac
 	var wg sync.WaitGroup
 
 	c.RLock()
+	defer c.RUnlock()
 	for _, n := range c.engines {
 		wg.Add(1)
 
@@ -322,7 +323,6 @@ func (c *Cluster) Pull(name string, authConfig *dockerclient.AuthConfig, callbac
 			}
 		}(n)
 	}
-	c.RUnlock()
 
 	wg.Wait()
 }


### PR DESCRIPTION
I'm not sure about the correctness of this one. Actually the Pull mutates the nodes' states as well, so I'm not sure if this should be a reader lock either. Any ideas @vieux ?

Signed-off-by: Ahmet Alp Balkan