### PR TITLE
Removing references to boot2docker

### DIFF
--- a/docs/install-w-machine.md
+++ b/docs/install-w-machine.md
@@ -40,11 +40,12 @@ you can create a swarm that is secured.
 1. List the machines on your system.
 
 		$ docker-machine ls
-		NAME   ACTIVE   DRIVER       STATE     URL                         SWARM
-		dev    *        virtualbox   Running   tcp://192.168.99.100:2376   
+		NAME         ACTIVE   DRIVER       STATE     URL                         SWARM
+		docker-vm    *        virtualbox   Running   tcp://192.168.99.100:2376   
 
-	This example was run a Mac OSX system with `boot2docker` installed. So, the
-		`dev` environment in the list represents the `boot2docker` machine.
+	This example was run a Mac OSX system. So, the `docker-vm` in the
+	list represents the VM created if you follow the Docker Toolbox installer
+	instructions. 
 
 2. Create a VirtualBox machine called `local` on your system.  
 


### PR DESCRIPTION
- Closes 1072
- Boot2docker installer is deprected for the Docker Toolbox installer
- the new vm created is called `docker-vm`

Signed-off-by: Mary Anthony <mary@docker.com>