### PR TITLE
Route network connect/disconnect request to the right engine.

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -76,8 +76,8 @@ var routes = map[string]map[string]handler{
 		"/exec/{execid:.*}/start":             postExecStart,
 		"/exec/{execid:.*}/resize":            proxyContainer,
 		"/networks/create":                    postNetworksCreate,
-		"/networks/{networkid:.*}/connect":    proxyNetwork,
-		"/networks/{networkid:.*}/disconnect": proxyNetwork,
+		"/networks/{networkid:.*}/connect":    proxyNetworkContainerOperation,
+		"/networks/{networkid:.*}/disconnect": proxyNetworkContainerOperation,
 		"/volumes/create":                     postVolumesCreate,
 	},
 	"PUT": {


### PR DESCRIPTION
In swarm, `docker network connect overlaynetwork *container*` should be routed to the engine with  *container*. This issue is tracked by #1402. 
Signed-off-by: Dong Chen <dongluo.chen@docker.com>