### PR TITLE
OPTIONS response when cors is enabled

### DIFF
--- a/api/primary_test.go
+++ b/api/primary_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestRequest(t *testing.T) {
+	t.Parallel()
+
+	r := mux.NewRouter()
+	setupPrimaryRouter(r, nil, false)
+	w := httptest.NewRecorder()
+
+	req, e := http.NewRequest("GET", "/version", nil)
+	if nil != e {
+		t.Fatalf("couldn't set up test request")
+	}
+
+	r.ServeHTTP(w, req)
+
+	t.Logf("%d - %s", w.Code, w.Body.String())
+	t.Log("Expecting no extra Headers")
+	for k, v := range w.Header() {
+		t.Log(k, " : ", v)
+	}
+
+	if w.Code == 404 {
+		t.Fatalf("failed not found")
+	}
+}
+
+func TestCorsRequest(t *testing.T) {
+	t.Parallel()
+
+	primary := mux.NewRouter()
+	setupPrimaryRouter(primary, nil, true)
+	w := httptest.NewRecorder()
+
+	r, e := http.NewRequest("OPTIONS", "/version", nil)
+	if nil != e {
+		t.Fatalf("couldn't set up test request")
+	}
+
+	primary.ServeHTTP(w, r)
+
+	t.Logf("%d - %s", w.Code, w.Body.String())
+	t.Log("Expecting extra cors Headers")
+	for k, v := range w.Header() {
+		t.Log(k, " : ", v)
+	}
+
+	if w.Code == 404 {
+		t.Fatalf("failed not found")
+	}
+}


### PR DESCRIPTION
I am not a CORS expert, but I think this might help with #1442. From my limited understanding, there needs to be an OPTIONS response for every method/endpoint combo. I don't know how to get gorilla mux to just respond to everything, so I added an options response for every registered method. Probably overkill, but I think it might work.

I couldn't get any response to the OPTIONS method that was already defined, so I removed it.

I pulled out the setup of the router to make it easier to unit test directly. 

Added a super basic unit test with print statements to see how it works if you run `test -v`.