### PR TITLE
bump version to 0.5.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// VERSION should be updated by hand at each release
-	VERSION = "0.4.0"
+	VERSION = "0.5.0-dev"
 
 	// GITCOMMIT will be overwritten automatically by the build system
 	GITCOMMIT = "HEAD"


### PR DESCRIPTION
This PR fixes #1153 to support versioning scheme that switches between `release` (version containing only digits) and `-dev` (development versions).

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>