### PR TITLE
fix 'go test' invocation in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ First, prepare dependencies for `swarm` and try to compile it.
 ```sh
 cd src/github.com/docker/swarm
 $GOBIN/godep restore
-go test
+go test -v -race ./...
 go install
 ```
 


### PR DESCRIPTION
With the way it is listed, no tests get run.
```
λ go test
?   	github.com/docker/swarm	[no test files]
```
I copied the invocation from the travis.yml, which produces a lot of output and appears to run the tests.