### PR TITLE
New network functions for mesos cluster: CreateNetwork(), RemoveNetwork(), and Networks()

### DIFF
--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -244,7 +245,47 @@ func (c *Cluster) RemoveImages(name string, force bool) ([]*dockerclient.ImageDe
 
 // CreateNetwork creates a network in the cluster
 func (c *Cluster) CreateNetwork(request *dockerclient.NetworkCreate) (*dockerclient.NetworkCreateResponse, error) {
-	return nil, errNotSupported
+	var (
+		parts  = strings.SplitN(request.Name, "/", 2)
+		config = &cluster.ContainerConfig{}
+	)
+
+	if len(parts) == 2 {
+		// a node was specified, create the container only on this node
+		request.Name = parts[1]
+		config = cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==" + parts[0]}})
+	}
+
+	c.scheduler.Lock()
+	nodes, err := c.scheduler.SelectNodesForContainer(c.listNodes(), config)
+	c.scheduler.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if nodes == nil {
+		return nil, errors.New("cannot find node to create network")
+	}
+	n := nodes[0]
+	s, ok := c.agents[n.ID]
+	if !ok {
+		return nil, fmt.Errorf("Unable to create network on agent %q", n.ID)
+	}
+	resp, err := s.engine.CreateNetwork(request)
+	c.refreshNetworks()
+	return resp, err
+}
+
+func (c *Cluster) refreshNetworks() {
+	var wg sync.WaitGroup
+	for _, s := range c.agents {
+		e := s.engine
+		wg.Add(1)
+		go func(e *cluster.Engine) {
+			e.RefreshNetworks()
+			wg.Done()
+		}(e)
+	}
+	wg.Wait()
 }
 
 // CreateVolume creates a volume in the cluster
@@ -254,7 +295,9 @@ func (c *Cluster) CreateVolume(request *dockerclient.VolumeCreateRequest) (*clus
 
 // RemoveNetwork removes network from the cluster
 func (c *Cluster) RemoveNetwork(network *cluster.Network) error {
-	return errNotSupported
+	err := network.Engine.RemoveNetwork(network)
+	c.refreshNetworks()
+	return err
 }
 
 // RemoveVolumes removes volumes from the cluster
@@ -334,7 +377,16 @@ func (c *Cluster) RenameContainer(container *cluster.Container, newName string) 
 
 // Networks returns all the networks in the cluster.
 func (c *Cluster) Networks() cluster.Networks {
-	return cluster.Networks{}
+	c.RLock()
+	defer c.RUnlock()
+
+	out := cluster.Networks{}
+	for _, s := range c.agents {
+		out = append(out, s.engine.Networks()...)
+	}
+
+	return out
+
 }
 
 // Volumes returns all the volumes in the cluster.

--- a/test/integration/mesos/api/network.bats
+++ b/test/integration/mesos/api/network.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+
+load ../../helpers
+load ../mesos_helpers
+
+function teardown() {
+	swarm_manage_cleanup
+	stop_mesos
+	stop_docker
+}
+
+@test "mesos - docker network ls" {
+	start_docker 2
+	start_mesos
+	swarm_manage
+
+	run docker_swarm network ls
+	echo $output
+	[ "${#lines[@]}" -eq 7 ]
+}
+
+@test "mesos - docker network inspect" {
+	start_docker_with_busybox 2
+	start_mesos
+	swarm_manage
+
+	# run
+	docker_swarm run -d -e constraint:node==node-0 busybox sleep 100
+
+	run docker_swarm network inspect bridge
+	[ "$status" -ne 0 ]
+
+	run docker_swarm network inspect node-0/bridge
+	[[ "${output}" != *"\"Containers\": {}"* ]]
+
+	diff <(docker_swarm network inspect node-0/bridge) <(docker -H ${HOSTS[0]} network inspect bridge)
+}
+
+@test "mesos - docker network create" {
+	start_docker 2
+	start_mesos
+	swarm_manage
+
+	run docker_swarm network ls
+	[ "${#lines[@]}" -eq 7 ]
+
+	docker_swarm network create -d bridge test1
+	run docker_swarm network ls
+	[ "${#lines[@]}" -eq 8 ]
+
+	docker_swarm network create -d bridge node-1/test2
+	run docker_swarm network ls
+	[ "${#lines[@]}" -eq 9 ]
+
+	run docker_swarm network create -d bridge node-2/test3
+	[ "$status" -ne 0 ]
+}
+
+@test "mesos - docker network rm" {
+	start_docker_with_busybox 2
+	start_mesos
+	swarm_manage
+
+	run docker_swarm network rm test_network
+	[ "$status" -ne 0 ]
+
+	run docker_swarm network rm bridge
+	[ "$status" -ne 0 ]
+
+	docker_swarm network create -d bridge node-0/test
+	run docker_swarm network ls
+	[ "${#lines[@]}" -eq 8 ]
+
+	docker_swarm network rm node-0/test
+	run docker_swarm network ls
+	[ "${#lines[@]}" -eq 7 ]
+}
+
+@test "mesos - docker network disconnect connect" {
+	start_docker_with_busybox 2
+	start_mesos
+	swarm_manage
+
+	# run
+	docker_swarm run -d --name test_container -e constraint:node==node-0 busybox sleep 100
+
+	run docker_swarm network inspect node-0/bridge
+	[[ "${output}" != *"\"Containers\": {}"* ]]
+
+	docker_swarm network disconnect node-0/bridge test_container
+
+	run docker_swarm network inspect node-0/bridge
+	[[ "${output}" == *"\"Containers\": {}"* ]]
+
+	docker_swarm network connect node-0/bridge test_container
+
+	run docker_swarm network inspect node-0/bridge
+	[[ "${output}" != *"\"Containers\": {}"* ]]
+
+	docker_swarm rm -f test_container
+
+	run docker_swarm network inspect node-0/bridge
+	[[ "${output}" == *"\"Containers\": {}"* ]]
+}


### PR DESCRIPTION
Implement the missing network functions for mesos cluster.  
These functions allow us to support the new docker bridge and overlay networks by 
1) Create a network 2) create a container with net=none 3) connect the container to the network created in (1)

We are also working on adding the new network capabilities as part of createContainer (support --net=userNetworkName but this require some changes to the mesos executer (that we are starting to push as well)