### PR TITLE
606- Prevent panic if a container is removed during a refresh

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -209,9 +209,11 @@ func (e *Engine) RefreshContainers(full bool) error {
 
 	merged := make(map[string]*Container)
 	for _, c := range containers {
-		merged, err = e.updateContainer(c, merged, full)
+		mergedUpdate, err := e.updateContainer(c, merged, full)
 		if err != nil {
-			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Unable to update state of container %q", c.Id)
+			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Unable to update state of container %q: %v", c.Id, err)
+		} else {
+			merged = mergedUpdate
 		}
 	}
 


### PR DESCRIPTION
Hi, we ran into issue #606 and decided to investigate.  Here is a proposed change and unit test for the issue.

As stated in #606, this can be reproduced when containers are being removed.
