### PR TITLE
Enhance the README to install swarm from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,42 +21,51 @@ The goal is to provide a smooth out-of-the-box experience for simple use cases, 
 allow swapping in more powerful backends, like Mesos, for large scale production
 deployments.
 
-## Installation and documentation
+## Installation for Swarm Users
 
-Full documentation [is available here](http://docs.docker.com/swarm/).
+For installing swarm for using in your environment, use the Docker Swarm
+documentation on [docs.docker.com](http://docs.docker.com/swarm/).
 
-## Development installation
+## Installation for Swarm Developers
 
-You can download and install from source instead of using the Docker
-image. Ensure you have golang, godep and the git client installed.
+Developers should always download and install from source rather than
+using the Docker image.
 
-**For example, on Ubuntu you'd run:**
+### Prerequisites
+
+1. Beginning with Swarm 0.4 golang 1.4.x or later is required for building Swarm. 
+Refer to the [Go installation page](https://golang.org/doc/install#install)
+to download and install the golang 1.4.x or later package.
+> **Note**: On Ubuntu 14.04, the `apt-get` repositories install golang 1.2.1 version by
+> default. So, do not use `apt-get` but install golang 1.4.x manually using the
+> instructions provided on the Go site.
+
+2. Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+
+3. Install [godep](https://github.com/tools/godep).
+
+### Clone and build Swarm
+
+> **Note** `GOPATH` should be set when install godep in above step.
+
+Install the `swarm` binary in the `$GOPATH/bin` directory. An easy way to do this 
+is using the `go get` command.
 
 ```bash
-$ apt-get install golang git
-$ go get github.com/tools/godep
+$ go get github.com/docker/swarm
 ```
 
-You may need to set `$GOPATH`, e.g `mkdir ~/gocode; export GOPATH=~/gocode`.
-
-**For example, on Mac OS X you'd run:**
-
-```bash
-$ brew install go
-$ export GOPATH=~/go
-$ export PATH=$PATH:~/go/bin
-$ go get github.com/tools/godep
-```
-
-Then install the `swarm` binary:
+You can also do this manually using the following commands:
 
 ```bash
 $ mkdir -p $GOPATH/src/github.com/docker/
 $ cd $GOPATH/src/github.com/docker/
 $ git clone https://github.com/docker/swarm
 $ cd swarm
-$ godep go install .
+$ $GOPATH/bin/godep go install .
 ```
+
+Then you can find the swarm binary under `$GOPATH/bin`.
 
 From here, you can follow the instructions [in the main documentation](http://docs.docker.com/swarm/),
 replacing `docker run swarm` with just `swarm`.


### PR DESCRIPTION
The current steps to install swarm from source
does not work on Ubuntu 14.04, especially for a
swarm newer, it needs to spend plenty to time to
address this issue (unknown http.Client field 'Timeout'
in struct literal). Suggest to enhance those steps to make them can be followed easily.

Signed-off-by: James Wang Yong Qiao <jamesyongqiao@gmail.com>