### PR TITLE
Fixed typos

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -23,7 +23,7 @@ engine docs.
 
 This example assumes there are two nodes `node-0` and `node-1` in the cluster.
 
-    $ docker networks ls
+    $ docker network ls
     NETWORK ID          NAME                   DRIVER
     3dd50db9706d        node-0/host            host
     09138343e80e        node-0/bridge          bridge
@@ -41,7 +41,7 @@ scope driver.
 
     $ docker network create swarm_network
     42131321acab3233ba342443Ba4312
-    $ docker networks ls
+    $ docker network ls
     NETWORK ID          NAME                   DRIVER
     3dd50db9706d        node-0/host            host
     09138343e80e        node-0/bridge          bridge
@@ -63,7 +63,7 @@ random node.
     921817fefea521673217123abab223
     $ docker network create node-1/bridge2 -b bridge
     5262bbfe5616fef6627771289aacc2
-    $ docker networks ls
+    $ docker network ls
     NETWORK ID          NAME                   DRIVER
     3dd50db9706d        node-0/host            host
     09138343e80e        node-0/bridge          bridge
@@ -85,7 +85,7 @@ If two different network have the same name, use may use `<node>/<name>`.
     42131321acab3233ba342443Ba4312
     $ docker network rm node-0/bridge2
     921817fefea521673217123abab223
-    $ docker networks ls
+    $ docker network ls
     NETWORK ID          NAME                   DRIVER
     3dd50db9706d        node-0/host            host
     09138343e80e        node-0/bridge          bridge


### PR DESCRIPTION
A copy/paste containing a typos was made. I just replace `$ docker networks ls` with `$ docker network ls`.

Fix #1380 