### PR TITLE
try to use gnu version of readlink if available

### DIFF
--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+# try to use gnu version of readlink on non-gnu systems (e.g. bsd, osx)
+# on osx, install with 'brew install coreutils'
+READLINK_LOCATION=$(which greadlink readlink | head -n 1)
+THIS_SCRIPT=$(${READLINK_LOCATION} -f "$BASH_SOURCE")
+cd "$(dirname "${THIS_SCRIPT}")"
 
 # Root directory of Swarm.
 SWARM_ROOT=$(cd ../..; pwd -P)


### PR DESCRIPTION
On osx the integration script will fail if it is not run from /swarm/test/integration directory.

1. osx has bsd readlink, which doesn't have the -f flag. By pulling it out into separate subshell, it fails the script early.
2. osx users (and others) tend to also install the gnu version of tools (using `brew install coreutils` or some such) but with a `g` prefix, so try to find and use that version before using a different version.

tested on osx and a linux vm.

^ I don't know if you want this information in the commit message, or if it's good enough to have it on a github PR.
