### PR TITLE
Fix the slave registry failed

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -105,7 +105,7 @@
 		},
 		{
 			"ImportPath": "github.com/samalba/dockerclient",
-			"Rev": "3342e9407a459d3cb369a81f8aa23b6cbe3fa8da"
+			"Rev": "a78609286676d55688dcedf8a90522bc7d1bd569"
 		},
 		{
 			"ImportPath": "github.com/samuel/go-zookeeper/zk",

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/types.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/types.go
@@ -297,7 +297,7 @@ type Info struct {
 	Debug              interface{}
 	NFd                int64
 	NGoroutines        int64
-	SystemTime         time.Time
+	SystemTime         string
 	NEventsListener    int64
 	InitPath           string
 	InitSha1           string

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	dockerfilters "github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/swarm/cluster"
@@ -41,6 +42,7 @@ func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 		HttpProxy:         os.Getenv("http_proxy"),
 		HttpsProxy:        os.Getenv("https_proxy"),
 		NoProxy:           os.Getenv("no_proxy"),
+		SystemTime:        time.Now().Format(time.RFC3339Nano),
 	}
 
 	if hostname, err := os.Hostname(); err == nil {


### PR DESCRIPTION
When using the file discovery method, if a slave address failed to registry itself when the scanning the configuration file at the first time (maybe the slave's docker service donot start), the slave will not be registry itself again, even if the slave's docker service started, unless remove the slave's address from the configuration file and add it again.

So, I changed the "addEngine" function, appending a return parameter "cluster.Engine", when the parameter is null, delegating the engine registered failed, and I add a function to loop to registry it every 30s, until it registry successfully.

Signed-off-by: Tingyi Hao haotingyi13@otcaix.iscas.ac.cn