### PR TITLE
Set labels for pending containers

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -28,8 +28,10 @@ type pendingContainer struct {
 
 func (p *pendingContainer) ToContainer() *cluster.Container {
 	container := &cluster.Container{
-		Container: dockerclient.Container{},
-		Config:    p.Config,
+		Container: dockerclient.Container{
+			Labels: p.Config.Labels,
+		},
+		Config: p.Config,
 		Info: dockerclient.ContainerInfo{
 			HostConfig: &dockerclient.HostConfig{},
 		},

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -4,7 +4,7 @@
 FROM dockerswarm/dind:1.9.0
 
 # Install dependencies.
-RUN apt-get update && apt-get install -y --no-install-recommends git file \
+RUN apt-get update && apt-get install -y --no-install-recommends git file parallel \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install golang


### PR DESCRIPTION
Labels where not set for pending containers, therefore the affinity filter was malfunctioning during parallel runs.

Fixes docker/compose#2447