### PR TITLE
Fix storage integration tests

### DIFF
--- a/discovery/kv/kv.go
+++ b/discovery/kv/kv.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	discoveryPath           = "docker/swarm/nodes"
-	defaultFailoverWaitTime = 10 * time.Second
+	discoveryPath = "docker/swarm/nodes"
 )
 
 // Discovery is exported
@@ -124,7 +123,7 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 			// If we get here it means the store watch channel was closed. This
 			// is unexpected so let's retry later.
 			errCh <- fmt.Errorf("Unexpected watch error")
-			time.Sleep(defaultFailoverWaitTime)
+			time.Sleep(s.heartbeat)
 		}
 	}()
 	return ch, errCh


### PR DESCRIPTION
Fix the storage integration tests on Jenkins.

Those were relying on the `--heartbeat` flag for the store failover test. The PR reverts to using `--heartbeat` until we find a proper flag structure for the leader election timeout and the store failover wait time.

Signed-off-by: Alexandre Beslic <abronan@docker.com>