### PR TITLE
docs: add note for the case of the daemon being started through ssh

### DIFF
--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -36,6 +36,13 @@ Docker engine as registered. To workaround this problem, you can generate a new
 ID for each node with affected by this issue. To do this stop the daemon on a node,
 delete its `/etc/docker/key.json` file, and restart the daemon.
 
+If you use `ssh` to start the Engine `daemon`, make sure the daemon runs in the
+background. You can do this using `disown` or `nohup` in combination with the `&`
+(ampersand). Or you could launch the `daemon` through `systemd` or any other
+Linux-distribution-specific method. Regardless of which launch method you
+choose, make sure the daemon process does not stop when your session on a node
+ends.
+
 You can run Docker Swarm on Linux 64-bit architectures. You can also install and
 run it on 64-bit Windows and Max OSX but these architectures are *not* regularly
 tested for compatibility.


### PR DESCRIPTION
Add a simple note in the case the daemon is started through SSH for the manual install process.

Fixes #1343 

/cc @moxiegirl 

Signed-off-by: Alexandre Beslic <abronan@docker.com>