### PR TITLE
Add configurable discovery path option

### DIFF
--- a/discovery/kv/kv.go
+++ b/discovery/kv/kv.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	discoveryPath = "docker/swarm/nodes"
+	defaultDiscoveryPath = "docker/swarm/nodes"
 )
 
 // Discovery is exported
@@ -62,7 +62,14 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 
 	s.heartbeat = heartbeat
 	s.ttl = ttl
-	s.path = path.Join(s.prefix, discoveryPath)
+
+	// Use a custom path if specified in discovery options
+	dpath := defaultDiscoveryPath
+	if discoveryOpt["kv.path"] != "" {
+		dpath = discoveryOpt["kv.path"]
+	}
+
+	s.path = path.Join(s.prefix, dpath)
 
 	var config *store.Config
 	if discoveryOpt["kv.cacertfile"] != "" && discoveryOpt["kv.certfile"] != "" && discoveryOpt["kv.keyfile"] != "" {


### PR DESCRIPTION
This PR allows to configure the discovery path using the
`--discovery-opt` flag (with `kv.path=path/to/nodes`). We
can point to `docker/nodes` and use the docker discovery.

If docker instances are advertising to the cluster using
the `--cluster-advertise` flag, the `swarm join` command
becomes unnecessary.

Signed-off-by: Alexandre Beslic <abronan@docker.com>