### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,52 @@
-Alexandre Beslic <abronan@docker.com> (@abronan)
-Andrea Luzzardi <al@docker.com> (@aluzzardi)
-Chanwit Kaewkasi <chanwit@gmail.com> (@chanwit)
-Victor Vieux <vieux@docker.com> (@vieux)
-Xian Chaobo <xianchaobo@huawei.com> (@jimmyxian)
+# Swarm maintainers file
+#
+# This file describes who runs the docker/swarm project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"abronan",
+			"aluzzardi",
+			"chanwit",
+			"jimmyxian",
+			"vieux",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.abronan]
+	Name = "Alexandre Beslic"
+	Email = "abronan@docker.com"
+	GitHub = "abronan"
+
+	[people.aluzzardi]
+	Name = "Andrea Luzzardi"
+	Email = "al@docker.com"
+	GitHub = "aluzzardi"
+
+	[people.chanwit]
+	Name = "Chanwit Kaewkasi"
+	Email = "chanwit@gmail.com"
+	GitHub = "chanwit"
+
+	[people.vieux]
+	Name = "Victor Vieux"
+	Email = "vieux@docker.com"
+	GitHub = "vieux"
+
+	[people.jimmyxian]
+	Name = "Xian Chaobo"
+	Email = "xianchaobo@huawei.com"
+	GitHub = "jimmyxian"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321
