### PR TITLE
WIP: Remove the lock at the scheduler level

### DIFF
--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -180,9 +180,6 @@ func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string) 
 
 // RemoveContainer to remove containers on mesos cluster
 func (c *Cluster) RemoveContainer(container *cluster.Container, force bool) error {
-	c.scheduler.Lock()
-	defer c.scheduler.Unlock()
-
 	return container.Engine.RemoveContainer(container, force)
 }
 
@@ -400,9 +397,6 @@ func (c *Cluster) removeOffer(offer *mesosproto.Offer) bool {
 }
 
 func (c *Cluster) scheduleTask(t *task) bool {
-	c.scheduler.Lock()
-	defer c.scheduler.Unlock()
-
 	n, err := c.scheduler.SelectNodeForContainer(c.listNodes(), t.config)
 	if err != nil {
 		return false
@@ -514,15 +508,12 @@ func (c *Cluster) RANDOMENGINE() (*cluster.Engine, error) {
 
 // BuildImage build an image
 func (c *Cluster) BuildImage(buildImage *dockerclient.BuildImage, out io.Writer) error {
-	c.scheduler.Lock()
-
 	// get an engine
 	config := &cluster.ContainerConfig{dockerclient.ContainerConfig{
 		CpuShares: buildImage.CpuShares,
 		Memory:    buildImage.Memory,
 	}}
 	n, err := c.scheduler.SelectNodeForContainer(c.listNodes(), config)
-	c.scheduler.Unlock()
 	if err != nil {
 		return err
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/filter"
@@ -12,8 +11,6 @@ import (
 
 // Scheduler is exported
 type Scheduler struct {
-	sync.Mutex
-
 	strategy strategy.PlacementStrategy
 	filters  []filter.Filter
 }

--- a/scheduler/strategy/weighted_node.go
+++ b/scheduler/strategy/weighted_node.go
@@ -36,6 +36,7 @@ func weighNodes(config *cluster.ContainerConfig, nodes []*node.Node) (weightedNo
 	weightedNodes := weightedNodeList{}
 
 	for _, node := range nodes {
+		node.RLock()
 		nodeMemory := node.TotalMemory
 		nodeCpus := node.TotalCpus
 
@@ -55,6 +56,7 @@ func weighNodes(config *cluster.ContainerConfig, nodes []*node.Node) (weightedNo
 		if config.Memory > 0 {
 			memoryScore = (node.UsedMemory + config.Memory) * 100 / nodeMemory
 		}
+		node.RUnlock()
 
 		if cpuScore <= 100 && memoryScore <= 100 {
 			weightedNodes = append(weightedNodes, &weightedNode{Node: node, Weight: cpuScore + memoryScore})


### PR DESCRIPTION
fixes #1194 #786 

This PR removes the `Lock` at the `scheduler` level and moves it to `node.Node` for better granularity. `cluster` now maintains a list of Nodes with resource accounting protected by a `Lock` which avoids races for resource reservation. Processes not lucky enough to get a resource slice on a machine that gets full in the meantime are retrying the process of scheduling unless they get the resources they need (it fails if there is no more resource available cluster-wide).

This is I think the most simple approach to remove the `lock` at the scheduler level for now and avoid the races. Note that this does not solve the naming issue (we should settle if we allow duplicate names and solve the ambiguity through the prefix which is the node name or if each container must absolutely have a unique name).

*Downside*: The blocked `pull` problem still persists so some resources are going to be locked up for a while if this happens because we have no way to know if this is due to the issue or just a *very slow* `pull`.

TODO items:
- [ ] Integration tests
- [ ] Take a look at the implications on strategies and constraints, and parallel create/remove/build

Signed-off-by: Alexandre Beslic <abronan@docker.com>