### PR TITLE
Fix soft filter

### DIFF
--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -64,7 +64,7 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 		}
 		if len(candidates) == 0 {
 			if affinity.isSoft {
-				return nodes, nil
+				continue
 			}
 			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", affinity.key, OPERATORS[affinity.operator], affinity.value)
 		}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -43,7 +43,7 @@ func (f *ConstraintFilter) Filter(config *cluster.ContainerConfig, nodes []*node
 		}
 		if len(candidates) == 0 {
 			if constraint.isSoft {
-				return nodes, nil
+				continue
 			}
 			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", constraint.key, OPERATORS[constraint.operator], constraint.value)
 		}

--- a/test/integration/affinities.bats
+++ b/test/integration/affinities.bats
@@ -125,3 +125,18 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${output}" != *'"Name": "node-1"'* ]]
 }
+
+@test "soft affinity" {
+	start_docker_with_busybox 2
+
+	# Create a new image just on the second host.
+	docker -H ${HOSTS[1]} tag busybox test
+
+	swarm_manage
+
+	docker_swarm run --name c1 -e affinity:image==~not_exist -e affinity:image==test -d busybox:latest sh
+
+	run docker_swarm inspect c1
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *'"Name": "node-1"'* ]]
+}

--- a/test/integration/constraints.bats
+++ b/test/integration/constraints.bats
@@ -39,6 +39,22 @@ function teardown() {
 	[[ "${output}" == *'"Name": "node-1"'* ]]
 }
 
+@test "soft constraint" {
+	start_docker_with_busybox 2
+	swarm_manage
+
+	docker_swarm run --name c1 -e constraint:storagedriver==~not_exist -e constraint:node==node-0 -d busybox:latest sh
+	docker_swarm run --name c2 -e constraint:storagedriver==~not_exist -e constraint:node==node-0 -d busybox:latest sh
+
+	run docker_swarm inspect c1
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *'"Name": "node-0"'* ]]
+
+	run docker_swarm inspect c2
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *'"Name": "node-0"'* ]]
+}
+
 @test "label constraints" {
 	start_docker_with_busybox 1 --label foo=a
 	start_docker_with_busybox 1 --label foo=b


### PR DESCRIPTION
This Case(2 nodes:node1 and node2):
```
[root@localhost ~]docker -H 127.0.0.1:2222 run -d -e contraint:storagedriver==~abc -e contraint:node==node1 busybox sleep 1000
a585b05dbc899fd724bbe7c5b2f35b9cf9ad85b02c1f8fd110bae4d005caee82
[root@localhost ~]# docker -H 127.0.0.1:2222 ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
a585b05dbc89        busybox:latest      "sleep 1000"        13 seconds ago                                              node2/berserk_banach
```
We can see that even use ` -e contraint:node==node1`,  the container was created on node2.

This PR fix this.
When we use soft Affinities/Constraints, we should not use `return`, should use `continue` so that meet the other Affinities/Constraints.

Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>