### PR TITLE
Add @mhbauer to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,6 +15,7 @@
 			"aluzzardi",
 			"chanwit",
 			"jimmyxian",
+			"mhbauer",
 			"vieux",
 		]
 
@@ -40,6 +41,11 @@
 	Name = "Chanwit Kaewkasi"
 	Email = "chanwit@gmail.com"
 	GitHub = "chanwit"
+
+	[people.mhbauer]
+	Name = "Morgan Bauer"
+	Email = "mbauer@us.ibm.com"
+	GitHub = "mhbauer"
 
 	[people.vieux]
 	Name = "Victor Vieux"


### PR DESCRIPTION
Let me know if I put it into the wrong place. The "org-People" section seems to be in order by key, while the people definition section seems to be in order by given name. 

almost did spaces instead of tabs. phew.