### PR TITLE
improve usage for discovery

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -39,7 +39,7 @@ Arguments:
                    * etcd://<ip1>,<ip2>/<path>
                    * file://path/to/file
                    * zk://<ip1>,<ip2>/<path>
-                   * <ip1>,<ip2>{{end}}{{if .Flags}}
+                   * [nodes://]<ip1>,<ip2>{{end}}{{if .Flags}}
 
 Options:
    {{range .Flags}}{{.}}

--- a/discovery/nodes/nodes.go
+++ b/discovery/nodes/nodes.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -27,7 +28,7 @@ func (s *Discovery) Initialize(uris string, _ time.Duration, _ time.Duration) er
 		for _, ip := range discovery.Generate(input) {
 			entry, err := discovery.NewEntry(ip)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s, please check you are using the correct discovery (missing token:// ?)", err.Error())
 			}
 			s.entries = append(s.entries, entry)
 		}


### PR DESCRIPTION
fixes #951

I'm not in favor on enforcing `nodes://` I like the fact that it's optional, so I tried to update the error message.