### PR TITLE
Fix etcd lock TTL refresh value in seconds

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -47,7 +47,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libkv",
-			"Rev": "1d2361d74ecd9aa75b17992cf5c63d2c5ab717ab"
+			"Rev": "975dbc9a3dc76a4b3ed1f60f73b9c0323b40336c"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/consul/consul.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/consul/consul.go
@@ -88,7 +88,7 @@ func (s *Consul) setTLS(tls *tls.Config) {
 	s.config.Scheme = "https"
 }
 
-// SetTimeout sets the timout for connecting to Consul
+// SetTimeout sets the timeout for connecting to Consul
 func (s *Consul) setTimeout(time time.Duration) {
 	s.config.WaitTime = time
 }

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/etcd/etcd.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/etcd/etcd.go
@@ -495,7 +495,7 @@ func (l *etcdLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
 func (l *etcdLock) holdLock(key string, lockHeld chan struct{}, stopLocking <-chan struct{}) {
 	defer close(lockHeld)
 
-	update := time.NewTicker(time.Duration((l.ttl / 3) + 1))
+	update := time.NewTicker(time.Duration(l.ttl) * time.Second / 3)
 	defer update.Stop()
 
 	var err error


### PR DESCRIPTION
Latest changes in `libkv` to include the `LeaderTTL` flag here in swarm included a wrong calculation for the TTL lock refresh value in etcd. This would cause the refresh event to be triggered way more than expected for etcd.

This PR updates libkv to the latest including the change.

Signed-off-by: Alexandre Beslic <abronan@docker.com>