### PR TITLE
preserve status code from POST /containers/*/exec

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -494,6 +494,7 @@ func postContainersExec(c *context, w http.ResponseWriter, r *http.Request) {
 	container.Info.ExecIDs = append(container.Info.ExecIDs, id.ID)
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
 	w.Write(data)
 }
 


### PR DESCRIPTION
The docker remote API specifies that a 201 is returned on successful
creation of an Exec and a strict client will not accept that being
turned into a 200.

https://docs.docker.com/reference/api/docker_remote_api_v1.19/#exec-create

Resolves #1055