### PR TITLE
Do not try retry with soft-image-affinity when have node constraint

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -158,3 +158,15 @@ func (c *ContainerConfig) AddAffinity(affinity string) error {
 	c.Labels[SwarmLabelNamespace+".affinities"] = string(labels)
 	return nil
 }
+
+// HaveNodeConstraint in config
+func (c *ContainerConfig) HaveNodeConstraint() bool {
+	constraints := c.extractExprs("constraints")
+
+	for _, constraint := range constraints {
+		if strings.HasPrefix(constraint, "node==") && !strings.HasPrefix(constraint, "node==~") {
+			return true
+		}
+	}
+	return false
+}

--- a/cluster/config_test.go
+++ b/cluster/config_test.go
@@ -89,3 +89,11 @@ func TestAddAffinity(t *testing.T) {
 	config.AddAffinity("image==~testimage")
 	assert.Len(t, config.Affinities(), 1)
 }
+
+func TestHaveNodeConstraint(t *testing.T) {
+	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	assert.False(t, config.HaveNodeConstraint())
+
+	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==node1"}})
+	assert.True(t, config.HaveNodeConstraint())
+}

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -90,7 +90,7 @@ func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string) 
 	container, err := c.createContainer(config, name, false)
 
 	//  fails with image not found, then try to reschedule with soft-image-affinity
-	if err != nil && strings.HasSuffix(err.Error(), "not found") {
+	if err != nil && strings.HasSuffix(err.Error(), "not found") && !config.HaveNodeConstraint() {
 		// Check if the image exists in the cluster
 		// If exists, retry with a soft-image-affinity
 		if image := c.Image(config.Image); image != nil {


### PR DESCRIPTION
Fix: https://github.com/docker/swarm/issues/1232

Two nodes: node1 and node2, node 2 has `mycentos`
Before:
```
[root@localhost ~]# docker -H 127.0.0.1:2222 run -d -e constraint:node==node1 mycentos sleep 1000
Error response from daemon: unable to find a node that satisfies node==node1
```
After:
```
[root@localhost ~]# docker -H 127.0.0.1:2222 run -d -e constraint:node==node1 mycentos sleep 1000
Error response from daemon: Error: image library/mycentos:latest not found
```
Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>