### PR TITLE
fix gitignore to specifically ignore the binary called swarm in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-swarm
+/swarm


### PR DESCRIPTION
The current gitignore will not see any new files added to cluster/swarm directory. It will see changes to existing files.

This caused a problem for me, when using a search tool called "ag" that takes into account the .gitignore present in a git repository.

I *think* the original intention was to exclude go generated `swarm` binary in the projects root.

Unfortunately we can't ignore based on file type, only on a matching name.