### PR TITLE
Update Github links to point to docker/swarm

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Docker Swarm is native clustering for Docker. It allows you create and access to
 a pool of Docker hosts using the full suite of Docker tools. Because Docker
 Swarm serves the standard Docker API, any tool that already communicates with a
 Docker daemon can use Swarm to transparently scale to multiple hosts. Supported
-tools include, but are not  limited to, the following: 
+tools include, but are not limited to, the following:
 
 - Dokku
 - Docker Compose
@@ -43,7 +43,7 @@ As a starting point, the manual method is best suited for experienced administra
 
 Using Docker Machine, you can quickly install a Docker Swarm on cloud providers or inside your own data center. If you have VirtualBox installed on your local machine, you can quickly build and explore Docker Swarm in your local environment. This method automatically generates a certificate to secure your swarm.
 
-Using Docker Machine is the best method for users getting started with Swarm for the first time. To try the recommended method of getting started, see [Get Started with Docker Swarm](install-w-machine.md). 
+Using Docker Machine is the best method for users getting started with Swarm for the first time. To try the recommended method of getting started, see [Get Started with Docker Swarm](install-w-machine.md).
 
 If you are interested manually installing or interested in contributing, see [Create a swarm for development](install-manual.md).
 
@@ -70,10 +70,10 @@ Docker Swarm is still in its infancy and under active development. If you need
 help, would like to contribute, or simply want to talk about the project with
 like-minded individuals, we have a number of open channels for communication.
 
-* To report bugs or file feature requests: please use the [issue tracker on Github](https://github.com/docker/machine/issues).
+* To report bugs or file feature requests: please use the [issue tracker on Github](https://github.com/docker/swarm/issues).
 
 * To talk about the project with people in real time: please join the `#docker-swarm` channel on IRC.
 
-* To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/machine/pulls).
+* To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/swarm/pulls).
 
 For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/project/get-help/).


### PR DESCRIPTION
Update issues and pull requests links to point to docker/swarm instead of docker/machine. Also, a couple of whitespace fixes.

Hopefully I'm not supposed to take the existing docs literally and open this PR on machine. :)

Signed-off-by: Peggy Li <peggyli.224@gmail.com>