### PR TITLE
Use smaller zk image for integration tests

### DIFF
--- a/test/integration/discovery/zk.bats
+++ b/test/integration/discovery/zk.bats
@@ -12,7 +12,7 @@ DISCOVERY="zk://${STORE_HOST}/test"
 CONTAINER_NAME=swarm_integration_zk
 
 function start_store() {
-	docker_host run --name $CONTAINER_NAME -p $STORE_HOST:2181 -d jplock/zookeeper:3.4.6
+	docker_host run --name $CONTAINER_NAME -p $STORE_HOST:2181 -d dnephin/docker-zookeeper:3.4.6
 }
 
 function stop_store() {


### PR DESCRIPTION
This is an image I built for https://github.com/dnephin/compose-swarm-sandbox, it's basically the same `Dockerfile` except that it uses `alpine:edge` base, so it's half the size of the `jplock/zookeeper` image, so the tests should run a bit faster.

https://hub.docker.com/r/dnephin/docker-zookeeper/~/dockerfile/