### PR TITLE
remove \b (\u0008) prefix from /info api calls

### DIFF
--- a/cli/manage.go
+++ b/cli/manage.go
@@ -52,12 +52,12 @@ func (h *statusHandler) Status() [][]string {
 
 	if h.candidate != nil && !h.candidate.IsLeader() {
 		status = [][]string{
-			{"\bRole", "replica"},
-			{"\bPrimary", h.follower.Leader()},
+			{"Role", "replica"},
+			{"Primary", h.follower.Leader()},
 		}
 	} else {
 		status = [][]string{
-			{"\bRole", "primary"},
+			{"Role", "primary"},
 		}
 	}
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -610,9 +610,9 @@ func (c *Cluster) TotalCpus() int64 {
 // Info returns some info about the cluster, like nb or containers / images
 func (c *Cluster) Info() [][]string {
 	info := [][]string{
-		{"\bStrategy", c.scheduler.Strategy()},
-		{"\bFilters", c.scheduler.Filters()},
-		{"\bNodes", fmt.Sprintf("%d", len(c.engines))},
+		{"Strategy", c.scheduler.Strategy()},
+		{"Filters", c.scheduler.Filters()},
+		{"Nodes", fmt.Sprintf("%d", len(c.engines))},
 	}
 
 	engines := c.listEngines()


### PR DESCRIPTION
This is related to issue https://github.com/docker/swarm/issues/1237