### PR TITLE
Test commit to fix CI failure

### DIFF
--- a/test/integration/port-filters.bats
+++ b/test/integration/port-filters.bats
@@ -34,7 +34,10 @@ function teardown() {
 
 	run docker_swarm run -d --expose=80 -p 80:80 busybox sh
 	[ "$status" -eq 0 ]
+	# Sleep for 1 second to make sure the port 80 is available again
+	sleep 1
 	run docker_swarm run -d --expose=80 -p 80:80 busybox sh
+	echo $output
 	[ "$status" -eq 0 ]
 
 	# When trying to start the 3rd one, it should be error finding port 80.


### PR DESCRIPTION
This PR fixes a race in the port filter test case where if two containers are started quickly in succession before the first container has been completely cleaned up, the second container may fail to start because we share the host port space and the port might be still in use. Fixed it by introducing a 1 second delay in between container starts.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>