### PR TITLE
 do not save image affinity on reschedule

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -159,6 +159,22 @@ func (c *ContainerConfig) AddAffinity(affinity string) error {
 	return nil
 }
 
+// RemoveAffinity from config
+func (c *ContainerConfig) RemoveAffinity(affinity string) error {
+	affinities := []string{}
+	for _, a := range c.extractExprs("affinities") {
+		if a != affinity {
+			affinities = append(affinities, a)
+		}
+	}
+	labels, err := json.Marshal(affinities)
+	if err != nil {
+		return err
+	}
+	c.Labels[SwarmLabelNamespace+".affinities"] = string(labels)
+	return nil
+}
+
 // HaveNodeConstraint in config
 func (c *ContainerConfig) HaveNodeConstraint() bool {
 	constraints := c.extractExprs("constraints")

--- a/cluster/config_test.go
+++ b/cluster/config_test.go
@@ -90,6 +90,20 @@ func TestAddAffinity(t *testing.T) {
 	assert.Len(t, config.Affinities(), 1)
 }
 
+func TestRemoveAffinity(t *testing.T) {
+	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	assert.Empty(t, config.Affinities())
+
+	config.AddAffinity("image==~testimage1")
+	config.AddAffinity("image==~testimage2")
+	assert.Len(t, config.Affinities(), 2)
+
+	config.RemoveAffinity("image==~testimage1")
+	assert.Len(t, config.Affinities(), 1)
+
+	assert.Equal(t, config.Affinities()[0], "image==~testimage2")
+}
+
 func TestHaveNodeConstraint(t *testing.T) {
 	config := BuildContainerConfig(dockerclient.ContainerConfig{})
 	assert.False(t, config.HaveNodeConstraint())

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -101,7 +101,7 @@ function teardown() {
 	[[ "${output}" == *"\"StopSignal\": \"SIGKILL\""* ]]
 }
 
-@test "docker run - reschedule with soft-image-affinity" {
+@test "docker run - reschedule with image affinity" {
 	start_docker_with_busybox 1
 	start_docker 1
 
@@ -115,15 +115,19 @@ function teardown() {
 
 	# try to create container on node-1, node-1 does not have busyboxabcde and will pull it
 	# but can not find busyboxabcde in dockerhub
-	# then will retry with soft-image-affinity
+	# then will retry with image affinity
 	docker_swarm run -d --name test_container -e constraint:node==~node-1 busyboxabcde sleep 1000
 
 	# check container running on node-0
 	run docker_swarm ps
 	[[ "${output}" == *"node-0/test_container"* ]]
+
+	# check the image affinity wasn't saved
+	run docker_swarm inspect test_container
+	[[ "${output}" != *"image==busyboxabcde"* ]]
 }
 
-@test "docker run - reschedule with soft-image-affinity and node constraint" {
+@test "docker run - reschedule with image affinity and node constraint" {
 	start_docker_with_busybox 1
 	start_docker 1
 


### PR DESCRIPTION
it was the original intent, but wasn't working correctly /cc @jimmyxian 
Thanks @dongluochen for catching it.

using `configTemp := *config` and using `configTemp` doesn't do the trick since the embed `Label` field in a map (pointer)
So I decided to go toward the `RemoveAffinity` approach.