### PR TITLE
Leadership: Fault tolerant Leader Election mechanism

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -52,7 +52,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libkv",
-			"Rev": "057813e38a46ee5951b1fc33f6f749f7cfce2941"
+			"Rev": "261ee167337a70a244e30410080685843b22e184"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/store.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/store.go
@@ -107,10 +107,6 @@ type LockOptions struct {
 	TTL   time.Duration // Optional, expiration ttl associated with the lock
 }
 
-// WatchCallback is used for watch methods on keys
-// and is triggered on key change
-type WatchCallback func(entries ...*KVPair)
-
 // Locker provides locking mechanism on top of the store.
 // Similar to `sync.Lock` except it may return errors.
 type Locker interface {

--- a/Godeps/_workspace/src/github.com/docker/libkv/testutils/utils.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/testutils/utils.go
@@ -288,6 +288,11 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	err = lock.Unlock()
 	assert.NoError(t, err)
 
+	// Lock should succeed again
+	lockChan, err = lock.Lock()
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
+
 	// Get should work
 	pair, err = kv.Get(key)
 	assert.NoError(t, err)

--- a/leadership/README.md
+++ b/leadership/README.md
@@ -16,9 +16,8 @@ if err != nil {
 }
 
 underwood := leadership.NewCandidate(client, "service/swarm/leader", "underwood")
-underwood.RunForElection()
+electedCh, _ := underwood.RunForElection()
 
-electedCh := underwood.ElectedCh()
 for isElected := range electedCh {
 	// This loop will run every time there is a change in our leadership
 	// status.
@@ -47,8 +46,7 @@ It is possible to follow an election in real-time and get notified whenever
 there is a change in leadership:
 ```go
 follower := leadership.NewFollower(client, "service/swarm/leader")
-follower.FollowElection()
-leaderCh := follower.LeaderCh()
+leaderCh, _ := follower.FollowElection()
 for leader := <-leaderCh {
 	// Leader is a string containing the value passed to `NewCandidate`.
 	log.Printf("%s is now the leader", leader)
@@ -57,3 +55,47 @@ for leader := <-leaderCh {
 
 A typical use case for this is to be able to always send requests to the current
 leader.
+
+## Fault tolerance
+
+Leadership returns an error channel for Candidates and Followers that you can use
+to be resilient to failures. For example, if the watch on the leader key fails
+because the store becomes unavailable, you can retry the process later.
+
+```go
+func participate() {
+    // Create a store using pkg/store.
+    client, err := store.NewStore("consul", []string{"127.0.0.1:8500"}, &store.Config{})
+    if err != nil {
+        panic(err)
+    }
+
+    waitTime := 10 * time.Second
+    underwood := leadership.NewCandidate(client, "service/swarm/leader", "underwood")
+
+    go func() {
+        for {
+            run(underwood)
+            time.Sleep(waitTime)
+            // retry
+        }
+    }
+}
+
+func run(candidate *leadership.Candidate) {
+    electedCh, errCh := candidate.RunForElection()
+    for {
+        select {
+            case elected := <-electedCh:
+            if isElected {
+                // Do something
+            } else {
+                // Do something else
+            }
+
+            case err := <-errCh:
+                log.Error(err)
+                return
+    }
+}
+```

--- a/leadership/candidate.go
+++ b/leadership/candidate.go
@@ -3,7 +3,6 @@ package leadership
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 )
 
@@ -18,6 +17,7 @@ type Candidate struct {
 	leader    bool
 	stopCh    chan struct{}
 	resignCh  chan bool
+	errCh     chan error
 }
 
 // NewCandidate creates a new Candidate
@@ -27,18 +27,10 @@ func NewCandidate(client store.Store, key, node string) *Candidate {
 		key:    key,
 		node:   node,
 
-		electedCh: make(chan bool),
-		leader:    false,
-		resignCh:  make(chan bool),
-		stopCh:    make(chan struct{}),
+		leader:   false,
+		resignCh: make(chan bool),
+		stopCh:   make(chan struct{}),
 	}
-}
-
-// ElectedCh is used to get a channel which delivers signals on
-// acquiring or losing leadership. It sends true if we become
-// the leader, and false if we lose it.
-func (c *Candidate) ElectedCh() <-chan bool {
-	return c.electedCh
 }
 
 // IsLeader returns true if the candidate is currently a leader.
@@ -48,15 +40,23 @@ func (c *Candidate) IsLeader() bool {
 
 // RunForElection starts the leader election algorithm. Updates in status are
 // pushed through the ElectedCh channel.
-func (c *Candidate) RunForElection() error {
+//
+// ElectedCh is used to get a channel which delivers signals on
+// acquiring or losing leadership. It sends true if we become
+// the leader, and false if we lose it.
+func (c *Candidate) RunForElection() (<-chan bool, <-chan error) {
+	c.electedCh = make(chan bool)
+	c.errCh = make(chan error)
+
 	// Need a `SessionTTL` (keep-alive) and a stop channel.
 	lock, err := c.client.NewLock(c.key, &store.LockOptions{Value: []byte(c.node)})
 	if err != nil {
-		return err
+		c.errCh <- err
+	} else {
+		go c.campaign(lock)
 	}
 
-	go c.campaign(lock)
-	return nil
+	return c.electedCh, c.errCh
 }
 
 // Stop running for election.
@@ -87,6 +87,7 @@ func (c *Candidate) update(status bool) {
 
 func (c *Candidate) campaign(lock store.Locker) {
 	defer close(c.electedCh)
+	defer close(c.errCh)
 
 	for {
 		// Start as a follower.
@@ -94,7 +95,7 @@ func (c *Candidate) campaign(lock store.Locker) {
 
 		lostCh, err := lock.Lock()
 		if err != nil {
-			log.Error(err)
+			c.errCh <- err
 			return
 		}
 

--- a/leadership/follower.go
+++ b/leadership/follower.go
@@ -1,6 +1,10 @@
 package leadership
 
-import "github.com/docker/libkv/store"
+import (
+	"errors"
+
+	"github.com/docker/libkv/store"
+)
 
 // Follower can folow an election in real-time and push notifications whenever
 // there is a change in leadership.
@@ -11,22 +15,16 @@ type Follower struct {
 	leader   string
 	leaderCh chan string
 	stopCh   chan struct{}
+	errCh    chan error
 }
 
 // NewFollower creates a new follower.
 func NewFollower(client store.Store, key string) *Follower {
 	return &Follower{
-		client:   client,
-		key:      key,
-		leaderCh: make(chan string),
-		stopCh:   make(chan struct{}),
+		client: client,
+		key:    key,
+		stopCh: make(chan struct{}),
 	}
-}
-
-// LeaderCh is used to get a channel which delivers the currently elected
-// leader.
-func (f *Follower) LeaderCh() <-chan string {
-	return f.leaderCh
 }
 
 // Leader returns the current leader.
@@ -35,15 +33,18 @@ func (f *Follower) Leader() string {
 }
 
 // FollowElection starts monitoring the election.
-func (f *Follower) FollowElection() error {
+func (f *Follower) FollowElection() (<-chan string, <-chan error) {
+	f.leaderCh = make(chan string)
+	f.errCh = make(chan error)
+
 	ch, err := f.client.Watch(f.key, f.stopCh)
 	if err != nil {
-		return err
+		f.errCh <- err
+	} else {
+		go f.follow(ch)
 	}
 
-	go f.follow(ch)
-
-	return nil
+	return f.leaderCh, f.errCh
 }
 
 // Stop stops monitoring an election.
@@ -51,17 +52,15 @@ func (f *Follower) Stop() {
 	close(f.stopCh)
 }
 
-func (f *Follower) follow(<-chan *store.KVPair) {
+func (f *Follower) follow(ch <-chan *store.KVPair) {
 	defer close(f.leaderCh)
-
-	// FIXME: We should pass `RequireConsistent: true` to Consul.
-	ch, err := f.client.Watch(f.key, f.stopCh)
-	if err != nil {
-		return
-	}
+	defer close(f.errCh)
 
 	f.leader = ""
 	for kv := range ch {
+		if kv == nil {
+			continue
+		}
 		curr := string(kv.Value)
 		if curr == f.leader {
 			continue
@@ -69,4 +68,7 @@ func (f *Follower) follow(<-chan *store.KVPair) {
 		f.leader = curr
 		f.leaderCh <- f.leader
 	}
+
+	// Channel closed, we return an error
+	f.errCh <- errors.New("Leader Election: watch leader channel closed, the store may be unavailable...")
 }


### PR DESCRIPTION
Makes the leader Election process resilient to failures of the backend storage (on Consul and etcd, zookeeper already allowed that naturally by keeping the leader information) using an error channel.

Fixes #982 #983 #1025 

Signed-off-by: Alexandre Beslic <abronan@docker.com>