### PR TITLE
add buildtime, kernelversion and experimental to API version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/docker/swarm
 WORKDIR /go/src/github.com/docker/swarm
 
 ENV GOPATH /go/src/github.com/docker/swarm/Godeps/_workspace:$GOPATH
-RUN CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD`"
+RUN CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD` -X github.com/docker/swarm/version.BUILDTIME \"`date -u`\""
 
 ENV SWARM_HOST :2375
 EXPOSE 2375

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -47,6 +47,11 @@
 			"Rev": "f11b6a2ab313a03d051dd6f69d264d0482df72d6"
 		},
 		{
+			"ImportPath": "github.com/docker/docker/pkg/parsers/kernel",
+			"Comment": "v1.4.1-9107-gf11b6a2",
+			"Rev": "f11b6a2ab313a03d051dd6f69d264d0482df72d6"
+		},
+		{
 			"ImportPath": "github.com/docker/docker/pkg/random",
 			"Comment": "v1.4.1-9107-gf11b6a2",
 			"Rev": "f11b6a2ab313a03d051dd6f69d264d0482df72d6"
@@ -62,9 +67,14 @@
 			"Rev": "f11b6a2ab313a03d051dd6f69d264d0482df72d6"
 		},
 		{
-			"ImportPath": "github.com/docker/engine-api/types/filters",
+			"ImportPath": "github.com/docker/engine-api/types",
 			"Comment": "v0.2.0",
 			"Rev": "259fce04b5a17bc7a202090d52ca873762fa8b25"
+		},
+		{
+			"ImportPath": "github.com/docker/go-connections/nat",
+			"Comment": "v0.1.2",
+			"Rev": "4e42727957c146776e5de9cec8c39e4059ed9f20"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/tlsconfig",

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/kernel.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/kernel.go
@@ -1,0 +1,100 @@
+// +build !windows
+
+// Package kernel provides helper function to get, parse and compare kernel
+// versions for different platforms.
+package kernel
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// VersionInfo holds information about the kernel.
+type VersionInfo struct {
+	Kernel int    // Version of the kernel (e.g. 4.1.2-generic -> 4)
+	Major  int    // Major part of the kernel version (e.g. 4.1.2-generic -> 1)
+	Minor  int    // Minor part of the kernel version (e.g. 4.1.2-generic -> 2)
+	Flavor string // Flavor of the kernel version (e.g. 4.1.2-generic -> generic)
+}
+
+func (k *VersionInfo) String() string {
+	return fmt.Sprintf("%d.%d.%d%s", k.Kernel, k.Major, k.Minor, k.Flavor)
+}
+
+// CompareKernelVersion compares two kernel.VersionInfo structs.
+// Returns -1 if a < b, 0 if a == b, 1 it a > b
+func CompareKernelVersion(a, b VersionInfo) int {
+	if a.Kernel < b.Kernel {
+		return -1
+	} else if a.Kernel > b.Kernel {
+		return 1
+	}
+
+	if a.Major < b.Major {
+		return -1
+	} else if a.Major > b.Major {
+		return 1
+	}
+
+	if a.Minor < b.Minor {
+		return -1
+	} else if a.Minor > b.Minor {
+		return 1
+	}
+
+	return 0
+}
+
+// GetKernelVersion gets the current kernel version.
+func GetKernelVersion() (*VersionInfo, error) {
+	var (
+		err error
+	)
+
+	uts, err := uname()
+	if err != nil {
+		return nil, err
+	}
+
+	release := make([]byte, len(uts.Release))
+
+	i := 0
+	for _, c := range uts.Release {
+		release[i] = byte(c)
+		i++
+	}
+
+	// Remove the \x00 from the release for Atoi to parse correctly
+	release = release[:bytes.IndexByte(release, 0)]
+
+	return ParseRelease(string(release))
+}
+
+// ParseRelease parses a string and creates a VersionInfo based on it.
+func ParseRelease(release string) (*VersionInfo, error) {
+	var (
+		kernel, major, minor, parsed int
+		flavor, partial              string
+	)
+
+	// Ignore error from Sscanf to allow an empty flavor.  Instead, just
+	// make sure we got all the version numbers.
+	parsed, _ = fmt.Sscanf(release, "%d.%d%s", &kernel, &major, &partial)
+	if parsed < 2 {
+		return nil, errors.New("Can't parse kernel version " + release)
+	}
+
+	// sometimes we have 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64
+	parsed, _ = fmt.Sscanf(partial, ".%d%s", &minor, &flavor)
+	if parsed < 1 {
+		flavor = partial
+	}
+
+	return &VersionInfo{
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
+		Flavor: flavor,
+	}, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/kernel_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/kernel_windows.go
@@ -1,0 +1,67 @@
+package kernel
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// VersionInfo holds information about the kernel.
+type VersionInfo struct {
+	kvi   string // Version of the kernel (e.g. 6.1.7601.17592 -> 6)
+	major int    // Major part of the kernel version (e.g. 6.1.7601.17592 -> 1)
+	minor int    // Minor part of the kernel version (e.g. 6.1.7601.17592 -> 7601)
+	build int    // Build number of the kernel version (e.g. 6.1.7601.17592 -> 17592)
+}
+
+func (k *VersionInfo) String() string {
+	return fmt.Sprintf("%d.%d %d (%s)", k.major, k.minor, k.build, k.kvi)
+}
+
+// GetKernelVersion gets the current kernel version.
+func GetKernelVersion() (*VersionInfo, error) {
+
+	var (
+		h         syscall.Handle
+		dwVersion uint32
+		err       error
+	)
+
+	KVI := &VersionInfo{"Unknown", 0, 0, 0}
+
+	if err = syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE,
+		syscall.StringToUTF16Ptr(`SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\`),
+		0,
+		syscall.KEY_READ,
+		&h); err != nil {
+		return KVI, err
+	}
+	defer syscall.RegCloseKey(h)
+
+	var buf [1 << 10]uint16
+	var typ uint32
+	n := uint32(len(buf) * 2) // api expects array of bytes, not uint16
+
+	if err = syscall.RegQueryValueEx(h,
+		syscall.StringToUTF16Ptr("BuildLabEx"),
+		nil,
+		&typ,
+		(*byte)(unsafe.Pointer(&buf[0])),
+		&n); err != nil {
+		return KVI, err
+	}
+
+	KVI.kvi = syscall.UTF16ToString(buf[:])
+
+	// Important - docker.exe MUST be manifested for this API to return
+	// the correct information.
+	if dwVersion, err = syscall.GetVersion(); err != nil {
+		return KVI, err
+	}
+
+	KVI.major = int(dwVersion & 0xFF)
+	KVI.minor = int((dwVersion & 0XFF00) >> 8)
+	KVI.build = int((dwVersion & 0xFFFF0000) >> 16)
+
+	return KVI, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/uname_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/uname_linux.go
@@ -1,0 +1,19 @@
+package kernel
+
+import (
+	"syscall"
+)
+
+// Utsname represents the system name structure.
+// It is passthgrouh for syscall.Utsname in order to make it portable with
+// other platforms where it is not available.
+type Utsname syscall.Utsname
+
+func uname() (*syscall.Utsname, error) {
+	uts := &syscall.Utsname{}
+
+	if err := syscall.Uname(uts); err != nil {
+		return nil, err
+	}
+	return uts, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/uname_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/kernel/uname_unsupported.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package kernel
+
+import (
+	"errors"
+)
+
+// Utsname represents the system name structure.
+// It is defined here to make it portable as it is available on linux but not
+// on windows.
+type Utsname struct {
+	Release [65]byte
+}
+
+func uname() (*Utsname, error) {
+	return nil, errors.New("Kernel version detection is available only on linux")
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/auth.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/auth.go
@@ -1,0 +1,11 @@
+package types
+
+// AuthConfig contains authorization information for connecting to a Registry
+type AuthConfig struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth"`
+	Email         string `json:"email"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/blkiodev/blkio.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/blkiodev/blkio.go
@@ -1,0 +1,23 @@
+package blkiodev
+
+import "fmt"
+
+// WeightDevice is a structure that hold device:weight pair
+type WeightDevice struct {
+	Path   string
+	Weight uint16
+}
+
+func (w *WeightDevice) String() string {
+	return fmt.Sprintf("%s:%d", w.Path, w.Weight)
+}
+
+// ThrottleDevice is a structure that hold device:rate_per_second pair
+type ThrottleDevice struct {
+	Path string
+	Rate uint64
+}
+
+func (t *ThrottleDevice) String() string {
+	return fmt.Sprintf("%s:%d", t.Path, t.Rate)
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/client.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/client.go
@@ -1,0 +1,235 @@
+package types
+
+import (
+	"bufio"
+	"io"
+	"net"
+
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/go-units"
+)
+
+// ContainerAttachOptions holds parameters to attach to a container.
+type ContainerAttachOptions struct {
+	ContainerID string
+	Stream      bool
+	Stdin       bool
+	Stdout      bool
+	Stderr      bool
+	DetachKeys  string
+}
+
+// ContainerCommitOptions holds parameters to commit changes into a container.
+type ContainerCommitOptions struct {
+	ContainerID    string
+	RepositoryName string
+	Tag            string
+	Comment        string
+	Author         string
+	Changes        []string
+	Pause          bool
+	Config         *container.Config
+}
+
+// ContainerExecInspect holds information returned by exec inspect.
+type ContainerExecInspect struct {
+	ExecID      string
+	ContainerID string
+	Running     bool
+	ExitCode    int
+}
+
+// ContainerListOptions holds parameters to list containers with.
+type ContainerListOptions struct {
+	Quiet  bool
+	Size   bool
+	All    bool
+	Latest bool
+	Since  string
+	Before string
+	Limit  int
+	Filter filters.Args
+}
+
+// ContainerLogsOptions holds parameters to filter logs with.
+type ContainerLogsOptions struct {
+	ContainerID string
+	ShowStdout  bool
+	ShowStderr  bool
+	Since       string
+	Timestamps  bool
+	Follow      bool
+	Tail        string
+}
+
+// ContainerRemoveOptions holds parameters to remove containers.
+type ContainerRemoveOptions struct {
+	ContainerID   string
+	RemoveVolumes bool
+	RemoveLinks   bool
+	Force         bool
+}
+
+// CopyToContainerOptions holds information
+// about files to copy into a container
+type CopyToContainerOptions struct {
+	ContainerID               string
+	Path                      string
+	Content                   io.Reader
+	AllowOverwriteDirWithFile bool
+}
+
+// EventsOptions hold parameters to filter events with.
+type EventsOptions struct {
+	Since   string
+	Until   string
+	Filters filters.Args
+}
+
+// NetworkListOptions holds parameters to filter the list of networks with.
+type NetworkListOptions struct {
+	Filters filters.Args
+}
+
+// HijackedResponse holds connection information for a hijacked request.
+type HijackedResponse struct {
+	Conn   net.Conn
+	Reader *bufio.Reader
+}
+
+// Close closes the hijacked connection and reader.
+func (h *HijackedResponse) Close() {
+	h.Conn.Close()
+}
+
+// CloseWriter is an interface that implement structs
+// that close input streams to prevent from writing.
+type CloseWriter interface {
+	CloseWrite() error
+}
+
+// CloseWrite closes a readWriter for writing.
+func (h *HijackedResponse) CloseWrite() error {
+	if conn, ok := h.Conn.(CloseWriter); ok {
+		return conn.CloseWrite()
+	}
+	return nil
+}
+
+// ImageBuildOptions holds the information
+// necessary to build images.
+type ImageBuildOptions struct {
+	Tags           []string
+	SuppressOutput bool
+	RemoteContext  string
+	NoCache        bool
+	Remove         bool
+	ForceRemove    bool
+	PullParent     bool
+	IsolationLevel container.IsolationLevel
+	CPUSetCPUs     string
+	CPUSetMems     string
+	CPUShares      int64
+	CPUQuota       int64
+	CPUPeriod      int64
+	Memory         int64
+	MemorySwap     int64
+	CgroupParent   string
+	ShmSize        int64
+	Dockerfile     string
+	Ulimits        []*units.Ulimit
+	BuildArgs      map[string]string
+	AuthConfigs    map[string]AuthConfig
+	Context        io.Reader
+}
+
+// ImageBuildResponse holds information
+// returned by a server after building
+// an image.
+type ImageBuildResponse struct {
+	Body   io.ReadCloser
+	OSType string
+}
+
+// ImageCreateOptions holds information to create images.
+type ImageCreateOptions struct {
+	Parent       string // Parent is the name of the image to pull
+	Tag          string // Tag is the name to tag this image with
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+}
+
+// ImageImportOptions holds information to import images from the client host.
+type ImageImportOptions struct {
+	Source         io.Reader // Source is the data to send to the server to create this image from (mutually exclusive with SourceName)
+	SourceName     string    // SourceName is the name of the image to pull (mutually exclusive with Source)
+	RepositoryName string    // RepositoryName is the name of the repository to import this image into
+	Message        string    // Message is the message to tag the image with
+	Tag            string    // Tag is the name to tag this image with
+	Changes        []string  // Changes are the raw changes to apply to this image
+}
+
+// ImageListOptions holds parameters to filter the list of images with.
+type ImageListOptions struct {
+	MatchName string
+	All       bool
+	Filters   filters.Args
+}
+
+// ImageLoadResponse returns information to the client about a load process.
+type ImageLoadResponse struct {
+	Body io.ReadCloser
+	JSON bool
+}
+
+// ImagePullOptions holds information to pull images.
+type ImagePullOptions struct {
+	ImageID      string // ImageID is the name of the image to pull
+	Tag          string // Tag is the name of the tag to be pulled
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+}
+
+//ImagePushOptions holds information to push images.
+type ImagePushOptions ImagePullOptions
+
+// ImageRemoveOptions holds parameters to remove images.
+type ImageRemoveOptions struct {
+	ImageID       string
+	Force         bool
+	PruneChildren bool
+}
+
+// ImageSearchOptions holds parameters to search images with.
+type ImageSearchOptions struct {
+	Term         string
+	RegistryAuth string
+}
+
+// ImageTagOptions holds parameters to tag an image
+type ImageTagOptions struct {
+	ImageID        string
+	RepositoryName string
+	Tag            string
+	Force          bool
+}
+
+// ResizeOptions holds parameters to resize a tty.
+// It can be used to resize container ttys and
+// exec process ttys too.
+type ResizeOptions struct {
+	ID     string
+	Height int
+	Width  int
+}
+
+// VersionResponse holds version information for the client and the server
+type VersionResponse struct {
+	Client *Version
+	Server *Version
+}
+
+// ServerOK return true when the client could connect to the docker server
+// and parse the information received. It returns false otherwise.
+func (v VersionResponse) ServerOK() bool {
+	return v.Server != nil
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/configs.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/configs.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
+)
+
+// configs holds structs used for internal communication between the
+// frontend (such as an http server) and the backend (such as the
+// docker daemon).
+
+// ContainerCreateConfig is the parameter set to ContainerCreate()
+type ContainerCreateConfig struct {
+	Name             string
+	Config           *container.Config
+	HostConfig       *container.HostConfig
+	NetworkingConfig *network.NetworkingConfig
+	AdjustCPUShares  bool
+}
+
+// ContainerRmConfig holds arguments for the container remove
+// operation. This struct is used to tell the backend what operations
+// to perform.
+type ContainerRmConfig struct {
+	ForceRemove, RemoveVolume, RemoveLink bool
+}
+
+// ContainerCommitConfig contains build configs for commit operation,
+// and is used when making a commit with the current state of the container.
+type ContainerCommitConfig struct {
+	Pause   bool
+	Repo    string
+	Tag     string
+	Author  string
+	Comment string
+	// merge container config into commit config before commit
+	MergeConfigs bool
+	Config       *container.Config
+}
+
+// ExecConfig is a small subset of the Config struct that hold the configuration
+// for the exec feature of docker.
+type ExecConfig struct {
+	User         string   // User that will run the command
+	Privileged   bool     // Is the container in privileged mode
+	Tty          bool     // Attach standard streams to a tty.
+	Container    string   // Name of the container (to execute in)
+	AttachStdin  bool     // Attach the standard input, makes possible user interaction
+	AttachStderr bool     // Attach the standard output
+	AttachStdout bool     // Attach the standard error
+	Detach       bool     // Execute in detach mode
+	DetachKeys   string   // Escape keys for detach
+	Cmd          []string // Execution commands and args
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/container/config.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/container/config.go
@@ -1,0 +1,38 @@
+package container
+
+import (
+	"github.com/docker/engine-api/types/strslice"
+	"github.com/docker/go-connections/nat"
+)
+
+// Config contains the configuration data about a container.
+// It should hold only portable information about the container.
+// Here, "portable" means "independent from the host we are running on".
+// Non-portable information *should* appear in HostConfig.
+// All fields added to this struct must be marked `omitempty` to keep getting
+// predictable hashes from the old `v1Compatibility` configuration.
+type Config struct {
+	Hostname        string                // Hostname
+	Domainname      string                // Domainname
+	User            string                // User that will run the command(s) inside the container
+	AttachStdin     bool                  // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                  // Attach the standard output
+	AttachStderr    bool                  // Attach the standard error
+	ExposedPorts    map[nat.Port]struct{} `json:",omitempty"` // List of exposed ports
+	PublishService  string                `json:",omitempty"` // Name of the network service exposed by the container
+	Tty             bool                  // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                  // Open stdin
+	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
+	Env             []string              // List of environment variable to set in the container
+	Cmd             *strslice.StrSlice    // Command to run when starting the container
+	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
+	Image           string                // Name of the image as it was passed by the operator (eg. could be symbolic)
+	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container
+	WorkingDir      string                // Current directory (PWD) in the command will be launched
+	Entrypoint      *strslice.StrSlice    // Entrypoint to run when starting the container
+	NetworkDisabled bool                  `json:",omitempty"` // Is network disabled
+	MacAddress      string                `json:",omitempty"` // Mac Address of the container
+	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string     // List of labels set to this container
+	StopSignal      string                `json:",omitempty"` // Signal to stop a container
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/container/host_config.go
@@ -1,0 +1,236 @@
+package container
+
+import (
+	"strings"
+
+	"github.com/docker/engine-api/types/blkiodev"
+	"github.com/docker/engine-api/types/strslice"
+	"github.com/docker/go-connections/nat"
+	"github.com/docker/go-units"
+)
+
+// NetworkMode represents the container network stack.
+type NetworkMode string
+
+// IsolationLevel represents the isolation level of a container. The supported
+// values are platform specific
+type IsolationLevel string
+
+// IsDefault indicates the default isolation level of a container. On Linux this
+// is the native driver. On Windows, this is a Windows Server Container.
+func (i IsolationLevel) IsDefault() bool {
+	return strings.ToLower(string(i)) == "default" || string(i) == ""
+}
+
+// IpcMode represents the container ipc stack.
+type IpcMode string
+
+// IsPrivate indicates whether the container uses it's private ipc stack.
+func (n IpcMode) IsPrivate() bool {
+	return !(n.IsHost() || n.IsContainer())
+}
+
+// IsHost indicates whether the container uses the host's ipc stack.
+func (n IpcMode) IsHost() bool {
+	return n == "host"
+}
+
+// IsContainer indicates whether the container uses a container's ipc stack.
+func (n IpcMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+// Valid indicates whether the ipc stack is valid.
+func (n IpcMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	case "container":
+		if len(parts) != 2 || parts[1] == "" {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+// Container returns the name of the container ipc stack is going to be used.
+func (n IpcMode) Container() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
+// UTSMode represents the UTS namespace of the container.
+type UTSMode string
+
+// IsPrivate indicates whether the container uses it's private UTS namespace.
+func (n UTSMode) IsPrivate() bool {
+	return !(n.IsHost())
+}
+
+// IsHost indicates whether the container uses the host's UTS namespace.
+func (n UTSMode) IsHost() bool {
+	return n == "host"
+}
+
+// Valid indicates whether the UTS namespace is valid.
+func (n UTSMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	default:
+		return false
+	}
+	return true
+}
+
+// PidMode represents the pid stack of the container.
+type PidMode string
+
+// IsPrivate indicates whether the container uses it's private pid stack.
+func (n PidMode) IsPrivate() bool {
+	return !(n.IsHost())
+}
+
+// IsHost indicates whether the container uses the host's pid stack.
+func (n PidMode) IsHost() bool {
+	return n == "host"
+}
+
+// Valid indicates whether the pid stack is valid.
+func (n PidMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	default:
+		return false
+	}
+	return true
+}
+
+// DeviceMapping represents the device mapping between the host and the container.
+type DeviceMapping struct {
+	PathOnHost        string
+	PathInContainer   string
+	CgroupPermissions string
+}
+
+// RestartPolicy represents the restart policies of the container.
+type RestartPolicy struct {
+	Name              string
+	MaximumRetryCount int
+}
+
+// IsNone indicates whether the container has the "no" restart policy.
+// This means the container will not automatically restart when exiting.
+func (rp *RestartPolicy) IsNone() bool {
+	return rp.Name == "no"
+}
+
+// IsAlways indicates whether the container has the "always" restart policy.
+// This means the container will automatically restart regardless of the exit status.
+func (rp *RestartPolicy) IsAlways() bool {
+	return rp.Name == "always"
+}
+
+// IsOnFailure indicates whether the container has the "on-failure" restart policy.
+// This means the contain will automatically restart of exiting with a non-zero exit status.
+func (rp *RestartPolicy) IsOnFailure() bool {
+	return rp.Name == "on-failure"
+}
+
+// IsUnlessStopped indicates whether the container has the
+// "unless-stopped" restart policy. This means the container will
+// automatically restart unless user has put it to stopped state.
+func (rp *RestartPolicy) IsUnlessStopped() bool {
+	return rp.Name == "unless-stopped"
+}
+
+// LogConfig represents the logging configuration of the container.
+type LogConfig struct {
+	Type   string
+	Config map[string]string
+}
+
+// Resources contains container's resources (cgroups config, ulimits...)
+type Resources struct {
+	// Applicable to all platforms
+	CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
+
+	// Applicable to UNIX platforms
+	CgroupParent         string // Parent cgroup.
+	BlkioWeight          uint16 // Block IO weight (relative weight vs. other containers)
+	BlkioWeightDevice    []*blkiodev.WeightDevice
+	BlkioDeviceReadBps   []*blkiodev.ThrottleDevice
+	BlkioDeviceWriteBps  []*blkiodev.ThrottleDevice
+	BlkioDeviceReadIOps  []*blkiodev.ThrottleDevice
+	BlkioDeviceWriteIOps []*blkiodev.ThrottleDevice
+	CPUPeriod            int64           `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
+	CPUQuota             int64           `json:"CpuQuota"`  // CPU CFS (Completely Fair Scheduler) quota
+	CpusetCpus           string          // CpusetCpus 0-2, 0,1
+	CpusetMems           string          // CpusetMems 0-2, 0,1
+	Devices              []DeviceMapping // List of devices to map inside the container
+	KernelMemory         int64           // Kernel memory limit (in bytes)
+	Memory               int64           // Memory limit (in bytes)
+	MemoryReservation    int64           // Memory soft limit (in bytes)
+	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
+	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
+	OomKillDisable       *bool           // Whether to disable OOM Killer or not
+	PidsLimit            int64           // Setting pids limit for a container
+	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
+}
+
+// UpdateConfig holds the mutable attributes of a Container.
+// Those attributes can be updated at runtime.
+type UpdateConfig struct {
+	// Contains container's resources (cgroups, ulimits)
+	Resources
+}
+
+// HostConfig the non-portable Config structure of a container.
+// Here, "non-portable" means "dependent of the host we are running on".
+// Portable information *should* appear in Config.
+type HostConfig struct {
+	// Applicable to all platforms
+	Binds           []string      // List of volume bindings for this container
+	ContainerIDFile string        // File (path) where the containerId is written
+	LogConfig       LogConfig     // Configuration of the logs for this container
+	NetworkMode     NetworkMode   // Network mode to use for the container
+	PortBindings    nat.PortMap   // Port mapping between the exposed port (container) and the host
+	RestartPolicy   RestartPolicy // Restart policy to be used for the container
+	VolumeDriver    string        // Name of the volume driver used to mount volumes
+	VolumesFrom     []string      // List of volumes to take from other container
+
+	// Applicable to UNIX platforms
+	CapAdd          *strslice.StrSlice // List of kernel capabilities to add to the container
+	CapDrop         *strslice.StrSlice // List of kernel capabilities to remove from the container
+	DNS             []string           `json:"Dns"`        // List of DNS server to lookup
+	DNSOptions      []string           `json:"DnsOptions"` // List of DNSOption to look for
+	DNSSearch       []string           `json:"DnsSearch"`  // List of DNSSearch to look for
+	ExtraHosts      []string           // List of extra hosts
+	GroupAdd        []string           // List of additional groups that the container process will run as
+	IpcMode         IpcMode            // IPC namespace to use for the container
+	Links           []string           // List of links (in the name:alias form)
+	OomScoreAdj     int                // Container preference for OOM-killing
+	PidMode         PidMode            // PID namespace to use for the container
+	Privileged      bool               // Is the container in privileged mode
+	PublishAllPorts bool               // Should docker publish all exposed port for the container
+	ReadonlyRootfs  bool               // Is the container root filesystem in read-only
+	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
+	StorageOpt      []string           // Graph storage options per container
+	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
+	UTSMode         UTSMode            // UTS namespace to use for the container
+	ShmSize         int64              // Total shm memory usage
+
+	// Applicable to Windows
+	ConsoleSize [2]int         // Initial console size
+	Isolation   IsolationLevel // Isolation level of the container (eg default, hyperv)
+
+	// Contains container's resources (cgroups, ulimits)
+	Resources
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/container/hostconfig_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/container/hostconfig_unix.go
@@ -1,0 +1,87 @@
+// +build !windows
+
+package container
+
+import "strings"
+
+// IsValid indicates is an isolation level is valid
+func (i IsolationLevel) IsValid() bool {
+	return i.IsDefault()
+}
+
+// IsPrivate indicates whether container uses it's private network stack.
+func (n NetworkMode) IsPrivate() bool {
+	return !(n.IsHost() || n.IsContainer())
+}
+
+// IsDefault indicates whether container uses the default network stack.
+func (n NetworkMode) IsDefault() bool {
+	return n == "default"
+}
+
+// NetworkName returns the name of the network stack.
+func (n NetworkMode) NetworkName() string {
+	if n.IsBridge() {
+		return "bridge"
+	} else if n.IsHost() {
+		return "host"
+	} else if n.IsContainer() {
+		return "container"
+	} else if n.IsNone() {
+		return "none"
+	} else if n.IsDefault() {
+		return "default"
+	} else if n.IsUserDefined() {
+		return n.UserDefined()
+	}
+	return ""
+}
+
+// IsBridge indicates whether container uses the bridge network stack
+func (n NetworkMode) IsBridge() bool {
+	return n == "bridge"
+}
+
+// IsHost indicates whether container uses the host network stack.
+func (n NetworkMode) IsHost() bool {
+	return n == "host"
+}
+
+// IsContainer indicates whether container uses a container network stack.
+func (n NetworkMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+// IsNone indicates whether container isn't using a network stack.
+func (n NetworkMode) IsNone() bool {
+	return n == "none"
+}
+
+// ConnectedContainer is the id of the container which network this container is connected to.
+func (n NetworkMode) ConnectedContainer() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
+// IsUserDefined indicates user-created network
+func (n NetworkMode) IsUserDefined() bool {
+	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
+}
+
+// IsPreDefinedNetwork indicates if a network is predefined by the daemon
+func IsPreDefinedNetwork(network string) bool {
+	n := NetworkMode(network)
+	return n.IsBridge() || n.IsHost() || n.IsNone()
+}
+
+//UserDefined indicates user-created network
+func (n NetworkMode) UserDefined() string {
+	if n.IsUserDefined() {
+		return string(n)
+	}
+	return ""
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/container/hostconfig_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/container/hostconfig_windows.go
@@ -1,0 +1,85 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IsDefault indicates whether container uses the default network stack.
+func (n NetworkMode) IsDefault() bool {
+	return n == "default"
+}
+
+// IsNone indicates whether container isn't using a network stack.
+func (n NetworkMode) IsNone() bool {
+	return n == "none"
+}
+
+// IsUserDefined indicates user-created network
+func (n NetworkMode) IsUserDefined() bool {
+	return !n.IsDefault() && !n.IsNone()
+}
+
+// IsHyperV indicates the use of a Hyper-V partition for isolation
+func (i IsolationLevel) IsHyperV() bool {
+	return strings.ToLower(string(i)) == "hyperv"
+}
+
+// IsProcess indicates the use of process isolation
+func (i IsolationLevel) IsProcess() bool {
+	return strings.ToLower(string(i)) == "process"
+}
+
+// IsValid indicates is an isolation level is valid
+func (i IsolationLevel) IsValid() bool {
+	return i.IsDefault() || i.IsHyperV() || i.IsProcess()
+}
+
+// DefaultDaemonNetworkMode returns the default network stack the daemon should
+// use.
+func DefaultDaemonNetworkMode() NetworkMode {
+	return NetworkMode("default")
+}
+
+// NetworkName returns the name of the network stack.
+func (n NetworkMode) NetworkName() string {
+	if n.IsDefault() {
+		return "default"
+	}
+	return ""
+}
+
+// IsPreDefinedNetwork indicates if a network is predefined by the daemon
+func IsPreDefinedNetwork(network string) bool {
+	return false
+}
+
+// ValidateNetMode ensures that the various combinations of requested
+// network settings are valid.
+func ValidateNetMode(c *Config, hc *HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	parts := strings.Split(string(hc.NetworkMode), ":")
+	switch mode := parts[0]; mode {
+	case "default", "none":
+	default:
+		return fmt.Errorf("invalid --net: %s", hc.NetworkMode)
+	}
+	return nil
+}
+
+// ValidateIsolationLevel performs platform specific validation of the
+// isolation level in the hostconfig structure. Windows supports 'default' (or
+// blank), 'process', or 'hyperv'.
+func ValidateIsolationLevel(hc *HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if !hc.Isolation.IsValid() {
+		return fmt.Errorf("invalid --isolation: %q. Windows supports 'default', 'process', or 'hyperv'", hc.Isolation)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/events/events.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/events/events.go
@@ -1,0 +1,38 @@
+package events
+
+const (
+	// ContainerEventType is the event type that containers generate
+	ContainerEventType = "container"
+	// ImageEventType is the event type that images generate
+	ImageEventType = "image"
+	// VolumeEventType is the event type that volumes generate
+	VolumeEventType = "volume"
+	// NetworkEventType is the event type that networks generate
+	NetworkEventType = "network"
+)
+
+// Actor describes something that generates events,
+// like a container, or a network, or a volume.
+// It has a defined name and a set or attributes.
+// The container attributes are its labels, other actors
+// can generate these attributes from other properties.
+type Actor struct {
+	ID         string
+	Attributes map[string]string
+}
+
+// Message represents the information an event contains
+type Message struct {
+	// Deprecated information from JSONMessage.
+	// With data only in container events.
+	Status string `json:"status,omitempty"`
+	ID     string `json:"id,omitempty"`
+	From   string `json:"from,omitempty"`
+
+	Type   string
+	Action string
+	Actor  Actor
+
+	Time     int64 `json:"time,omitempty"`
+	TimeNano int64 `json:"timeNano,omitempty"`
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/network/network.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/network/network.go
@@ -1,0 +1,52 @@
+package network
+
+// Address represents an IP address
+type Address struct {
+	Addr      string
+	PrefixLen int
+}
+
+// IPAM represents IP Address Management
+type IPAM struct {
+	Driver  string
+	Options map[string]string //Per network IPAM driver options
+	Config  []IPAMConfig
+}
+
+// IPAMConfig represents IPAM configurations
+type IPAMConfig struct {
+	Subnet     string            `json:",omitempty"`
+	IPRange    string            `json:",omitempty"`
+	Gateway    string            `json:",omitempty"`
+	AuxAddress map[string]string `json:"AuxiliaryAddresses,omitempty"`
+}
+
+// EndpointIPAMConfig represents IPAM configurations for the endpoint
+type EndpointIPAMConfig struct {
+	IPv4Address string `json:",omitempty"`
+	IPv6Address string `json:",omitempty"`
+}
+
+// EndpointSettings stores the network endpoint details
+type EndpointSettings struct {
+	// Configurations
+	IPAMConfig *EndpointIPAMConfig
+	Links      []string
+	Aliases    []string
+	// Operational data
+	NetworkID           string
+	EndpointID          string
+	Gateway             string
+	IPAddress           string
+	IPPrefixLen         int
+	IPv6Gateway         string
+	GlobalIPv6Address   string
+	GlobalIPv6PrefixLen int
+	MacAddress          string
+}
+
+// NetworkingConfig represents the container's networking configuration for each of its interfaces
+// Carries the networink configs specified in the `docker run` and `docker network connect` commands
+type NetworkingConfig struct {
+	EndpointsConfig map[string]*EndpointSettings // Endpoint configs for each conencting network
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/registry/registry.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/registry/registry.go
@@ -1,0 +1,101 @@
+package registry
+
+import (
+	"encoding/json"
+	"net"
+)
+
+// ServiceConfig stores daemon registry services configuration.
+type ServiceConfig struct {
+	InsecureRegistryCIDRs []*NetIPNet           `json:"InsecureRegistryCIDRs"`
+	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
+	Mirrors               []string
+}
+
+// NetIPNet is the net.IPNet type, which can be marshalled and
+// unmarshalled to JSON
+type NetIPNet net.IPNet
+
+// MarshalJSON returns the JSON representation of the IPNet
+func (ipnet *NetIPNet) MarshalJSON() ([]byte, error) {
+	return json.Marshal((*net.IPNet)(ipnet).String())
+}
+
+// UnmarshalJSON sets the IPNet from a byte array of JSON
+func (ipnet *NetIPNet) UnmarshalJSON(b []byte) (err error) {
+	var ipnetStr string
+	if err = json.Unmarshal(b, &ipnetStr); err == nil {
+		var cidr *net.IPNet
+		if _, cidr, err = net.ParseCIDR(ipnetStr); err == nil {
+			*ipnet = NetIPNet(*cidr)
+		}
+	}
+	return
+}
+
+// IndexInfo contains information about a registry
+//
+// RepositoryInfo Examples:
+// {
+//   "Index" : {
+//     "Name" : "docker.io",
+//     "Mirrors" : ["https://registry-2.docker.io/v1/", "https://registry-3.docker.io/v1/"],
+//     "Secure" : true,
+//     "Official" : true,
+//   },
+//   "RemoteName" : "library/debian",
+//   "LocalName" : "debian",
+//   "CanonicalName" : "docker.io/debian"
+//   "Official" : true,
+// }
+//
+// {
+//   "Index" : {
+//     "Name" : "127.0.0.1:5000",
+//     "Mirrors" : [],
+//     "Secure" : false,
+//     "Official" : false,
+//   },
+//   "RemoteName" : "user/repo",
+//   "LocalName" : "127.0.0.1:5000/user/repo",
+//   "CanonicalName" : "127.0.0.1:5000/user/repo",
+//   "Official" : false,
+// }
+type IndexInfo struct {
+	// Name is the name of the registry, such as "docker.io"
+	Name string
+	// Mirrors is a list of mirrors, expressed as URIs
+	Mirrors []string
+	// Secure is set to false if the registry is part of the list of
+	// insecure registries. Insecure registries accept HTTP and/or accept
+	// HTTPS with certificates from unknown CAs.
+	Secure bool
+	// Official indicates whether this is an official registry
+	Official bool
+}
+
+// SearchResult describes a search result returned from a registry
+type SearchResult struct {
+	// StarCount indicates the number of stars this repository has
+	StarCount int `json:"star_count"`
+	// IsOfficial indicates whether the result is an official repository or not
+	IsOfficial bool `json:"is_official"`
+	// Name is the name of the repository
+	Name string `json:"name"`
+	// IsOfficial indicates whether the result is trusted
+	IsTrusted bool `json:"is_trusted"`
+	// IsAutomated indicates whether the result is automated
+	IsAutomated bool `json:"is_automated"`
+	// Description is a textual description of the repository
+	Description string `json:"description"`
+}
+
+// SearchResults lists a collection search results returned from a registry
+type SearchResults struct {
+	// Query contains the query string that generated the search results
+	Query string `json:"query"`
+	// NumResults indicates the number of results the query returned
+	NumResults int `json:"num_results"`
+	// Results is a slice containing the actual results for the search
+	Results []SearchResult `json:"results"`
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/seccomp.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/seccomp.go
@@ -1,0 +1,68 @@
+package types
+
+// Seccomp represents the config for a seccomp profile for syscall restriction.
+type Seccomp struct {
+	DefaultAction Action     `json:"defaultAction"`
+	Architectures []Arch     `json:"architectures"`
+	Syscalls      []*Syscall `json:"syscalls"`
+}
+
+// Arch used for additional architectures
+type Arch string
+
+// Additional architectures permitted to be used for system calls
+// By default only the native architecture of the kernel is permitted
+const (
+	ArchX86         Arch = "SCMP_ARCH_X86"
+	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
+	ArchX32         Arch = "SCMP_ARCH_X32"
+	ArchARM         Arch = "SCMP_ARCH_ARM"
+	ArchAARCH64     Arch = "SCMP_ARCH_AARCH64"
+	ArchMIPS        Arch = "SCMP_ARCH_MIPS"
+	ArchMIPS64      Arch = "SCMP_ARCH_MIPS64"
+	ArchMIPS64N32   Arch = "SCMP_ARCH_MIPS64N32"
+	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
+	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
+	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+)
+
+// Action taken upon Seccomp rule match
+type Action string
+
+// Define actions for Seccomp rules
+const (
+	ActKill  Action = "SCMP_ACT_KILL"
+	ActTrap  Action = "SCMP_ACT_TRAP"
+	ActErrno Action = "SCMP_ACT_ERRNO"
+	ActTrace Action = "SCMP_ACT_TRACE"
+	ActAllow Action = "SCMP_ACT_ALLOW"
+)
+
+// Operator used to match syscall arguments in Seccomp
+type Operator string
+
+// Define operators for syscall arguments in Seccomp
+const (
+	OpNotEqual     Operator = "SCMP_CMP_NE"
+	OpLessThan     Operator = "SCMP_CMP_LT"
+	OpLessEqual    Operator = "SCMP_CMP_LE"
+	OpEqualTo      Operator = "SCMP_CMP_EQ"
+	OpGreaterEqual Operator = "SCMP_CMP_GE"
+	OpGreaterThan  Operator = "SCMP_CMP_GT"
+	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
+)
+
+// Arg used for matching specific syscall arguments in Seccomp
+type Arg struct {
+	Index    uint     `json:"index"`
+	Value    uint64   `json:"value"`
+	ValueTwo uint64   `json:"valueTwo"`
+	Op       Operator `json:"op"`
+}
+
+// Syscall is used to match a syscall in Seccomp
+type Syscall struct {
+	Name   string `json:"name"`
+	Action Action `json:"action"`
+	Args   []*Arg `json:"args"`
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/stats.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/stats.go
@@ -1,0 +1,112 @@
+// Package types is used for API stability in the types and response to the
+// consumers of the API stats endpoint.
+package types
+
+import "time"
+
+// ThrottlingData stores CPU throttling stats of one running container
+type ThrottlingData struct {
+	// Number of periods with throttling active
+	Periods uint64 `json:"periods"`
+	// Number of periods when the container hit its throttling limit.
+	ThrottledPeriods uint64 `json:"throttled_periods"`
+	// Aggregate time the container was throttled for in nanoseconds.
+	ThrottledTime uint64 `json:"throttled_time"`
+}
+
+// CPUUsage stores All CPU stats aggregated since container inception.
+type CPUUsage struct {
+	// Total CPU time consumed.
+	// Units: nanoseconds.
+	TotalUsage uint64 `json:"total_usage"`
+	// Total CPU time consumed per core.
+	// Units: nanoseconds.
+	PercpuUsage []uint64 `json:"percpu_usage"`
+	// Time spent by tasks of the cgroup in kernel mode.
+	// Units: nanoseconds.
+	UsageInKernelmode uint64 `json:"usage_in_kernelmode"`
+	// Time spent by tasks of the cgroup in user mode.
+	// Units: nanoseconds.
+	UsageInUsermode uint64 `json:"usage_in_usermode"`
+}
+
+// CPUStats aggregates and wraps all CPU related info of container
+type CPUStats struct {
+	CPUUsage       CPUUsage       `json:"cpu_usage"`
+	SystemUsage    uint64         `json:"system_cpu_usage"`
+	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
+}
+
+// MemoryStats aggregates All memory stats since container inception
+type MemoryStats struct {
+	// current res_counter usage for memory
+	Usage uint64 `json:"usage"`
+	// maximum usage ever recorded.
+	MaxUsage uint64 `json:"max_usage"`
+	// TODO(vishh): Export these as stronger types.
+	// all the stats exported via memory.stat.
+	Stats map[string]uint64 `json:"stats"`
+	// number of times memory usage hits limits.
+	Failcnt uint64 `json:"failcnt"`
+	Limit   uint64 `json:"limit"`
+}
+
+// BlkioStatEntry is one small entity to store a piece of Blkio stats
+// TODO Windows: This can be factored out
+type BlkioStatEntry struct {
+	Major uint64 `json:"major"`
+	Minor uint64 `json:"minor"`
+	Op    string `json:"op"`
+	Value uint64 `json:"value"`
+}
+
+// BlkioStats stores All IO service stats for data read and write
+// TODO Windows: This can be factored out
+type BlkioStats struct {
+	// number of bytes transferred to and from the block device
+	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive"`
+	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recursive"`
+	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive"`
+	IoServiceTimeRecursive  []BlkioStatEntry `json:"io_service_time_recursive"`
+	IoWaitTimeRecursive     []BlkioStatEntry `json:"io_wait_time_recursive"`
+	IoMergedRecursive       []BlkioStatEntry `json:"io_merged_recursive"`
+	IoTimeRecursive         []BlkioStatEntry `json:"io_time_recursive"`
+	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive"`
+}
+
+// NetworkStats aggregates All network stats of one container
+// TODO Windows: This will require refactoring
+type NetworkStats struct {
+	RxBytes   uint64 `json:"rx_bytes"`
+	RxPackets uint64 `json:"rx_packets"`
+	RxErrors  uint64 `json:"rx_errors"`
+	RxDropped uint64 `json:"rx_dropped"`
+	TxBytes   uint64 `json:"tx_bytes"`
+	TxPackets uint64 `json:"tx_packets"`
+	TxErrors  uint64 `json:"tx_errors"`
+	TxDropped uint64 `json:"tx_dropped"`
+}
+
+// PidsStats contains the stats of a container's pids
+type PidsStats struct {
+	// Current is the number of pids in the cgroup
+	Current uint64 `json:"current,omitempty"`
+}
+
+// Stats is Ultimate struct aggregating all types of stats of one container
+type Stats struct {
+	Read        time.Time   `json:"read"`
+	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"`
+	CPUStats    CPUStats    `json:"cpu_stats,omitempty"`
+	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
+	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
+	PidsStats   PidsStats   `json:"pids_stats,omitempty"`
+}
+
+// StatsJSON is newly used Networks
+type StatsJSON struct {
+	Stats
+
+	// Networks request version >=1.21
+	Networks map[string]NetworkStats `json:"networks,omitempty"`
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/strslice/strslice.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/strslice/strslice.go
@@ -1,0 +1,71 @@
+package strslice
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// StrSlice represents a string or an array of strings.
+// We need to override the json decoder to accept both options.
+type StrSlice struct {
+	parts []string
+}
+
+// MarshalJSON Marshals (or serializes) the StrSlice into the json format.
+// This method is needed to implement json.Marshaller.
+func (e *StrSlice) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte{}, nil
+	}
+	return json.Marshal(e.Slice())
+}
+
+// UnmarshalJSON decodes the byte slice whether it's a string or an array of strings.
+// This method is needed to implement json.Unmarshaler.
+func (e *StrSlice) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+
+	p := make([]string, 0, 1)
+	if err := json.Unmarshal(b, &p); err != nil {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		p = append(p, s)
+	}
+
+	e.parts = p
+	return nil
+}
+
+// Len returns the number of parts of the StrSlice.
+func (e *StrSlice) Len() int {
+	if e == nil {
+		return 0
+	}
+	return len(e.parts)
+}
+
+// Slice gets the parts of the StrSlice as a Slice of string.
+func (e *StrSlice) Slice() []string {
+	if e == nil {
+		return nil
+	}
+	return e.parts
+}
+
+// ToString gets space separated string of all the parts.
+func (e *StrSlice) ToString() string {
+	s := e.Slice()
+	if s == nil {
+		return ""
+	}
+	return strings.Join(s, " ")
+}
+
+// New creates an StrSlice based on the specified parts (as strings).
+func New(parts ...string) *StrSlice {
+	return &StrSlice{parts}
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/time/timestamp.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/time/timestamp.go
@@ -1,0 +1,124 @@
+package time
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// These are additional predefined layouts for use in Time.Format and Time.Parse
+// with --since and --until parameters for `docker logs` and `docker events`
+const (
+	rFC3339Local     = "2006-01-02T15:04:05"           // RFC3339 with local timezone
+	rFC3339NanoLocal = "2006-01-02T15:04:05.999999999" // RFC3339Nano with local timezone
+	dateWithZone     = "2006-01-02Z07:00"              // RFC3339 with time at 00:00:00
+	dateLocal        = "2006-01-02"                    // RFC3339 with local timezone and time at 00:00:00
+)
+
+// GetTimestamp tries to parse given string as golang duration,
+// then RFC3339 time and finally as a Unix timestamp. If
+// any of these were successful, it returns a Unix timestamp
+// as string otherwise returns the given value back.
+// In case of duration input, the returned timestamp is computed
+// as the given reference time minus the amount of the duration.
+func GetTimestamp(value string, reference time.Time) (string, error) {
+	if d, err := time.ParseDuration(value); value != "0" && err == nil {
+		return strconv.FormatInt(reference.Add(-d).Unix(), 10), nil
+	}
+
+	var format string
+	var parseInLocation bool
+
+	// if the string has a Z or a + or three dashes use parse otherwise use parseinlocation
+	parseInLocation = !(strings.ContainsAny(value, "zZ+") || strings.Count(value, "-") == 3)
+
+	if strings.Contains(value, ".") {
+		if parseInLocation {
+			format = rFC3339NanoLocal
+		} else {
+			format = time.RFC3339Nano
+		}
+	} else if strings.Contains(value, "T") {
+		// we want the number of colons in the T portion of the timestamp
+		tcolons := strings.Count(value, ":")
+		// if parseInLocation is off and we have a +/- zone offset (not Z) then
+		// there will be an extra colon in the input for the tz offset subtract that
+		// colon from the tcolons count
+		if !parseInLocation && !strings.ContainsAny(value, "zZ") && tcolons > 0 {
+			tcolons--
+		}
+		if parseInLocation {
+			switch tcolons {
+			case 0:
+				format = "2006-01-02T15"
+			case 1:
+				format = "2006-01-02T15:04"
+			default:
+				format = rFC3339Local
+			}
+		} else {
+			switch tcolons {
+			case 0:
+				format = "2006-01-02T15Z07:00"
+			case 1:
+				format = "2006-01-02T15:04Z07:00"
+			default:
+				format = time.RFC3339
+			}
+		}
+	} else if parseInLocation {
+		format = dateLocal
+	} else {
+		format = dateWithZone
+	}
+
+	var t time.Time
+	var err error
+
+	if parseInLocation {
+		t, err = time.ParseInLocation(format, value, time.FixedZone(reference.Zone()))
+	} else {
+		t, err = time.Parse(format, value)
+	}
+
+	if err != nil {
+		// if there is a `-` then its an RFC3339 like timestamp otherwise assume unixtimestamp
+		if strings.Contains(value, "-") {
+			return "", err // was probably an RFC3339 like timestamp but the parser failed with an error
+		}
+		return value, nil // unixtimestamp in and out case (meaning: the value passed at the command line is already in the right format for passing to the server)
+	}
+
+	return fmt.Sprintf("%d.%09d", t.Unix(), int64(t.Nanosecond())), nil
+}
+
+// ParseTimestamps returns seconds and nanoseconds from a timestamp that has the
+// format "%d.%09d", time.Unix(), int64(time.Nanosecond()))
+// if the incoming nanosecond portion is longer or shorter than 9 digits it is
+// converted to nanoseconds.  The expectation is that the seconds and
+// seconds will be used to create a time variable.  For example:
+//     seconds, nanoseconds, err := ParseTimestamp("1136073600.000000001",0)
+//     if err == nil since := time.Unix(seconds, nanoseconds)
+// returns seconds as def(aultSeconds) if value == ""
+func ParseTimestamps(value string, def int64) (int64, int64, error) {
+	if value == "" {
+		return def, 0, nil
+	}
+	sa := strings.SplitN(value, ".", 2)
+	s, err := strconv.ParseInt(sa[0], 10, 64)
+	if err != nil {
+		return s, 0, err
+	}
+	if len(sa) != 2 {
+		return s, 0, nil
+	}
+	n, err := strconv.ParseInt(sa[1], 10, 64)
+	if err != nil {
+		return s, n, err
+	}
+	// should already be in nanoseconds but just in case convert n to nanoseonds
+	n = int64(float64(n) * math.Pow(float64(10), float64(9-len(sa[1]))))
+	return s, n, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/types.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/types.go
@@ -1,0 +1,426 @@
+package types
+
+import (
+	"os"
+	"time"
+
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
+	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/go-connections/nat"
+)
+
+// ContainerCreateResponse contains the information returned to a client on the
+// creation of a new container.
+type ContainerCreateResponse struct {
+	// ID is the ID of the created container.
+	ID string `json:"Id"`
+
+	// Warnings are any warnings encountered during the creation of the container.
+	Warnings []string `json:"Warnings"`
+}
+
+// ContainerExecCreateResponse contains response of Remote API:
+// POST "/containers/{name:.*}/exec"
+type ContainerExecCreateResponse struct {
+	// ID is the exec ID.
+	ID string `json:"Id"`
+}
+
+// ContainerUpdateResponse contains response of Remote API:
+// POST /containers/{name:.*}/update
+type ContainerUpdateResponse struct {
+	// Warnings are any warnings encountered during the updating of the container.
+	Warnings []string `json:"Warnings"`
+}
+
+// AuthResponse contains response of Remote API:
+// POST "/auth"
+type AuthResponse struct {
+	// Status is the authentication status
+	Status string `json:"Status"`
+}
+
+// ContainerWaitResponse contains response of Remote API:
+// POST "/containers/"+containerID+"/wait"
+type ContainerWaitResponse struct {
+	// StatusCode is the status code of the wait job
+	StatusCode int `json:"StatusCode"`
+}
+
+// ContainerCommitResponse contains response of Remote API:
+// POST "/commit?container="+containerID
+type ContainerCommitResponse struct {
+	ID string `json:"Id"`
+}
+
+// ContainerChange contains response of Remote API:
+// GET "/containers/{name:.*}/changes"
+type ContainerChange struct {
+	Kind int
+	Path string
+}
+
+// ImageHistory contains response of Remote API:
+// GET "/images/{name:.*}/history"
+type ImageHistory struct {
+	ID        string `json:"Id"`
+	Created   int64
+	CreatedBy string
+	Tags      []string
+	Size      int64
+	Comment   string
+}
+
+// ImageDelete contains response of Remote API:
+// DELETE "/images/{name:.*}"
+type ImageDelete struct {
+	Untagged string `json:",omitempty"`
+	Deleted  string `json:",omitempty"`
+}
+
+// Image contains response of Remote API:
+// GET "/images/json"
+type Image struct {
+	ID          string `json:"Id"`
+	ParentID    string `json:"ParentId"`
+	RepoTags    []string
+	RepoDigests []string
+	Created     int64
+	Size        int64
+	VirtualSize int64
+	Labels      map[string]string
+}
+
+// GraphDriverData returns Image's graph driver config info
+// when calling inspect command
+type GraphDriverData struct {
+	Name string
+	Data map[string]string
+}
+
+// ImageInspect contains response of Remote API:
+// GET "/images/{name:.*}/json"
+type ImageInspect struct {
+	ID              string `json:"Id"`
+	RepoTags        []string
+	RepoDigests     []string
+	Parent          string
+	Comment         string
+	Created         string
+	Container       string
+	ContainerConfig *container.Config
+	DockerVersion   string
+	Author          string
+	Config          *container.Config
+	Architecture    string
+	Os              string
+	Size            int64
+	VirtualSize     int64
+	GraphDriver     GraphDriverData
+}
+
+// Port stores open ports info of container
+// e.g. {"PrivatePort": 8080, "PublicPort": 80, "Type": "tcp"}
+type Port struct {
+	IP          string `json:",omitempty"`
+	PrivatePort int
+	PublicPort  int `json:",omitempty"`
+	Type        string
+}
+
+// Container contains response of Remote API:
+// GET  "/containers/json"
+type Container struct {
+	ID         string `json:"Id"`
+	Names      []string
+	Image      string
+	ImageID    string
+	Command    string
+	Created    int64
+	Ports      []Port
+	SizeRw     int64 `json:",omitempty"`
+	SizeRootFs int64 `json:",omitempty"`
+	Labels     map[string]string
+	Status     string
+	HostConfig struct {
+		NetworkMode string `json:",omitempty"`
+	}
+	NetworkSettings *SummaryNetworkSettings
+}
+
+// CopyConfig contains request body of Remote API:
+// POST "/containers/"+containerID+"/copy"
+type CopyConfig struct {
+	Resource string
+}
+
+// ContainerPathStat is used to encode the header from
+// GET "/containers/{name:.*}/archive"
+// "Name" is the file or directory name.
+type ContainerPathStat struct {
+	Name       string      `json:"name"`
+	Size       int64       `json:"size"`
+	Mode       os.FileMode `json:"mode"`
+	Mtime      time.Time   `json:"mtime"`
+	LinkTarget string      `json:"linkTarget"`
+}
+
+// ContainerProcessList contains response of Remote API:
+// GET "/containers/{name:.*}/top"
+type ContainerProcessList struct {
+	Processes [][]string
+	Titles    []string
+}
+
+// Version contains response of Remote API:
+// GET "/version"
+type Version struct {
+	Version       string
+	APIVersion    string `json:"ApiVersion"`
+	GitCommit     string
+	GoVersion     string
+	Os            string
+	Arch          string
+	KernelVersion string `json:",omitempty"`
+	Experimental  bool   `json:",omitempty"`
+	BuildTime     string `json:",omitempty"`
+}
+
+// Info contains response of Remote API:
+// GET "/info"
+type Info struct {
+	ID                 string
+	Containers         int
+	Images             int
+	Driver             string
+	DriverStatus       [][2]string
+	Plugins            PluginsInfo
+	MemoryLimit        bool
+	SwapLimit          bool
+	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
+	CPUCfsQuota        bool `json:"CpuCfsQuota"`
+	CPUShares          bool
+	CPUSet             bool
+	IPv4Forwarding     bool
+	BridgeNfIptables   bool
+	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`
+	Debug              bool
+	NFd                int
+	OomKillDisable     bool
+	NGoroutines        int
+	SystemTime         string
+	ExecutionDriver    string
+	LoggingDriver      string
+	NEventsListener    int
+	KernelVersion      string
+	OperatingSystem    string
+	OSType             string
+	Architecture       string
+	IndexServerAddress string
+	RegistryConfig     *registry.ServiceConfig
+	InitSha1           string
+	InitPath           string
+	NCPU               int
+	MemTotal           int64
+	DockerRootDir      string
+	HTTPProxy          string `json:"HttpProxy"`
+	HTTPSProxy         string `json:"HttpsProxy"`
+	NoProxy            string
+	Name               string
+	Labels             []string
+	ExperimentalBuild  bool
+	ServerVersion      string
+	ClusterStore       string
+	ClusterAdvertise   string
+}
+
+// PluginsInfo is temp struct holds Plugins name
+// registered with docker daemon. It used by Info struct
+type PluginsInfo struct {
+	// List of Volume plugins registered
+	Volume []string
+	// List of Network plugins registered
+	Network []string
+	// List of Authorization plugins registered
+	Authorization []string
+}
+
+// ExecStartCheck is a temp struct used by execStart
+// Config fields is part of ExecConfig in runconfig package
+type ExecStartCheck struct {
+	// ExecStart will first check if it's detached
+	Detach bool
+	// Check if there's a tty
+	Tty bool
+}
+
+// ContainerState stores container's running state
+// it's part of ContainerJSONBase and will return by "inspect" command
+type ContainerState struct {
+	Status     string
+	Running    bool
+	Paused     bool
+	Restarting bool
+	OOMKilled  bool
+	Dead       bool
+	Pid        int
+	ExitCode   int
+	Error      string
+	StartedAt  string
+	FinishedAt string
+}
+
+// ContainerJSONBase contains response of Remote API:
+// GET "/containers/{name:.*}/json"
+type ContainerJSONBase struct {
+	ID              string `json:"Id"`
+	Created         string
+	Path            string
+	Args            []string
+	State           *ContainerState
+	Image           string
+	ResolvConfPath  string
+	HostnamePath    string
+	HostsPath       string
+	LogPath         string
+	Name            string
+	RestartCount    int
+	Driver          string
+	MountLabel      string
+	ProcessLabel    string
+	AppArmorProfile string
+	ExecIDs         []string
+	HostConfig      *container.HostConfig
+	GraphDriver     GraphDriverData
+	SizeRw          *int64 `json:",omitempty"`
+	SizeRootFs      *int64 `json:",omitempty"`
+}
+
+// ContainerJSON is newly used struct along with MountPoint
+type ContainerJSON struct {
+	*ContainerJSONBase
+	Mounts          []MountPoint
+	Config          *container.Config
+	NetworkSettings *NetworkSettings
+}
+
+// NetworkSettings exposes the network settings in the api
+type NetworkSettings struct {
+	NetworkSettingsBase
+	DefaultNetworkSettings
+	Networks map[string]*network.EndpointSettings
+}
+
+// SummaryNetworkSettings provides a summary of container's networks
+// in /containers/json
+type SummaryNetworkSettings struct {
+	Networks map[string]*network.EndpointSettings
+}
+
+// NetworkSettingsBase holds basic information about networks
+type NetworkSettingsBase struct {
+	Bridge                 string
+	SandboxID              string
+	HairpinMode            bool
+	LinkLocalIPv6Address   string
+	LinkLocalIPv6PrefixLen int
+	Ports                  nat.PortMap
+	SandboxKey             string
+	SecondaryIPAddresses   []network.Address
+	SecondaryIPv6Addresses []network.Address
+}
+
+// DefaultNetworkSettings holds network information
+// during the 2 release deprecation period.
+// It will be removed in Docker 1.11.
+type DefaultNetworkSettings struct {
+	EndpointID          string
+	Gateway             string
+	GlobalIPv6Address   string
+	GlobalIPv6PrefixLen int
+	IPAddress           string
+	IPPrefixLen         int
+	IPv6Gateway         string
+	MacAddress          string
+}
+
+// MountPoint represents a mount point configuration inside the container.
+type MountPoint struct {
+	Name        string `json:",omitempty"`
+	Source      string
+	Destination string
+	Driver      string `json:",omitempty"`
+	Mode        string
+	RW          bool
+	Propagation string
+}
+
+// Volume represents the configuration of a volume for the remote API
+type Volume struct {
+	Name       string // Name is the name of the volume
+	Driver     string // Driver is the Driver name used to create the volume
+	Mountpoint string // Mountpoint is the location on disk of the volume
+}
+
+// VolumesListResponse contains the response for the remote API:
+// GET "/volumes"
+type VolumesListResponse struct {
+	Volumes  []*Volume // Volumes is the list of volumes being returned
+	Warnings []string  // Warnings is a list of warnings that occurred when getting the list from the volume drivers
+}
+
+// VolumeCreateRequest contains the response for the remote API:
+// POST "/volumes/create"
+type VolumeCreateRequest struct {
+	Name       string            // Name is the requested name of the volume
+	Driver     string            // Driver is the name of the driver that should be used to create the volume
+	DriverOpts map[string]string // DriverOpts holds the driver specific options to use for when creating the volume.
+}
+
+// NetworkResource is the body of the "get network" http response message
+type NetworkResource struct {
+	Name       string
+	ID         string `json:"Id"`
+	Scope      string
+	Driver     string
+	IPAM       network.IPAM
+	Containers map[string]EndpointResource
+	Options    map[string]string
+}
+
+// EndpointResource contains network resources allocated and used for a container in a network
+type EndpointResource struct {
+	Name        string
+	EndpointID  string
+	MacAddress  string
+	IPv4Address string
+	IPv6Address string
+}
+
+// NetworkCreate is the expected body of the "create network" http request message
+type NetworkCreate struct {
+	Name           string
+	CheckDuplicate bool
+	Driver         string
+	IPAM           network.IPAM
+	Options        map[string]string
+}
+
+// NetworkCreateResponse is the response message sent by the server for network create call
+type NetworkCreateResponse struct {
+	ID      string `json:"Id"`
+	Warning string
+}
+
+// NetworkConnect represents the data to be used to connect a container to the network
+type NetworkConnect struct {
+	Container      string
+	EndpointConfig *network.EndpointSettings `json:"endpoint_config"`
+}
+
+// NetworkDisconnect represents the data to be used to disconnect a container from the network
+type NetworkDisconnect struct {
+	Container string
+	Force     bool
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/versions/README.md
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/versions/README.md
@@ -1,0 +1,14 @@
+## Legacy API type versions
+
+This package includes types for legacy API versions. The stable version of the API types live in `api/types/*.go`.
+
+Consider moving a type here when you need to keep backwards compatibility in the API. This legacy types are organized by the latest API version they appear in. For instance, types in the `v1p19` package are valid for API versions below or equal `1.19`. Types in the `v1p20` package are valid for the API version `1.20`, since the versions below that will use the legacy types in `v1p19`.
+
+### Package name conventions
+
+The package name convention is to use `v` as a prefix for the version number and `p`(patch) as a separator. We use this nomenclature due to a few restrictions in the Go package name convention:
+
+1. We cannot use `.` because it's interpreted by the language, think of `v1.20.CallFunction`.
+2. We cannot use `_` because golint complains abount it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
+
+For instance, if you want to modify a type that was available in the version `1.21` of the API but it will have different fields in the version `1.22`, you want to create a new package under `api/types/versions/v1p21`.

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/versions/v1p19/types.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/versions/v1p19/types.go
@@ -1,0 +1,35 @@
+// Package v1p19 provides specific API types for the API version 1, patch 19.
+package v1p19
+
+import (
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/versions/v1p20"
+	"github.com/docker/go-connections/nat"
+)
+
+// ContainerJSON is a backcompatibility struct for APIs prior to 1.20.
+// Note this is not used by the Windows daemon.
+type ContainerJSON struct {
+	*types.ContainerJSONBase
+	Volumes         map[string]string
+	VolumesRW       map[string]bool
+	Config          *ContainerConfig
+	NetworkSettings *v1p20.NetworkSettings
+}
+
+// ContainerConfig is a backcompatibility struct for APIs prior to 1.20.
+type ContainerConfig struct {
+	*container.Config
+
+	MacAddress      string
+	NetworkDisabled bool
+	ExposedPorts    map[nat.Port]struct{}
+
+	// backward compatibility, they now live in HostConfig
+	VolumeDriver string
+	Memory       int64
+	MemorySwap   int64
+	CPUShares    int64  `json:"CpuShares"`
+	CPUSet       string `json:"Cpuset"`
+}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/versions/v1p20/types.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/versions/v1p20/types.go
@@ -1,0 +1,40 @@
+// Package v1p20 provides specific API types for the API version 1, patch 20.
+package v1p20
+
+import (
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/go-connections/nat"
+)
+
+// ContainerJSON is a backcompatibility struct for the API 1.20
+type ContainerJSON struct {
+	*types.ContainerJSONBase
+	Mounts          []types.MountPoint
+	Config          *ContainerConfig
+	NetworkSettings *NetworkSettings
+}
+
+// ContainerConfig is a backcompatibility struct used in ContainerJSON for the API 1.20
+type ContainerConfig struct {
+	*container.Config
+
+	MacAddress      string
+	NetworkDisabled bool
+	ExposedPorts    map[nat.Port]struct{}
+
+	// backward compatibility, they now live in HostConfig
+	VolumeDriver string
+}
+
+// StatsJSON is a backcompatibility struct used in Stats for API prior to 1.21
+type StatsJSON struct {
+	types.Stats
+	Network types.NetworkStats `json:"network,omitempty"`
+}
+
+// NetworkSettings is a backward compatible struct for APIs prior to 1.21
+type NetworkSettings struct {
+	types.NetworkSettingsBase
+	types.DefaultNetworkSettings
+}

--- a/Godeps/_workspace/src/github.com/docker/go-connections/nat/nat.go
+++ b/Godeps/_workspace/src/github.com/docker/go-connections/nat/nat.go
@@ -1,0 +1,223 @@
+// Package nat is a convenience package for manipulation of strings describing network ports.
+package nat
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+const (
+	// portSpecTemplate is the expected format for port specifications
+	portSpecTemplate = "ip:hostPort:containerPort"
+)
+
+// PortBinding represents a binding between a Host IP address and a Host Port
+type PortBinding struct {
+	// HostIP is the host IP Address
+	HostIP string `json:"HostIp"`
+	// HostPort is the host port number
+	HostPort string
+}
+
+// PortMap is a collection of PortBinding indexed by Port
+type PortMap map[Port][]PortBinding
+
+// PortSet is a collection of structs indexed by Port
+type PortSet map[Port]struct{}
+
+// Port is a string containing port number and protocol in the format "80/tcp"
+type Port string
+
+// NewPort creates a new instance of a Port given a protocol and port number or port range
+func NewPort(proto, port string) (Port, error) {
+	// Check for parsing issues on "port" now so we can avoid having
+	// to check it later on.
+
+	portStartInt, portEndInt, err := ParsePortRangeToInt(port)
+	if err != nil {
+		return "", err
+	}
+
+	if portStartInt == portEndInt {
+		return Port(fmt.Sprintf("%d/%s", portStartInt, proto)), nil
+	}
+	return Port(fmt.Sprintf("%d-%d/%s", portStartInt, portEndInt, proto)), nil
+}
+
+// ParsePort parses the port number string and returns an int
+func ParsePort(rawPort string) (int, error) {
+	if len(rawPort) == 0 {
+		return 0, nil
+	}
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	return int(port), nil
+}
+
+// ParsePortRangeToInt parses the port range string and returns start/end ints
+func ParsePortRangeToInt(rawPort string) (int, int, error) {
+	if len(rawPort) == 0 {
+		return 0, 0, nil
+	}
+	start, end, err := ParsePortRange(rawPort)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(start), int(end), nil
+}
+
+// Proto returns the protocol of a Port
+func (p Port) Proto() string {
+	proto, _ := SplitProtoPort(string(p))
+	return proto
+}
+
+// Port returns the port number of a Port
+func (p Port) Port() string {
+	_, port := SplitProtoPort(string(p))
+	return port
+}
+
+// Int returns the port number of a Port as an int
+func (p Port) Int() int {
+	portStr := p.Port()
+	if len(portStr) == 0 {
+		return 0
+	}
+
+	// We don't need to check for an error because we're going to
+	// assume that any error would have been found, and reported, in NewPort()
+	port, _ := strconv.ParseUint(portStr, 10, 16)
+	return int(port)
+}
+
+// Range returns the start/end port numbers of a Port range as ints
+func (p Port) Range() (int, int, error) {
+	return ParsePortRangeToInt(p.Port())
+}
+
+// SplitProtoPort splits a port in the format of proto/port
+func SplitProtoPort(rawPort string) (string, string) {
+	parts := strings.Split(rawPort, "/")
+	l := len(parts)
+	if len(rawPort) == 0 || l == 0 || len(parts[0]) == 0 {
+		return "", ""
+	}
+	if l == 1 {
+		return "tcp", rawPort
+	}
+	if len(parts[1]) == 0 {
+		return "tcp", parts[0]
+	}
+	return parts[1], parts[0]
+}
+
+func validateProto(proto string) bool {
+	for _, availableProto := range []string{"tcp", "udp"} {
+		if availableProto == proto {
+			return true
+		}
+	}
+	return false
+}
+
+// ParsePortSpecs receives port specs in the format of ip:public:private/proto and parses
+// these in to the internal types
+func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, error) {
+	var (
+		exposedPorts = make(map[Port]struct{}, len(ports))
+		bindings     = make(map[Port][]PortBinding)
+	)
+
+	for _, rawPort := range ports {
+		proto := "tcp"
+
+		if i := strings.LastIndex(rawPort, "/"); i != -1 {
+			proto = rawPort[i+1:]
+			rawPort = rawPort[:i]
+		}
+		if !strings.Contains(rawPort, ":") {
+			rawPort = fmt.Sprintf("::%s", rawPort)
+		} else if len(strings.Split(rawPort, ":")) == 2 {
+			rawPort = fmt.Sprintf(":%s", rawPort)
+		}
+
+		parts, err := PartParser(portSpecTemplate, rawPort)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var (
+			containerPort = parts["containerPort"]
+			rawIP         = parts["ip"]
+			hostPort      = parts["hostPort"]
+		)
+
+		if rawIP != "" && net.ParseIP(rawIP) == nil {
+			return nil, nil, fmt.Errorf("Invalid ip address: %s", rawIP)
+		}
+		if containerPort == "" {
+			return nil, nil, fmt.Errorf("No port specified: %s<empty>", rawPort)
+		}
+
+		startPort, endPort, err := ParsePortRange(containerPort)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Invalid containerPort: %s", containerPort)
+		}
+
+		var startHostPort, endHostPort uint64 = 0, 0
+		if len(hostPort) > 0 {
+			startHostPort, endHostPort, err = ParsePortRange(hostPort)
+			if err != nil {
+				return nil, nil, fmt.Errorf("Invalid hostPort: %s", hostPort)
+			}
+		}
+
+		if hostPort != "" && (endPort-startPort) != (endHostPort-startHostPort) {
+			// Allow host port range iff containerPort is not a range.
+			// In this case, use the host port range as the dynamic
+			// host port range to allocate into.
+			if endPort != startPort {
+				return nil, nil, fmt.Errorf("Invalid ranges specified for container and host Ports: %s and %s", containerPort, hostPort)
+			}
+		}
+
+		if !validateProto(strings.ToLower(proto)) {
+			return nil, nil, fmt.Errorf("Invalid proto: %s", proto)
+		}
+
+		for i := uint64(0); i <= (endPort - startPort); i++ {
+			containerPort = strconv.FormatUint(startPort+i, 10)
+			if len(hostPort) > 0 {
+				hostPort = strconv.FormatUint(startHostPort+i, 10)
+			}
+			// Set hostPort to a range only if there is a single container port
+			// and a dynamic host port.
+			if startPort == endPort && startHostPort != endHostPort {
+				hostPort = fmt.Sprintf("%s-%s", hostPort, strconv.FormatUint(endHostPort, 10))
+			}
+			port, err := NewPort(strings.ToLower(proto), containerPort)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, exists := exposedPorts[port]; !exists {
+				exposedPorts[port] = struct{}{}
+			}
+
+			binding := PortBinding{
+				HostIP:   rawIP,
+				HostPort: hostPort,
+			}
+			bslice, exists := bindings[port]
+			if !exists {
+				bslice = []PortBinding{}
+			}
+			bindings[port] = append(bslice, binding)
+		}
+	}
+	return exposedPorts, bindings, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/go-connections/nat/parse.go
+++ b/Godeps/_workspace/src/github.com/docker/go-connections/nat/parse.go
@@ -1,0 +1,56 @@
+package nat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PartParser parses and validates the specified string (data) using the specified template
+// e.g. ip:public:private -> 192.168.0.1:80:8000
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse. %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+// ParsePortRange parses and validates the specified string as a port-range (8000-9000)
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/go-connections/nat/sort.go
+++ b/Godeps/_workspace/src/github.com/docker/go-connections/nat/sort.go
@@ -1,0 +1,96 @@
+package nat
+
+import (
+	"sort"
+	"strings"
+)
+
+type portSorter struct {
+	ports []Port
+	by    func(i, j Port) bool
+}
+
+func (s *portSorter) Len() int {
+	return len(s.ports)
+}
+
+func (s *portSorter) Swap(i, j int) {
+	s.ports[i], s.ports[j] = s.ports[j], s.ports[i]
+}
+
+func (s *portSorter) Less(i, j int) bool {
+	ip := s.ports[i]
+	jp := s.ports[j]
+
+	return s.by(ip, jp)
+}
+
+// Sort sorts a list of ports using the provided predicate
+// This function should compare `i` and `j`, returning true if `i` is
+// considered to be less than `j`
+func Sort(ports []Port, predicate func(i, j Port) bool) {
+	s := &portSorter{ports, predicate}
+	sort.Sort(s)
+}
+
+type portMapEntry struct {
+	port    Port
+	binding PortBinding
+}
+
+type portMapSorter []portMapEntry
+
+func (s portMapSorter) Len() int      { return len(s) }
+func (s portMapSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// sort the port so that the order is:
+// 1. port with larger specified bindings
+// 2. larger port
+// 3. port with tcp protocol
+func (s portMapSorter) Less(i, j int) bool {
+	pi, pj := s[i].port, s[j].port
+	hpi, hpj := toInt(s[i].binding.HostPort), toInt(s[j].binding.HostPort)
+	return hpi > hpj || pi.Int() > pj.Int() || (pi.Int() == pj.Int() && strings.ToLower(pi.Proto()) == "tcp")
+}
+
+// SortPortMap sorts the list of ports and their respected mapping. The ports
+// will explicit HostPort will be placed first.
+func SortPortMap(ports []Port, bindings PortMap) {
+	s := portMapSorter{}
+	for _, p := range ports {
+		if binding, ok := bindings[p]; ok {
+			for _, b := range binding {
+				s = append(s, portMapEntry{port: p, binding: b})
+			}
+			bindings[p] = []PortBinding{}
+		} else {
+			s = append(s, portMapEntry{port: p})
+		}
+	}
+
+	sort.Sort(s)
+	var (
+		i  int
+		pm = make(map[Port]struct{})
+	)
+	// reorder ports
+	for _, entry := range s {
+		if _, ok := pm[entry.port]; !ok {
+			ports[i] = entry.port
+			pm[entry.port] = struct{}{}
+			i++
+		}
+		// reorder bindings for this port
+		if _, ok := bindings[entry.port]; ok {
+			bindings[entry.port] = append(bindings[entry.port], entry.binding)
+		}
+	}
+}
+
+func toInt(s string) uint64 {
+	i, _, err := ParsePortRange(s)
+	if err != nil {
+		i = 0
+	}
+	return i
+}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -14,8 +14,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/pkg/parsers/kernel"
+	apitypes "github.com/docker/engine-api/types"
 	dockerfilters "github.com/docker/engine-api/types/filters"
 	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/experimental"
 	"github.com/docker/swarm/version"
 	"github.com/gorilla/mux"
 	"github.com/samalba/dockerclient"
@@ -55,13 +58,19 @@ func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 
 // GET /version
 func getVersion(c *context, w http.ResponseWriter, r *http.Request) {
-	version := dockerclient.Version{
-		Version:    "swarm/" + version.VERSION,
-		ApiVersion: APIVERSION,
-		GoVersion:  runtime.Version(),
-		GitCommit:  version.GITCOMMIT,
-		Os:         runtime.GOOS,
-		Arch:       runtime.GOARCH,
+	version := apitypes.Version{
+		Version:      "swarm/" + version.VERSION,
+		APIVersion:   APIVERSION,
+		GoVersion:    runtime.Version(),
+		GitCommit:    version.GITCOMMIT,
+		Os:           runtime.GOOS,
+		Arch:         runtime.GOARCH,
+		Experimental: experimental.ENABLED,
+		BuildTime:    version.BUILDTIME,
+	}
+
+	if kernelVersion, err := kernel.GetKernelVersion(); err == nil {
+		version.KernelVersion = kernelVersion.String()
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/version/version.go
+++ b/version/version.go
@@ -6,4 +6,7 @@ var (
 
 	// GITCOMMIT will be overwritten automatically by the build system
 	GITCOMMIT = "HEAD"
+
+	// BUILDTIME will be overwritten automatically by the build system
+	BUILDTIME = "<unknown>"
 )


### PR DESCRIPTION
follow up of #1626

It makes me very happy as we introduce the `engine-api` dependency,
we can slowly start using it instead of `samalba/dockerclient` (at least for all the types)

/cc @calavera @icecrime 

(I used it because, as usual, `samalba/dockerclient `has it's types outdated (no Experimental, BuildTime or KernelVersion in the Version struct))