### PR TITLE
Add @jimmyxian as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,4 @@
 Alexandre Beslic <abronan@docker.com> (@abronan)
 Andrea Luzzardi <al@docker.com> (@aluzzardi)
 Victor Vieux <vieux@docker.com> (@vieux)
+Xian Chaobo <xianchaobo@huawei.com> (@jimmyxian)


### PR DESCRIPTION
@jimmyxian has been one of our most active contributors since the inception of Swarm.

I'd like to welcome him as an official maintainer of the project!