### PR TITLE
Increase default TTL and heartbeat value

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -48,12 +48,12 @@ var (
 	}
 	flHeartBeat = cli.StringFlag{
 		Name:  "heartbeat",
-		Value: "20s",
+		Value: "60s",
 		Usage: "period between each heartbeat",
 	}
 	flTTL = cli.StringFlag{
 		Name:  "ttl",
-		Value: "60s",
+		Value: "180s",
 		Usage: "sets the expiration of an ephemeral node",
 	}
 	flTimeout = cli.StringFlag{

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -184,6 +184,14 @@ func (e *Engine) IsHealthy() bool {
 	return e.healthy
 }
 
+// Status returns the health status of the Engine: Healthy or Unhealthy
+func (e *Engine) Status() string {
+	if e.healthy {
+		return "Healthy"
+	}
+	return "Unhealthy"
+}
+
 // Gather engine specs (CPU, memory, constraints, ...).
 func (e *Engine) updateSpecs() error {
 	info, err := e.client.Info()

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -734,6 +734,7 @@ func (c *Cluster) Info() [][]string {
 
 	for _, engine := range engines {
 		info = append(info, []string{engine.Name, engine.Addr})
+		info = append(info, []string{" └ Status", engine.Status()})
 		info = append(info, []string{" └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
 		info = append(info, []string{" └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})
 		info = append(info, []string{" └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(engine.UsedMemory())), units.BytesSize(float64(engine.TotalMemory())))})


### PR DESCRIPTION
Increases the default TTL and heartbeat value for discovery.
Because the node will still be listed for a long period on
`docker info`, there is now a Status to know if a node is
in the healthy or unhealthy state.

Fixes #1485 

I think a default 3 minutes TTL and 60 seconds heartbeat is fair for now. We can reconsider and increase that default value when we'll have Node Management proposed in #1486.

Depends on #1500 .Without it, there is a probability that the scheduler will block subsequent requests for up to 60 seconds. Because of the probability to pick the downed node before it being marked as Unhealthy by the refresh loop which can take up to `max_refresh_time`.