### PR TITLE
Fix token discovery Watch on failure

### DIFF
--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -112,7 +112,7 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 		}
 	}()
 
-	return ch, nil
+	return ch, errCh
 }
 
 // Register adds a new entry identified by the into the discovery service


### PR DESCRIPTION
fixes #1200 

The error chan was not passed back to the caller, thus the hang in token discovery because the `select` clause in `swarm/cluster.go` -> `monitorDiscovery()` would wait on a nil chan (also explaining why the successive joins were succeeding).

Tested by savagely unplugging my ethernet cable and plugging it back after some time. #fun

Signed-off-by: Alexandre Beslic <abronan@docker.com>