### PR TITLE
add newline to event json to match docker

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -10,6 +10,8 @@ import (
 	"github.com/docker/swarm/cluster"
 )
 
+const eventFmt string = "{%q:%q,%q:%q,%q:%q,%q:%d,%q:{%q:%q,%q:%q,%q:%q,%q:%q}}\n"
+
 // EventsHandler broadcasts events to multiple client listeners.
 type eventsHandler struct {
 	sync.RWMutex
@@ -66,7 +68,7 @@ func (eh *eventsHandler) cleanupHandler(remoteAddr string) {
 func (eh *eventsHandler) Handle(e *cluster.Event) error {
 	eh.RLock()
 
-	str := fmt.Sprintf("{%q:%q,%q:%q,%q:%q,%q:%d,%q:{%q:%q,%q:%q,%q:%q,%q:%q}}",
+	str := fmt.Sprintf(eventFmt,
 		"status", e.Status,
 		"id", e.Id,
 		"from", e.From+" node:"+e.Engine.Name,

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -42,7 +42,7 @@ func TestHandle(t *testing.T) {
 
 	assert.NoError(t, eh.Handle(event))
 
-	str := fmt.Sprintf("{%q:%q,%q:%q,%q:%q,%q:%d,%q:{%q:%q,%q:%q,%q:%q,%q:%q}}",
+	str := fmt.Sprintf(eventFmt,
 		"status", "status",
 		"id", "id",
 		"from", "from node:node_name",


### PR DESCRIPTION
 - docker server has a newline separating individual json entries
 - resolves #1367 

this would fix it, but I'm wondering if we ought to be using a json encoder?