### PR TITLE
implement `--until` flag for swarm api

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -485,6 +485,21 @@ func postImagesLoad(c *context, w http.ResponseWriter, r *http.Request) {
 
 // GET /events
 func getEvents(c *context, w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		httpError(w, err.Error(), 400)
+		return
+	}
+
+	var until int64 = -1
+	if r.Form.Get("until") != "" {
+		u, err := strconv.ParseInt(r.Form.Get("until"), 10, 64)
+		if err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
+		until = u
+	}
+
 	c.eventsHandler.Add(r.RemoteAddr, w)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -493,7 +508,7 @@ func getEvents(c *context, w http.ResponseWriter, r *http.Request) {
 		f.Flush()
 	}
 
-	c.eventsHandler.Wait(r.RemoteAddr)
+	c.eventsHandler.Wait(r.RemoteAddr, until)
 }
 
 // POST /containers/{name:.*}/exec


### PR DESCRIPTION
for part of #1203 
I looked at docker base engine for the implementation idea. 

~~I'd like to write some integration tests, but I'm not sure how to run them.~~

tested with junk input for at least one http error case.
```
root@node-1:~# docker -H 127.0.0.1:3375 events --until esesese
Error response from daemon: strconv.ParseInt: parsing "esesese": invalid syntax
```

timeout seems to work
```

root@node-1:~# docker -H 127.0.0.1:3375 events --until 2015-09-09T22:44:00 && date
2015-09-09T22:43:38.000000000Z d2e0fb95c4e9ff0c799a09b0dd1cfa09c9af6ff6f1d0dadad02e0aaa96637965: (from hello-world node:node-1) create
2015-09-09T22:43:38.000000000Z d2e0fb95c4e9ff0c799a09b0dd1cfa09c9af6ff6f1d0dadad02e0aaa96637965: (from hello-world node:node-1) attach
2015-09-09T22:43:38.000000000Z d2e0fb95c4e9ff0c799a09b0dd1cfa09c9af6ff6f1d0dadad02e0aaa96637965: (from hello-world node:node-1) start
2015-09-09T22:43:38.000000000Z d2e0fb95c4e9ff0c799a09b0dd1cfa09c9af6ff6f1d0dadad02e0aaa96637965: (from hello-world node:node-1) die
2015-09-09T22:43:38.000000000Z d2e0fb95c4e9ff0c799a09b0dd1cfa09c9af6ff6f1d0dadad02e0aaa96637965: (from hello-world node:node-1) destroy
Wed Sep  9 22:44:00 UTC 2015
root@node-1:~#
```

Last I feel like I could maybe cleanup locking, and, move it to one place inside cleanupHandler. Thoughts?