### PR TITLE
remove deprecated unused flag

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -22,7 +22,6 @@ var (
 			ShortName: "m",
 			Usage:     "Manage a docker cluster",
 			Flags: []cli.Flag{
-				flStore,
 				flStrategy, flFilter,
 				flHosts,
 				flLeaderElection, flManageAdvertise,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -27,11 +27,6 @@ func getDiscovery(c *cli.Context) string {
 }
 
 var (
-	flStore = cli.StringFlag{
-		Name:  "rootdir",
-		Value: homepath(".swarm"),
-		Usage: "",
-	}
 	flJoinAdvertise = cli.StringFlag{
 		Name:   "advertise, addr",
 		Usage:  "Address of the Docker Engine joining the cluster. Swarm manager(s) MUST be able to reach the Docker Engine at this address.",


### PR DESCRIPTION
for #1090

The variables aren't referenced anywhere, and aren't retrieved from the cli. Seemed easy and safe to remove.

It does turn providing that flag into a fatal error, so it would break anyone who was using it, vs silently succeeding and doing nothing.

Not sure if this PR is worth it or not right now, but it is available.