### PR TITLE
Integration test for regression with parallel docker run when specifying a port

### DIFF
--- a/test/integration/api/port.bats
+++ b/test/integration/api/port.bats
@@ -20,3 +20,21 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${lines[*]}" == *"8000"* ]]
 }
+
+@test "docker port parallel" {
+	start_docker_with_busybox 2
+	swarm_manage
+
+	declare -a pids
+	for i in 1 2 3; do
+		# Use a non existing image to ensure that we pull at the same time
+		docker_swarm run -d -p 8888 alpine:edge sleep 2 &
+		pids[$i]=$!
+	done
+
+	# Wait for jobs in the background and check their exit status
+	for pid in "${pids[@]}"; do
+		wait $pid
+		[ "$?" -eq 0 ]
+	done
+}


### PR DESCRIPTION
Integration test for #1314

ping @chanwit @aluzzardi @vieux 

Tested before (failure with the nil pointer panic) and after the patch (test succeeded). This integration test should ensure that we don't see a regression in the future for this specific issue.

Not sure if the best way so let me know if I can improve it (`parallel` command is not available in the swarm test image). Also don't know where to put the test so it ended up in `port.bats` :smile: 

Signed-off-by: Alexandre Beslic <abronan@docker.com>