### PR TITLE
Log Redirection

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,13 +2,12 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/docker/swarm/experimental"
 	"github.com/docker/swarm/version"
+	"os"
+	"path"
 )
 
 // Run the Swarm CLI.
@@ -27,7 +26,6 @@ func Run() {
 			Usage:  "debug mode",
 			EnvVar: "DEBUG",
 		},
-
 		cli.StringFlag{
 			Name:  "log-level, l",
 			Value: "info",
@@ -38,11 +36,24 @@ func Run() {
 			Name:  "experimental",
 			Usage: "enable experimental features",
 		},
+		cli.StringFlag{
+			Name:  "log-file",
+			Usage: "Logging the output to a file instead of stdout",
+		},
 	}
-
 	// logs
 	app.Before = func(c *cli.Context) error {
 		log.SetOutput(os.Stderr)
+		if c.IsSet("log-file") {
+			logDir := c.String("log-file")
+			file, err := os.OpenFile(logDir, os.O_RDWR, 0777)
+			if err != nil {
+				//log.Warn("Error creating log file: falling back to default method")
+				log.Fatalf(err.Error())
+			} else {
+				log.SetOutput(file)
+			}
+		}
 		level, err := log.ParseLevel(c.String("log-level"))
 		if err != nil {
 			log.Fatalf(err.Error())


### PR DESCRIPTION
Editing cli/cli.go and cli/flags.go to allow logging to a file instead of to stdout.

Apologies for the new pull request. I accidentally closed the pull request when rebasing and amending.

Signed-off-by: CiaranCostello costelci@tcd.ie
