### PR TITLE
Improve node management.

### DIFF
--- a/cluster/mesos/driver.go
+++ b/cluster/mesos/driver.go
@@ -47,6 +47,8 @@ func (c *Cluster) ResourceOffers(_ mesosscheduler.SchedulerDriver, offers []*mes
 			if err := engine.Connect(c.TLSConfig); err != nil {
 				log.Error(err)
 			} else {
+				// Set engine state to healthy and start refresh loop
+				engine.ValidationComplete()
 				s = newAgent(agentID, engine)
 				c.agents[agentID] = s
 				if err := s.engine.RegisterEventHandler(c); err != nil {

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -327,9 +327,10 @@ func (c *Cluster) monitorDiscovery(ch <-chan discovery.Entries, errCh <-chan err
 
 // monitorPendingEngines checks if some previous unreachable/invalid engines have been fixed
 func (c *Cluster) monitorPendingEngines() {
+	const minimumValidationInterval time.Duration = 10 * time.Second
 	for {
 		// Don't need to do it frequently
-		time.Sleep(10 * time.Second)
+		time.Sleep(minimumValidationInterval)
 		// Get the list of pendingEngines
 		c.RLock()
 		pEngines := make([]*cluster.Engine, 0, len(c.pendingEngines))

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -805,7 +805,11 @@ func (c *Cluster) Info() [][]string {
 		}
 		sort.Strings(labels)
 		info = append(info, []string{" └ Labels", fmt.Sprintf("%s", strings.Join(labels, ", "))})
-		info = append(info, []string{" └ Error", engine.ErrMsg()})
+		errMsg := engine.ErrMsg()
+		if len(errMsg) == 0 {
+			errMsg = "(none)"
+		}
+		info = append(info, []string{" └ Error", errMsg})
 		info = append(info, []string{" └ UpdatedAt", engine.UpdatedAt().UTC().Format(time.RFC3339)})
 	}
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -329,7 +329,7 @@ func (c *Cluster) monitorDiscovery(ch <-chan discovery.Entries, errCh <-chan err
 func (c *Cluster) monitorPendingEngines() {
 	for {
 		// Don't need to do it frequently
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		// Get the list of pendingEngines
 		c.RLock()
 		pEngines := make([]*cluster.Engine, 0, len(c.pendingEngines))

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -25,7 +25,7 @@ func (nopCloser) Close() error {
 
 var (
 	mockInfo = &dockerclient.Info{
-		ID:              "id",
+		ID:              "test-engine",
 		Name:            "name",
 		NCPU:            10,
 		MemTotal:        20,

--- a/test/integration/nodemanagement/engine_options.bats
+++ b/test/integration/nodemanagement/engine_options.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load helpers
+load ../helpers
 
 @test "engine refresh options" {
 	# minimum refresh interval
@@ -8,7 +8,7 @@ load helpers
 	[ "$status" -ne 0 ]
 	[[ "${output}" == *"minimum refresh interval should be a positive number"* ]]
 
-	# max refresh interval 
+	# max refresh interval
 	run swarm manage --engine-refresh-min-interval "30s" -engine-refresh-max-interval "20s" --advertise 127.0.0.1:$SWARM_BASE_PORT 192.168.56.202:4444
 	[ "$status" -ne 0 ]
 	[[ "${output}" == *"max refresh interval cannot be less than min refresh interval"* ]]

--- a/test/integration/nodemanagement/state.bats
+++ b/test/integration/nodemanagement/state.bats
@@ -31,17 +31,17 @@ function setup_discovery_file() {
 	# Start swarm and check it can reach the node
 	swarm_manage --engine-refresh-min-interval "1s" --engine-refresh-max-interval "1s" --engine-failure-retry 2 "$DISCOVERY"
 
-  eval "docker_swarm info | grep -q -i 'Status: Healthy'"
+	eval "docker_swarm info | grep -q -i 'Status: Healthy'"
 
 	# Stop the node and let it fail
 	docker_host stop ${DOCKER_CONTAINERS[0]}
-  # Wait for swarm to detect node failure
-  retry 5 1 eval "docker_swarm info | grep -q -i 'Status: Unhealthy'"
+	# Wait for swarm to detect node failure
+	retry 5 1 eval "docker_swarm info | grep -q -i 'Status: Unhealthy'"
 
 	# Restart node
 	docker_host start ${DOCKER_CONTAINERS[0]}
-  # Wait for swarm to detect node recovery
-  retry 5 1 eval "docker_swarm info | grep -q -i 'Status: Healthy'"
+	# Wait for swarm to detect node recovery
+	retry 5 1 eval "docker_swarm info | grep -q -i 'Status: Healthy'"
 }
 
 @test "node pending and recovery" {
@@ -53,11 +53,11 @@ function setup_discovery_file() {
 
 	# Start swarm with the stopped node
 	swarm_manage_no_wait "$DISCOVERY"
-  retry 2 1 eval "docker_swarm info | grep -q -i 'Status: Pending'"
+	retry 2 1 eval "docker_swarm info | grep -q -i 'Status: Pending'"
 
 	# Restart the node
 	docker_host start ${DOCKER_CONTAINERS[0]}
-  # Wait for swarm to detect node recovery
-  retry 15 3 eval "docker_swarm info | grep -q -i 'Status: Healthy'"
+	# Wait for swarm to detect node recovery
+	retry 15 3 eval "docker_swarm info | grep -q -i 'Status: Healthy'"
 }
 

--- a/test/integration/nodemanagement/state.bats
+++ b/test/integration/nodemanagement/state.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+DISCOVERY_FILE=""
+DISCOVERY=""
+
+function setup() {
+	# create a blank temp file for discovery
+	DISCOVERY_FILE=$(mktemp)
+	DISCOVERY="file://$DISCOVERY_FILE"
+}
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_docker
+	rm -f "$DISCOVERY_FILE"
+}
+
+function setup_discovery_file() {
+	rm -f "$DISCOVERY_FILE"
+	for host in ${HOSTS[@]}; do
+		echo "$host" >> $DISCOVERY_FILE
+	done
+}
+
+@test "node failure and recovery" {
+	# Start 1 engine and register it in the file.
+	start_docker 1
+	setup_discovery_file
+	# Start swarm and check it can reach the node
+	swarm_manage --engine-refresh-min-interval "1s" --engine-refresh-max-interval "1s" --engine-failure-retry 2 "$DISCOVERY"
+
+	run docker_swarm info
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Status: Healthy"* ]]
+
+	# Stop the node and let it fail
+	docker_host stop ${DOCKER_CONTAINERS[0]}
+	sleep 4
+
+	# Verify swarm detects node failure
+	run docker_swarm info
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Status: Unhealthy"* ]]
+
+	# Verify swarm detects recovery
+	docker_host start ${DOCKER_CONTAINERS[0]}
+	sleep 4
+	run docker_swarm info
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Status: Healthy"* ]]
+}
+
+@test "node pending and recovery" {
+	# Start 1 engine and register it in the file.
+	start_docker 1
+	setup_discovery_file
+	# Stop the node
+	docker_host stop ${DOCKER_CONTAINERS[0]}
+
+	# Start swarm with the stopped node
+	swarm_manage_no_wait "$DISCOVERY"
+	run docker_swarm info
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Status: Pending"* ]]
+
+	# Restart the node and wait for revalidation
+	docker_host start ${DOCKER_CONTAINERS[0]}
+	sleep 40
+
+	# Verify swarm detects recovery
+	run docker_swarm info
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Status: Healthy"* ]]
+}
+


### PR DESCRIPTION
This change improves swarm node management according to proposal #1486. 
1. Introduce pending state. Pending nodes need validation before moving to healthy state. Resolve issues of duplicate ID and no join retry for unreachable node issues.
2. Expose error and last update time in docker info.
3. Use connect success/failure to drive state transition between healthy and unhealthy.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>