### PR TITLE
Update Engine specs on refreshLoop

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -402,6 +402,9 @@ func (e *Engine) refreshLoop() {
 			return
 		}
 
+		// Refresh Engine specs
+		e.updateSpecs()
+
 		err = e.RefreshContainers(false)
 		if err == nil {
 			// Do not check error as older daemon don't support this call


### PR DESCRIPTION
Before, the labels of an Engine couldn't be refreshed if
a daemon was restarted not reaching the timeout on the
discovery (thus not being unregistered/registered again).

This would result in a daemon with updated labels and specs
without the Manager being aware of those new specs. Now we
call `updateSpecs` in the refreshLoop as a best effort
mechanism to refresh the labels and properties of a daemon.

fixes #1281 

Signed-off-by: Alexandre Beslic <abronan@docker.com>