### PR TITLE
fix the panic when "ps -a" with dead containers

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -282,7 +282,11 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Apply filters.
-		if !filters.Match("name", strings.TrimPrefix(container.Names[0], "/")) {
+		if len(container.Names) > 0 {
+			if !filters.Match("name", strings.TrimPrefix(container.Names[0], "/")) {
+				continue
+			}
+		} else if len(filters["name"]) > 0 {
 			continue
 		}
 		if !filters.Match("id", container.Id) {


### PR DESCRIPTION
Fixes #1436 
Fixes #1421
If it fails after https://github.com/docker/docker/blob/master/daemon/delete.go#L118 on container deletion, the `container.Names` will be empty because the container list API will query the graphdb at https://github.com/docker/docker/blob/master/daemon/list.go#L200

Signed-off-by: Shijiang Wei <mountkin@gmail.com>