### PR TITLE
add leader-path-prefix flag

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -25,7 +25,7 @@ var (
 				flStore,
 				flStrategy, flFilter,
 				flHosts,
-				flLeaderElection, flManageAdvertise,
+				flLeaderElection, flManageAdvertise, flLeaderPathPrefix,
 				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
 				flHeartBeat,
 				flEnableCors,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -122,4 +122,10 @@ var (
 		Name:  "replication",
 		Usage: "Enable Swarm manager replication",
 	}
+
+	flLeaderPathPrefix = cli.StringFlag{
+		Name:  "leader-path-prefix",
+		Usage: "Leader election path's prefix, leader addr will be set into <prefix>/docker/swarm/leader",
+		Value: "",
+	}
 )


### PR DESCRIPTION
#1037 

add new flag `--leader-path-prefix` to add prefix to leader-election-path. 

- empty by default, leader election will use `docker/swarm/leader` as before

- if set `--leader-path-prefix="/mycluster"`, will use `/mycluster/docker/swarm/leader`