### PR TITLE
Remove link to experimental "rescheduling"

### DIFF
--- a/docs/scheduler/index.md
+++ b/docs/scheduler/index.md
@@ -10,7 +10,5 @@ parent="smn_workw_swarm"
 
 ## Advanced Scheduling
 
-To learn more about advanced scheduling, see the [rescheduling]
-(rescheduling.md), [strategies](strategy.md) and [filters](filter.md)
-documents.
-
+To learn more about advanced scheduling, see the [strategies](strategy.md) and
+[filters](filter.md) documents.


### PR DESCRIPTION
It's in experimental, so should not be linked from in the online documentation; also the current link was broken, resulting in the documentation CI producing errors

Note; this is just temporary; a new link / docs for the experimental feature will be added soon (as discussed with @moxiegirl)