### PR TITLE
[DO NOT MERGE] add a test with network overlay

### DIFF
--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -77,6 +77,32 @@ function teardown() {
 	[ "$status" -ne 0 ]
 }
 
+@test "docker network create - overlay" {
+	PORT=$((RANDOM % 1000 + 9000))
+	STORE_HOST=127.0.0.1:$PORT
+
+	docker_host run -d \
+		--net=host \
+		--name=swarm_etcd \
+		quay.io/coreos/etcd:v2.2.0 \
+		--listen-client-urls="http://0.0.0.0:${PORT}" \
+		--advertise-client-urls="http://${STORE_HOST}"
+
+
+	start_docker 2 --cluster-advertise=127.0.0.1:_port --cluster-store=etcd://$STORE_HOST
+	swarm_manage
+
+	run docker_swarm network ls
+	[ "${#lines[@]}" -eq 7 ]
+
+	docker_swarm network create test
+	run docker_swarm network ls
+	[[ "${output}" == *"overlay"* ]]
+	[ "${#lines[@]}" -eq 8 ]
+
+	docker_host rm -f -v swarm_etcd
+}
+
 @test "docker network rm" {
 	start_docker_with_busybox 2
 	swarm_manage

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -211,7 +211,7 @@ function start_docker() {
 				docker daemon -H 127.0.0.1:$port \
 					-H=unix:///var/run/docker.sock \
 					--storage-driver=$STORAGE_DRIVER \
-					`join ' ' $@` \
+					`join ' ' ${@/_port/$port}` \
 		")
 	done
 


### PR DESCRIPTION
@mrjana @mavenugo one of you told me you managed to have overlay networking work with dind.

The swarm ci uses dind and I'm not able to make it work.

As you can see from those 2 tests, I'm able to create the network fine,
but I get `Error response from daemon: subnet sandbox join failed for "10.0.0.0/24": error creating vxlan interface: file exists`
when I try to docker run

Can you take a look ?
