### PR TITLE
Support filtering networks by id or name

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -30,6 +30,21 @@ func (networks Networks) Uniq() Networks {
 	return uniq
 }
 
+// Filter returns networks filtered by names or ids
+func (networks Networks) Filter(names []string, ids []string) Networks {
+	if len(names) == 0 && len(ids) == 0 {
+		return networks.Uniq()
+	}
+
+	out := Networks{}
+	for _, idOrName := range append(names, ids...) {
+		if network := networks.Get(idOrName); network != nil {
+			out = append(out, network)
+		}
+	}
+	return out
+}
+
 // Get returns a network using it's ID or Name
 func (networks Networks) Get(IDOrName string) *Network {
 	// Abort immediately if the name is empty.
@@ -78,5 +93,4 @@ func (networks Networks) Get(IDOrName string) *Network {
 	}
 
 	return nil
-
 }

--- a/cluster/network_test.go
+++ b/cluster/network_test.go
@@ -1,0 +1,36 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/samalba/dockerclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworksFilter(t *testing.T) {
+	engine := &Engine{ID: "id"}
+	networks := Networks{
+		{dockerclient.NetworkResource{
+			ID:   "ababababab",
+			Name: "something",
+		}, engine},
+		{dockerclient.NetworkResource{
+			ID:   "aaaaaaaaaa1",
+			Name: "network_name",
+		}, engine},
+		{dockerclient.NetworkResource{
+			ID:   "bbbbbbbbbb",
+			Name: "somethingelse",
+		}, engine},
+		{dockerclient.NetworkResource{
+			ID:   "aaaaaaaaa2",
+			Name: "foo",
+		}, engine},
+	}
+
+	filtered := networks.Filter([]string{"network_name"}, []string{"abababab"})
+	assert.Equal(t, len(filtered), 2)
+	for _, network := range filtered {
+		assert.True(t, network.ID == "aaaaaaaaaa1" || network.ID == "ababababab")
+	}
+}


### PR DESCRIPTION
Fixes #1316

I looked at adding an integration test but the docker-cli doesn't support this filtering yet.