### PR TITLE
Avoid nil pointer dereference in (*Cluster).createContainer

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -425,11 +425,11 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool) (*
 	e.RLock()
 	defer e.RUnlock()
 
-	justCreated := e.containers[id]
-	if justCreated == nil {
+	container := e.containers[id]
+	if container == nil {
 		err = errors.New("Container created but refresh didn't report it back")
 	}
-	return justCreated, err
+	return container, err
 }
 
 // RemoveContainer a container from the engine.

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -425,7 +425,11 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool) (*
 	e.RLock()
 	defer e.RUnlock()
 
-	return e.containers[id], nil
+	justCreated := e.containers[id]
+	if justCreated == nil {
+		err = errors.New("Container created but refresh didn't report it back")
+	}
+	return justCreated, err
 }
 
 // RemoveContainer a container from the engine.

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -130,6 +130,10 @@ func (c *Cluster) createContainer(config *cluster.ContainerConfig, name string, 
 			return nil, err
 		}
 
+		if container == nil {
+			return nil, errors.New("Container created but refresh didn't report it back")
+		}
+
 		st := &state.RequestedState{
 			ID:     container.Id,
 			Name:   name,

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -130,10 +130,6 @@ func (c *Cluster) createContainer(config *cluster.ContainerConfig, name string, 
 			return nil, err
 		}
 
-		if container == nil {
-			return nil, errors.New("Container created but refresh didn't report it back")
-		}
-
 		st := &state.RequestedState{
 			ID:     container.Id,
 			Name:   name,


### PR DESCRIPTION
Swarm Engine.Create can return nil,nil when refresh fails due to a network hiccup. It causes a panic described by issue https://github.com/docker/swarm/issues/1081 .