### PR TITLE
disable mesos tests because mesos is incompatible with the next version of docker

### DIFF
--- a/test/integration/test_runner.sh
+++ b/test/integration/test_runner.sh
@@ -12,7 +12,7 @@ function execute() {
 }
 
 # Tests to run. Defaults to all.
-TESTS=${@:-. discovery api mesos}
+TESTS=${@:-. discovery api } #mesos
 
 # Generate a temporary binary for the tests.
 export SWARM_BINARY=`mktemp`


### PR DESCRIPTION
The output of docker version changed recently.

From:

```
$ docker-ok version
Client version: 1.8.0-dev
Client API version: 1.20
Go version (client): go1.4.2
Git commit (client): f39b9a0
OS/Arch (client): linux/amd64
Experimental (client): true
Server version: 1.8.0-dev
Server API version: 1.20
Go version (server): go1.4.2
Git commit (server): 77396bd-dirty
OS/Arch (server): linux/amd64
```

To:

```
Client:
 Version:      1.8.0-dev
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   77396bd-dirty
 Built:        Tue Jun 30 18:26:39 UTC 2015
 OS/Arch:      linux/amd64

Server:
 Version:      1.8.0-dev
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   77396bd-dirty
 Built:        Tue Jun 30 18:26:39 UTC 2015
 OS/Arch:      linux/amd64

```

When Mesos starts, it tries to parse the cli out, looking for `Client version` therefore, refuses to start with the next version of docker.