### PR TITLE
Integration: fix --kernel-memory value set too low

### DIFF
--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -59,8 +59,8 @@ function teardown() {
 			 --pid=host \
 			 --memory-swappiness=2 \
 			 --group-add="root" \
-			 --memory-reservation=100 \
-			 --kernel-memory=100 \
+			 --memory-reservation=100M \
+			 --kernel-memory=100M \
 			 --dns-opt="someDnsOption" \
 			 --stop-signal="SIGKILL" \
 			 busybox sleep 1000
@@ -92,9 +92,9 @@ function teardown() {
 	# group-add
 	[[ "${output}" == *"root"* ]]
 	# memory-reservation
-	[[ "${output}" == *"\"MemoryReservation\": 100"* ]]
+	[[ "${output}" == *"\"MemoryReservation\": 104857600"* ]]
 	# kernel-memory
-	[[ "${output}" == *"\"KernelMemory\": 100"* ]]
+	[[ "${output}" == *"\"KernelMemory\": 104857600"* ]]
 	# dns-opt
 	[[ "${output}" == *"someDnsOption"* ]]
 	# stop-signal


### PR DESCRIPTION
Related to docker/docker#18272

`--kernel-memory` value was set too low in the CI, test was passing because setting `--kernel-memory` had no effect until now. As it is fixed in `docker:master`, the test would fail either with `cannot start container: broken pipe` or would crash the Jenkins slave process on the host.

Signed-off-by: Alexandre Beslic <abronan@docker.com>