### PR TITLE
Implement grouping list of images by Id

### DIFF
--- a/test/integration/api/images.bats
+++ b/test/integration/api/images.bats
@@ -14,16 +14,15 @@ function teardown() {
 	start_docker_with_busybox 2
 	swarm_manage
 
-
-	# we should get 2 busyboxes, plus the header.
+	# With grouping, we should get 1 busybox, plus the header.
 	run docker_swarm images
 	[ "$status" -eq 0 ]
-	[ "${#lines[@]}" -eq 3 ]
+	[ "${#lines[@]}" -eq 2 ]
 	# Every line should contain "busybox" except for the header
 	for((i=1; i<${#lines[@]}; i++)); do
 		[[ "${lines[i]}" == *"busybox"* ]]
 	done
-	
+
 	# Try with --filter.
 	run docker_swarm images --filter node=node-0
 	[ "$status" -eq 0 ]
@@ -40,6 +39,7 @@ function teardown() {
 	[[ "${lines[1]}" == *"busybox"* ]]
 
 	# Try images -a
+	# lines are: header, busybox, <none>, <none>
 	run docker_swarm images -a
-	[ "${#lines[@]}" -ge 5 ]
+	[ "${#lines[@]}" -ge 4 ]
 }

--- a/test/integration/api/pull.bats
+++ b/test/integration/api/pull.bats
@@ -18,11 +18,11 @@ function teardown() {
 
 	docker_swarm pull busybox
 
-	# we should get 2 busyboxes, plus the header.
+	# with grouping, we should get 1 busybox, plus the header.
 	run docker_swarm images
 	[ "$status" -eq 0 ]
-	[ "${#lines[@]}" -eq 3 ]
-	# every line should contain "busybox" exclude the first head line 
+	[ "${#lines[@]}" -eq 2 ]
+	# every line should contain "busybox" exclude the first head line
 	for((i=1; i<${#lines[@]}; i++)); do
 		[[ "${lines[i]}" == *"busybox"* ]]
 	done

--- a/test/integration/api/tag.bats
+++ b/test/integration/api/tag.bats
@@ -46,6 +46,10 @@ function teardown() {
 	docker_swarm tag busybox tag_busybox:test
 
 	# verify
-	run docker_swarm images
-	[[ $(echo ${output} | grep -o "tag_busybox" | wc -l) == 2 ]]
+	# change the way to verify tagged image on each node after image deduplication
+	run docker_swarm images --filter node=node-0
+	[[ $(echo ${output} | grep -o "tag_busybox" | wc -l) == 1 ]]
+
+	run docker_swarm images --filter node=node-1
+	[[ $(echo ${output} | grep -o "tag_busybox" | wc -l) == 1 ]]
 }


### PR DESCRIPTION
This PR attempts to fix #1164. Currently, `docker images` list every duplicated image on every node. This is very verbose when the cluster grows.

Although, it's understandable that keeping the Engine info for each image is necessary when calling `docker images --filter`.

This PR is trying to address both problems.

  * To make `docker images` less verbose, this PR introduces an inner `map[string]*cluster.Image` to group images by Id.
  * To keep `docker images --filter node=` work, this PR does grouping after the filter.
  * ~~In addition, Engine information for the grouped images are still kept in the struct and therefore accessible by `/images/json`. Will be useful when a client is able to process them in the future.~~

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>