### PR TITLE
Fix retry time when check disconnect events

### DIFF
--- a/test/integration/discovery/etcd.bats
+++ b/test/integration/discovery/etcd.bats
@@ -143,7 +143,7 @@ function teardown() {
 	retry 15 1 discovery_check_swarm_info 0
 
 	# Check disconnect events
-	retry 5 1 grep -q "engine_disconnect" "$log_file"
+	retry 15 1 grep -q "engine_disconnect" "$log_file"
 
 	# Finally, clean up `docker events` and remove the log file
 	kill "$events_pid"


### PR DESCRIPTION
Sometime `check disconnect events` failed because the retry time is short.
Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>