### PR TITLE
Use failureCount as a secondary health indicator.

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -386,6 +386,7 @@ func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	client, scheme := newClientAndScheme(c.tlsConfig)
 
 	resp, err := client.Get(scheme + "://" + container.Engine.Addr + "/containers/" + container.Id + "/json")
+	container.Engine.CheckConnectionErr(err)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -670,6 +671,7 @@ func postContainersExec(c *context, w http.ResponseWriter, r *http.Request) {
 	client, scheme := newClientAndScheme(c.tlsConfig)
 
 	resp, err := client.Post(scheme+"://"+container.Engine.Addr+"/containers/"+container.Id+"/exec", "application/json", r.Body)
+	container.Engine.CheckConnectionErr(err)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -796,7 +798,8 @@ func proxyNetwork(c *context, w http.ResponseWriter, r *http.Request) {
 func proxyVolume(c *context, w http.ResponseWriter, r *http.Request) {
 	var name = mux.Vars(r)["volumename"]
 	if volume := c.cluster.Volume(name); volume != nil {
-		proxy(c.tlsConfig, volume.Engine.Addr, w, r)
+		err := proxy(c.tlsConfig, volume.Engine.Addr, w, r)
+		volume.Engine.CheckConnectionErr(err)
 		return
 	}
 	httpError(w, fmt.Sprintf("No such volume: %s", name), http.StatusNotFound)
@@ -838,7 +841,9 @@ func proxyNetworkContainerOperation(c *context, w http.ResponseWriter, r *http.R
 	}
 
 	// request is forwarded to the container's address
-	if err := proxyAsync(c.tlsConfig, container.Engine.Addr, w, r, cb); err != nil {
+	err := proxyAsync(c.tlsConfig, container.Engine.Addr, w, r, cb)
+	container.Engine.CheckConnectionErr(err)
+	if err != nil {
 		httpError(w, err.Error(), http.StatusNotFound)
 	}
 }
@@ -856,7 +861,9 @@ func proxyContainer(c *context, w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = strings.Replace(r.URL.Path, name, container.Id, 1)
 	}
 
-	if err := proxy(c.tlsConfig, container.Engine.Addr, w, r); err != nil {
+	err = proxy(c.tlsConfig, container.Engine.Addr, w, r)
+	container.Engine.CheckConnectionErr(err)
+	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -879,7 +886,9 @@ func proxyContainerAndForceRefresh(c *context, w http.ResponseWriter, r *http.Re
 		container.Refresh()
 	}
 
-	if err := proxyAsync(c.tlsConfig, container.Engine.Addr, w, r, cb); err != nil {
+	err = proxyAsync(c.tlsConfig, container.Engine.Addr, w, r, cb)
+	container.Engine.CheckConnectionErr(err)
+	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -889,7 +898,8 @@ func proxyImage(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 
 	if image := c.cluster.Image(name); image != nil {
-		proxy(c.tlsConfig, image.Engine.Addr, w, r)
+		err := proxy(c.tlsConfig, image.Engine.Addr, w, r)
+		image.Engine.CheckConnectionErr(err)
 		return
 	}
 	httpError(w, fmt.Sprintf("No such image: %s", name), http.StatusNotFound)
@@ -902,7 +912,8 @@ func proxyImageGet(c *context, w http.ResponseWriter, r *http.Request) {
 	for _, image := range c.cluster.Images() {
 		if len(strings.SplitN(name, ":", 2)) == 2 && image.Match(name, true) ||
 			len(strings.SplitN(name, ":", 2)) == 1 && image.Match(name, false) {
-			proxy(c.tlsConfig, image.Engine.Addr, w, r)
+			err := proxy(c.tlsConfig, image.Engine.Addr, w, r)
+			image.Engine.CheckConnectionErr(err)
 			return
 		}
 	}
@@ -925,7 +936,8 @@ func proxyImagePush(c *context, w http.ResponseWriter, r *http.Request) {
 	for _, image := range c.cluster.Images() {
 		if tag != "" && image.Match(name, true) ||
 			tag == "" && image.Match(name, false) {
-			proxy(c.tlsConfig, image.Engine.Addr, w, r)
+			err := proxy(c.tlsConfig, image.Engine.Addr, w, r)
+			image.Engine.CheckConnectionErr(err)
 			return
 		}
 	}
@@ -969,7 +981,9 @@ func proxyRandom(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := proxy(c.tlsConfig, engine.Addr, w, r); err != nil {
+	err = proxy(c.tlsConfig, engine.Addr, w, r)
+	engine.CheckConnectionErr(err)
+	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -1003,7 +1017,9 @@ func postCommit(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// proxy commit request to the right node
-	if err := proxyAsync(c.tlsConfig, container.Engine.Addr, w, r, cb); err != nil {
+	err = proxyAsync(c.tlsConfig, container.Engine.Addr, w, r, cb)
+	container.Engine.CheckConnectionErr(err)
+	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -1093,7 +1109,9 @@ func proxyHijack(c *context, w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = strings.Replace(r.URL.Path, name, container.Id, 1)
 	}
 
-	if err := hijack(c.tlsConfig, container.Engine.Addr, w, r); err != nil {
+	err = hijack(c.tlsConfig, container.Engine.Addr, w, r)
+	container.Engine.CheckConnectionErr(err)
+	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -26,7 +26,7 @@ var (
 				flHosts,
 				flLeaderElection, flLeaderTTL, flManageAdvertise,
 				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
-				flRefreshIntervalMin, flRefreshIntervalMax, flRefreshRetry,
+				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry,
 				flHeartBeat,
 				flEnableCors,
 				flCluster, flDiscoveryOpt, flClusterOpt},

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -26,7 +26,7 @@ var (
 				flHosts,
 				flLeaderElection, flLeaderTTL, flManageAdvertise,
 				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
-				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry,
+				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry, flRefreshRetry,
 				flHeartBeat,
 				flEnableCors,
 				flCluster, flDiscoveryOpt, flClusterOpt},

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -71,10 +71,10 @@ var (
 		Value: "60s",
 		Usage: "set engine refresh maximum interval",
 	}
-	flRefreshRetry = cli.IntFlag{
-		Name:  "engine-refresh-retry",
+	flFailureRetry = cli.IntFlag{
+		Name:  "engine-failure-retry",
 		Value: 3,
-		Usage: "set engine refresh retry count on failure",
+		Usage: "set engine failure retry count",
 	}
 	flEnableCors = cli.BoolFlag{
 		Name:  "api-enable-cors, cors",

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -71,6 +71,11 @@ var (
 		Value: "60s",
 		Usage: "set engine refresh maximum interval",
 	}
+	flRefreshRetry = cli.IntFlag{
+		Name:  "engine-refresh-retry",
+		Value: 3,
+		Usage: "deprecated; replaced by --engine-failure-retry",
+	}
 	flFailureRetry = cli.IntFlag{
 		Name:  "engine-failure-retry",
 		Value: 3,

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -240,14 +240,14 @@ func manage(c *cli.Context) {
 	if refreshMaxInterval < refreshMinInterval {
 		log.Fatal("max refresh interval cannot be less than min refresh interval")
 	}
-	refreshRetry := c.Int("engine-refresh-retry")
-	if refreshRetry <= 0 {
-		log.Fatal("invalid refresh retry count")
+	failureRetry := c.Int("engine-failure-retry")
+	if failureRetry <= 0 {
+		log.Fatal("invalid failure retry count")
 	}
 	engineOpts := &cluster.EngineOpts{
 		RefreshMinInterval: refreshMinInterval,
 		RefreshMaxInterval: refreshMaxInterval,
-		RefreshRetry:       refreshRetry,
+		FailureRetry:       failureRetry,
 	}
 
 	uri := getDiscovery(c)

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -240,6 +240,11 @@ func manage(c *cli.Context) {
 	if refreshMaxInterval < refreshMinInterval {
 		log.Fatal("max refresh interval cannot be less than min refresh interval")
 	}
+	// engine-refresh-retry is deprecated
+	refreshRetry := c.Int("engine-refresh-retry")
+	if refreshRetry != 3 {
+		log.Fatal("--engine-refresh-retry is deprecated. Use --engine-failure-retry")
+	}
 	failureRetry := c.Int("engine-failure-retry")
 	if failureRetry <= 0 {
 		log.Fatal("invalid failure retry count")

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -42,7 +42,7 @@ func TestEngineFailureCount(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	for i := 0; i < engine.opts.FailureRetry; i++ {
 		assert.True(t, engine.IsHealthy())
-		engine.IncFailureCount()
+		engine.incFailureCount()
 	}
 	assert.False(t, engine.IsHealthy())
 }

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -38,6 +38,15 @@ var (
 	}
 )
 
+func TestEngineFailureCount(t *testing.T) {
+	engine := NewEngine("test", 0, engOpts)
+	for i := 0; i < engineFailureCountThreshold; i++ {
+		assert.True(t, engine.IsHealthy())
+		engine.IncFailureCount()
+	}
+	assert.False(t, engine.IsHealthy())
+}
+
 func TestEngineConnectionFailure(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.False(t, engine.isConnected())

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -34,13 +34,13 @@ var (
 	engOpts = &EngineOpts{
 		RefreshMinInterval: time.Duration(30) * time.Second,
 		RefreshMaxInterval: time.Duration(60) * time.Second,
-		RefreshRetry:       3,
+		FailureRetry:       3,
 	}
 )
 
 func TestEngineFailureCount(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	for i := 0; i < engineFailureCountThreshold; i++ {
+	for i := 0; i < engine.opts.FailureRetry; i++ {
 		assert.True(t, engine.IsHealthy())
 		engine.IncFailureCount()
 	}

--- a/cluster/mesos/cluster_test.go
+++ b/cluster/mesos/cluster_test.go
@@ -13,7 +13,7 @@ func createAgent(t *testing.T, ID string, containers ...*cluster.Container) *age
 	engOpts := &cluster.EngineOpts{
 		RefreshMinInterval: time.Duration(30) * time.Second,
 		RefreshMaxInterval: time.Duration(60) * time.Second,
-		RefreshRetry:       3,
+		FailureRetry:       3,
 	}
 	engine := cluster.NewEngine(ID, 0, engOpts)
 	engine.Name = ID

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -43,7 +43,7 @@ var (
 	engOpts = &cluster.EngineOpts{
 		RefreshMinInterval: time.Duration(30) * time.Second,
 		RefreshMaxInterval: time.Duration(60) * time.Second,
-		RefreshRetry:       3,
+		FailureRetry:       3,
 	}
 )
 

--- a/test/integration/api/logs.bats
+++ b/test/integration/api/logs.bats
@@ -30,7 +30,7 @@ function teardown() {
 
 @test "docker logs unhealthy node" {
 	start_docker_with_busybox 1
-	swarm_manage --engine-refresh-min-interval=1s --engine-refresh-max-interval=1s --engine-refresh-retry=1 ${HOSTS[0]}
+	swarm_manage --engine-refresh-min-interval=1s --engine-refresh-max-interval=1s --engine-failure-retry=1 ${HOSTS[0]}
 
 	# run a container with echo command
 	docker_swarm run -d --name test_container busybox /bin/sh -c "echo hello world; echo hello docker; echo hello swarm"

--- a/test/integration/engine_options.bats
+++ b/test/integration/engine_options.bats
@@ -14,7 +14,7 @@ load helpers
 	[[ "${output}" == *"max refresh interval cannot be less than min refresh interval"* ]]
 
 	# engine refresh retry count
-	run swarm manage --engine-refresh-retry 0 --advertise 127.0.0.1:$SWARM_BASE_PORT 192.168.56.202:4444
+	run swarm manage --engine-failure-retry 0 --advertise 127.0.0.1:$SWARM_BASE_PORT 192.168.56.202:4444
 	[ "$status" -ne 0 ]
-	[[ "${output}" == *"invalid refresh retry count"* ]]
+	[[ "${output}" == *"invalid failure retry count"* ]]
 }


### PR DESCRIPTION
We will use failureCount to record connection failure or other engine unhealthy errors. When failureCount reaches threshold, engine is marked as unhealthy. This can fail engine fast, comparing with normal engine refresh loop. Ideally, failureCount can also be used to lower the priority of a engine in node selection so container creation has a higher success rate. This is under discussion/debate. 

This change is to implement fail/recover fast for Node Management #1486.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>