### PR TITLE
fix load api

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -405,6 +405,8 @@ func postImagesCreate(c *context, w http.ResponseWriter, r *http.Request) {
 
 // POST /images/load
 func postImagesLoad(c *context, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 
 	// call cluster to load image on every node
 	wf := NewWriteFlusher(w)


### PR DESCRIPTION
Origin:
```
[root@localhost home]# docker -H 127.0.0.1:2222 load < import.bats
{"id":"localhost.localdomain","status":"Loading Image... : 500 Internal Server Error: Untar exit status 1 archive/tar: invalid tar header\n","progressDetail":{}}
```

Now:
```
[root@localhost home]# docker -H 127.0.0.1:2222 load < import.bats
localhost.localdomain: Loading Image... : 500 Internal Server Error: Untar exit status 1 archive/tar: invalid tar header
```


Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>