### PR TITLE
Initialize the key/directory before watching on kv discovery

### DIFF
--- a/discovery/kv/kv.go
+++ b/discovery/kv/kv.go
@@ -112,6 +112,17 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 		// Forever: Create a store watch, watch until we get an error and then try again.
 		// Will only stop if we receive a stopCh request.
 		for {
+			// Create the path to watch if it does not exist yet
+			exists, err := s.store.Exists(s.path)
+			if err != nil {
+				errCh <- err
+			}
+			if !exists {
+				if err := s.store.Put(s.path, []byte(""), &store.WriteOptions{IsDir: true}); err != nil {
+					errCh <- err
+				}
+			}
+
 			// Set up a watch.
 			watchCh, err := s.store.WatchTree(s.path, stopCh)
 			if err != nil {


### PR DESCRIPTION
Before that change, etcd and zookeeper would fail to instantiate
the discovery without the key being already there in the store or
created beforehand and implicitely by a 'swarm join'.

Signed-off-by: Alexandre Beslic <abronan@docker.com>