### PR TITLE
update libkv godeps, fix zookeeper discovery list

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -52,7 +52,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libkv",
-			"Rev": "82ad407bbfaf1ef435a2ebabc498a9afb128ed37"
+			"Rev": "057813e38a46ee5951b1fc33f6f749f7cfce2941"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -153,10 +153,7 @@ func CreateEntries(addrs []string) (Entries, error) {
 	}
 
 	for _, addr := range addrs {
-		// Check if addr is non empty and valid,
-		// FIXME <= 1 because zookeeper may wrongfully
-		// return a separator character (SOH)
-		if len(addr) <= 1 {
+		if len(addr) == 0 {
 			continue
 		}
 		entry, err := NewEntry(addr)


### PR DESCRIPTION
fixes #974 

The only way to get rid of this code in libkv would be in `go-zookeeper` to:

- Investigate and fix the issue with `Get` returning a control character instead of the actual value
- Use `Multi` operations with Get to have a proper `List` implementation in `libkv`

In the meantime the PR fixes the linked issue so we can add and remove nodes properly using zookeeper..

Signed-off-by: Alexandre Beslic <abronan@docker.com>