### PR TITLE
Document CpuShares special handling in Swarm

### DIFF
--- a/docs/api/swarm-api.md
+++ b/docs/api/swarm-api.md
@@ -42,6 +42,8 @@ POST "/images/create" : "docker import" flow not implement
 
 * `GET "/images/json"` : Use '--filter node=\<Node name\>' to show images of the specific node.
 
+* `POST "/containers/create"`: `CpuShares` in `HostConfig` sets the number of CPU cores allocated to the container.
+
 ## Docker Swarm documentation index
 
 - [User guide](https://docs.docker.com/swarm/)


### PR DESCRIPTION
I realized that Swarm handles CpuShares differently after digging around some old GitHub issues.

This is great, as far as I'm concerned. Swarm's handling of CpuShares implements something I need. I added a summary of my findings to the documentation, so others can find out about this great feature with less work.