### PR TITLE
Update api version to match the version that swarm supports

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -21,8 +21,8 @@ import (
 	"github.com/samalba/dockerclient"
 )
 
-// APIVERSION is the Client API version
-const APIVERSION = "1.16"
+// APIVERSION is the API version supported by swarm manager
+const APIVERSION = "1.21"
 
 // GET /info
 func getInfo(c *context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Swarm reports that it uses api version 1.16, but this is a lie.  With the 1.0.0 release it supports api version 1.21.