### PR TITLE
Integration: Wait for nodes to be registered and discovered before testing

### DIFF
--- a/test/integration/discovery/consul.bats
+++ b/test/integration/discovery/consul.bats
@@ -99,7 +99,7 @@ function teardown() {
 	swarm_join "$DISCOVERY"
 
 	# Start a manager. It should keep retrying
-	swarm_manage "$DISCOVERY"
+	swarm_manage_no_wait "$DISCOVERY"
 
 	# Now start the store
 	start_store

--- a/test/integration/discovery/discovery_helpers.bash
+++ b/test/integration/discovery/discovery_helpers.bash
@@ -2,14 +2,6 @@
 
 load ../helpers
 
-# Returns true if all nodes have joined the swarm.
-function discovery_check_swarm_info() {
-	local total="$1"
-	[ -z "$total" ] && total="${#HOSTS[@]}"
-
-	docker_swarm info | grep -q "Nodes: $total"
-}
-
 # Returns true if swarm info outputs is empty (0 nodes).
 function discovery_check_swarm_info_empty() {
 	docker_swarm info | grep -q "Nodes: 0"

--- a/test/integration/discovery/etcd.bats
+++ b/test/integration/discovery/etcd.bats
@@ -106,7 +106,7 @@ function teardown() {
 	swarm_join "$DISCOVERY"
 
 	# Start a manager. It should keep retrying
-	swarm_manage "$DISCOVERY"
+	swarm_manage_no_wait "$DISCOVERY"
 
 	# Now start the store
 	start_store

--- a/test/integration/discovery/file.bats
+++ b/test/integration/discovery/file.bats
@@ -82,7 +82,7 @@ function setup_discovery_file() {
 	start_docker 2
 
 	# Start a manager. It should keep retrying
-	swarm_manage "$DISCOVERY"
+	swarm_manage_no_wait "$DISCOVERY"
 
 	# Now create the discovery file.
 	setup_discovery_file

--- a/test/integration/discovery/zk.bats
+++ b/test/integration/discovery/zk.bats
@@ -99,7 +99,7 @@ function teardown() {
 	swarm_join "$DISCOVERY"
 
 	# Start a manager. It should keep retrying
-	swarm_manage "$DISCOVERY"
+	swarm_manage_no_wait "$DISCOVERY"
 
 	# Now start the store
 	start_store

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -87,15 +87,12 @@ function wait_until_reachable() {
 
 # Returns true if all nodes have joined the swarm.
 function discovery_check_swarm_info() {
-	local host="$1"
-	local total="$2"
+	local total="$1"
 	[ -z "$total" ] && total="${#HOSTS[@]}"
+	local host="$2"
+	[ -z "$host" ] && host="${SWARM_HOSTS[0]}"
 
-	if [ -z "$host" ]; then
-		retry 10 1 $(docker_swarm info | grep -q "Nodes: $total")
-	else
-		retry 10 1 $(docker -H $host info | grep -q "Nodes: $total")
-	fi
+	retry 10 1 eval "docker -H $host info | grep -q -e \"Nodes: $total\" -e \"Offers: $total\""
 }
 
 # Start the swarm manager in background.
@@ -119,7 +116,7 @@ function swarm_manage() {
 	wait_until_reachable "$host"
 
 	# Wait for nodes to be discovered
-	discovery_check_swarm_info "$host"
+	discovery_check_swarm_info "${#HOSTS[@]}" "$host"
 }
 
 # swarm join every engine created with `start_docker`.

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -95,8 +95,17 @@ function discovery_check_swarm_info() {
 	retry 10 1 eval "docker -H $host info | grep -q -e \"Nodes: $total\" -e \"Offers: $total\""
 }
 
-# Start the swarm manager in background.
 function swarm_manage() {
+	local i=${#SWARM_MANAGE_PID[@]}
+
+	swarm_manage_no_wait "$@"
+
+	# Wait for nodes to be discovered
+	discovery_check_swarm_info "${#HOSTS[@]}" "${SWARM_HOSTS[$i]}"
+}
+
+# Start the swarm manager in background.
+function swarm_manage_no_wait() {
 	local discovery
 	if [ $# -eq 0 ]; then
 		discovery=`join , ${HOSTS[@]}`
@@ -114,9 +123,6 @@ function swarm_manage() {
 
 	# Wait for the Manager to be reachable
 	wait_until_reachable "$host"
-
-	# Wait for nodes to be discovered
-	discovery_check_swarm_info "${#HOSTS[@]}" "$host"
 }
 
 # swarm join every engine created with `start_docker`.

--- a/test/integration/mesos/zk/zk.bats
+++ b/test/integration/mesos/zk/zk.bats
@@ -32,7 +32,6 @@ function teardown() {
 	start_mesos_zk $DISCOVERY
 
 	swarm_manage --cluster-driver mesos-experimental $DISCOVERY
-	sleep 5
 
 	run docker_swarm info
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
There seems to be a race on the CI only (tests are now fine locally) that involves a race in the discovery. We issue a command before the Manager is ready and registers the Agents correctly. Thus we see random `No Healthy Node available in the cluster` errors on random tests.

Might be a side effect of limited resources on a Jenkins host (only a limited subset of machines seems to be affected).

Signed-off-by: Alexandre Beslic <abronan@docker.com>