### PR TITLE
first crack at solving gh 1185

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm/discovery"
 )
 
@@ -83,16 +84,14 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 			select {
 			case <-ticker.C:
 				newEntries, err := s.fetch()
+				log.Info(newEntries)
 				if err != nil {
 					errCh <- err
 					continue
 				}
 
-				// Check if the file has really changed.
-				if !newEntries.Equals(currentEntries) {
-					ch <- newEntries
-				}
-				currentEntries = newEntries
+				// always send the entries
+				ch <- newEntries
 			case <-stopCh:
 				ticker.Stop()
 				return

--- a/discovery/nodes/nodes.go
+++ b/discovery/nodes/nodes.go
@@ -42,6 +42,8 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 	ch := make(chan discovery.Entries)
 	go func() {
 		defer close(ch)
+
+		// need to make this periodically send entries in a loop
 		ch <- s.entries
 		<-stopCh
 	}()

--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm/discovery"
 )
 
@@ -95,17 +96,16 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 			select {
 			case <-ticker.C:
 				newEntries, err := s.fetch()
+				log.Info(newEntries)
 				if err != nil {
 					errCh <- err
 					continue
 				}
 
-				// Check if the file has really changed.
-				if !newEntries.Equals(currentEntries) {
-					ch <- newEntries
-				}
-				currentEntries = newEntries
+				// always send entries
+				ch <- newEntries
 			case <-stopCh:
+				log.Info("stopping")
 				ticker.Stop()
 				return
 			}


### PR DESCRIPTION
This works, but needs to be cleaned up. I left my debug logging in so anyone trying to repro doesn't have to do it themself. Please tag what you think should stay vs be removed. 

How does it look otherwise?

A similar change as in token.go needs to be made for the file and node versions of discovery. I am not sure about the other ways, like etcd, zookeeper, consul, etc.

unit test for file expects it to update immediately, but it could have the old value until it updates. I added a loop, but it needs to timeout with a failure. I need to learn how to use timers in go.

nodes.go only ever sends it's list once, and then exits. Not sure if adding an infinite loop there is wanted or if it should be left alone.

The logic for repeating needs to either be pushed down, or nodes that are fail to be added need to be pushed back upwards to the individual discovery implementations so that they can suggest retrying (or not).

for #1185