### PR TITLE
fix test images

### DIFF
--- a/test/integration/api/images.bats
+++ b/test/integration/api/images.bats
@@ -39,7 +39,7 @@ function teardown() {
 	[[ "${lines[1]}" == *"busybox"* ]]
 
 	# Try images -a
-	# lines are: header, busybox, <none>, <none>
+	# lines are: header, busybox, <none>
 	run docker_swarm images -a
-	[ "${#lines[@]}" -ge 4 ]
+	[ "${#lines[@]}" -ge 3 ]
 }


### PR DESCRIPTION
busybox is only one layer now, since https://github.com/docker-library/official-images/commit/ab7d119a7728e5ddf845eed35ec6b7981293e3b5
