### PR TITLE
Add token pass-thru for Authconfig

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -125,7 +125,7 @@
 		},
 		{
 			"ImportPath": "github.com/samalba/dockerclient",
-			"Rev": "9445e25ed06943cf2828bce5a92391d768513d21"
+			"Rev": "4656b1bc6cbc06b75d65983475e4809cbd53ebb5"
 		},
 		{
 			"ImportPath": "github.com/samuel/go-zookeeper/zk",

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/auth.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/auth.go
@@ -8,9 +8,10 @@ import (
 
 // AuthConfig hold parameters for authenticating with the docker registry
 type AuthConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Email    string `json:"email,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Email         string `json:"email,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
 // encode the auth configuration struct into base64 for the X-Registry-Auth header

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/dockerclient.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/dockerclient.go
@@ -21,8 +21,9 @@ const (
 )
 
 var (
-	ErrImageNotFound = errors.New("Image not found")
-	ErrNotFound      = errors.New("Not found")
+	ErrImageNotFound     = errors.New("Image not found")
+	ErrNotFound          = errors.New("Not found")
+	ErrConnectionRefused = errors.New("Cannot connect to the docker engine endpoint")
 
 	defaultTimeout = 30 * time.Second
 )
@@ -99,6 +100,9 @@ func (client *DockerClient) doStreamRequest(method string, path string, in io.Re
 	if err != nil {
 		if !strings.Contains(err.Error(), "connection refused") && client.TLSConfig == nil {
 			return nil, fmt.Errorf("%v. Are you trying to connect to a TLS-enabled daemon without TLS?", err)
+		}
+		if strings.Contains(err.Error(), "connection refused") {
+			return nil, ErrConnectionRefused
 		}
 		return nil, err
 	}
@@ -184,7 +188,7 @@ func (client *DockerClient) InspectContainer(id string) (*ContainerInfo, error) 
 	return info, nil
 }
 
-func (client *DockerClient) CreateContainer(config *ContainerConfig, name string) (string, error) {
+func (client *DockerClient) CreateContainer(config *ContainerConfig, name string, auth *AuthConfig) (string, error) {
 	data, err := json.Marshal(config)
 	if err != nil {
 		return "", err
@@ -195,14 +199,22 @@ func (client *DockerClient) CreateContainer(config *ContainerConfig, name string
 		v.Set("name", name)
 		uri = fmt.Sprintf("%s?%s", uri, v.Encode())
 	}
-	data, err = client.doRequest("POST", uri, data, nil)
+	headers := map[string]string{}
+	if auth != nil {
+		encoded_auth, err := auth.encode()
+		if err != nil {
+			return "", err
+		}
+		headers["X-Registry-Auth"] = encoded_auth
+	}
+	data, err = client.doRequest("POST", uri, data, headers)
 	if err != nil {
 		return "", err
 	}
 	result := &RespContainersCreate{}
 	err = json.Unmarshal(data, result)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf(string(data))
 	}
 	return result.Id, nil
 }

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/examples/stats/stats.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/examples/stats/stats.go
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	containerConfig := &dockerclient.ContainerConfig{Image: "busybox", Cmd: []string{"sh"}}
-	containerId, err := docker.CreateContainer(containerConfig, "")
+	containerId, err := docker.CreateContainer(containerConfig, "", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/interface.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/interface.go
@@ -13,7 +13,7 @@ type Client interface {
 	ListContainers(all, size bool, filters string) ([]Container, error)
 	InspectContainer(id string) (*ContainerInfo, error)
 	InspectImage(id string) (*ImageInfo, error)
-	CreateContainer(config *ContainerConfig, name string) (string, error)
+	CreateContainer(config *ContainerConfig, name string, authConfig *AuthConfig) (string, error)
 	ContainerLogs(id string, options *LogOptions) (io.ReadCloser, error)
 	ContainerChanges(id string) ([]*ContainerChanges, error)
 	ExecCreate(config *ExecConfig) (string, error)

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/mockclient/mock.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/mockclient/mock.go
@@ -35,8 +35,8 @@ func (client *MockClient) InspectImage(id string) (*dockerclient.ImageInfo, erro
 	return args.Get(0).(*dockerclient.ImageInfo), args.Error(1)
 }
 
-func (client *MockClient) CreateContainer(config *dockerclient.ContainerConfig, name string) (string, error) {
-	args := client.Mock.Called(config, name)
+func (client *MockClient) CreateContainer(config *dockerclient.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (string, error) {
+	args := client.Mock.Called(config, name, authConfig)
 	return args.String(0), args.Error(1)
 }
 

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/nopclient/nop.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/nopclient/nop.go
@@ -34,7 +34,7 @@ func (client *NopClient) InspectImage(id string) (*dockerclient.ImageInfo, error
 	return nil, ErrNoEngine
 }
 
-func (client *NopClient) CreateContainer(config *dockerclient.ContainerConfig, name string) (string, error) {
+func (client *NopClient) CreateContainer(config *dockerclient.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (string, error) {
 	return "", ErrNoEngine
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -427,7 +427,15 @@ func postContainersCreate(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	container, err := c.cluster.CreateContainer(cluster.BuildContainerConfig(config), name)
+	// Pass auth information along if present
+	var authConfig *dockerclient.AuthConfig
+	buf, err := base64.URLEncoding.DecodeString(r.Header.Get("X-Registry-Auth"))
+	if err == nil {
+		authConfig = &dockerclient.AuthConfig{}
+		json.Unmarshal(buf, authConfig)
+	}
+
+	container, err := c.cluster.CreateContainer(cluster.BuildContainerConfig(config), name, authConfig)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "Conflict") {
 			httpError(w, err.Error(), http.StatusConflict)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -9,7 +9,7 @@ import (
 // Cluster is exported
 type Cluster interface {
 	// Create a container
-	CreateContainer(config *ContainerConfig, name string) (*Container, error)
+	CreateContainer(config *ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*Container, error)
 
 	// Remove a container
 	RemoveContainer(container *Container, force, volumes bool) error

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -164,7 +164,7 @@ func (c *Cluster) RegisterEventHandler(h cluster.EventHandler) error {
 }
 
 // CreateContainer for container creation in Mesos task
-func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string) (*cluster.Container, error) {
+func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*cluster.Container, error) {
 	if config.Memory == 0 && config.CpuShares == 0 {
 		return nil, errResourcesNeeded
 	}

--- a/docs/api/swarm-api.md
+++ b/docs/api/swarm-api.md
@@ -45,6 +45,49 @@ POST "/images/create" : "docker import" flow not implement
 
 * `POST "/containers/create"`: `CpuShares` in `HostConfig` sets the number of CPU cores allocated to the container.
 
+# Registry Authentication
+
+During container create calls, the swarm API will optionally accept a X-Registry-Config header.
+If provided, this header will be passed down to the engine if the image must be pulled
+to complete the create operation.
+
+The following two examples demonstrate how to utilize this using the existing docker CLI
+
+* CLI usage example using username/password:
+
+    ```bash
+# Calculate the header
+REPO_USER=yourusername
+read -s PASSWORD
+HEADER=$(echo "{\"username\":\"${REPO_USER}\",\"password\":\"${PASSWORD}\"}"|base64 -w 0 )
+unset PASSWORD
+echo HEADER=$HEADER
+
+# Then add the following to your ~/.docker/config.json
+"HttpHeaders": {
+    "X-Registry-Auth": "<HEADER string from above>"
+}
+
+# Now run a private image against swarm:
+docker run --rm -it yourprivateimage:latest
+```
+
+* CLI usage example using registry tokens: (Requires engine 1.10 with new auth token support)
+
+    ```bash
+REPO=yourrepo/yourimage
+REPO_USER=yourusername
+read -s PASSWORD
+AUTH_URL=https://auth.docker.io/token
+TOKEN=$(curl -s -u "${REPO_USER}:${PASSWORD}" "${AUTH_URL}?scope=repository:${REPO}:pull&service=registry.docker.io" |
+    jq -r ".token")
+HEADER=$(echo "{\"registrytoken\":\"${TOKEN}\"}"|base64 -w 0 )
+echo HEADER=$HEADER
+
+# Update the docker config as above, but the token will expire quickly...
+```
+
+
 ## Docker Swarm documentation index
 
 - [User guide](https://docs.docker.com/swarm/)


### PR DESCRIPTION
Add token pass-thru for Authconfig
    
This augments the CreateContainer call to detect the AuthConfig header
and use any supplied auth for pull operations.  This will allow pulling
of protected image on to specific node during the create operation.
    
CLI usage example using username/password:

    # Calculate the header
    REPO_USER=yourusername
    read -s PASSWORD
    HEADER=$(echo "{\"username\":\"${REPO_USER}\",\"password\":\"${PASSWORD}\"}"|base64 -w 0 )
    unset PASSWORD
    echo HEADER=$HEADER

    # Then add the following to your ~/.docker/config.json
    "HttpHeaders": {
        "X-Registry-Auth": "<HEADER string from above>"
    }
    
    # Now run a private image against swarm:
    docker run --rm -it yourprivateimage:latest
    
CLI usage example using registry tokens: (Required engine 1.10 with new auth token support)
    
    REPO=yourrepo/yourimage
    REPO_USER=yourusername
    read -s PASSWORD
    AUTH_URL=https://auth.docker.io/token
    TOKEN=$(curl -s -u "${REPO_USER}:${PASSWORD}" "${AUTH_URL}?scope=repository:${REPO}:pull&service=registry.docker.io" |
        jq -r ".token")
    HEADER=$(echo "{\"registrytoken\":\"${TOKEN}\"}"|base64 -w 0 )
    echo HEADER=$HEADER
    
    # Update the docker config as above, but the token will expire quickly...
    
Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>
