### PR TITLE
Tcp user timeout

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -145,7 +145,7 @@ func (e *Engine) Connect(config *tls.Config) error {
 	}
 	e.IP = addr.IP.String()
 
-	c, err := dockerclient.NewDockerClientTimeout("tcp://"+e.Addr, config, time.Duration(requestTimeout), nil)
+	c, err := dockerclient.NewDockerClientTimeout("tcp://"+e.Addr, config, time.Duration(requestTimeout), setTCPUserTimeout)
 	if err != nil {
 		return err
 	}

--- a/cluster/utils_darwin.go
+++ b/cluster/utils_darwin.go
@@ -1,0 +1,22 @@
+// +build darwin
+
+package dockerclient
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// setTCPUserTimeout sets TCP_RXT_CONNDROPTIME on darwin
+func setTCPUserTimeout(conn *net.TCPConn, uto time.Duration) error {
+	f, err := conn.File()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	secs := int(uto.Nanoseconds() / 1e9)
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(f.Fd()), syscall.IPPROTO_TCP, unix.TCP_RXT_CONNDROPTIME, secs))
+}

--- a/cluster/utils_unix.go
+++ b/cluster/utils_unix.go
@@ -1,0 +1,28 @@
+// +build linux
+
+package cluster
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// setTCPUserTimeout sets TCP_USER_TIMEOUT according to RFC5842
+func setTCPUserTimeout(conn *net.TCPConn, uto time.Duration) error {
+	f, err := conn.File()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	msecs := int(uto.Nanoseconds() / 1e6)
+	// TCP_USER_TIMEOUT is a relatively new feature to detect dead peer from sender side.
+	// Linux supports it since kernel 2.6.37. It's among Golang experimental under
+	// golang.org/x/sys/unix but it doesn't support all Linux platforms yet.
+	// we explicitly define it here until it becomes official in golang.
+	// TODO: replace it with proper package when TCP_USER_TIMEOUT is supported in golang.
+	const tcpUserTimeout = 0x12
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(f.Fd()), syscall.IPPROTO_TCP, tcpUserTimeout, msecs))
+}

--- a/cluster/utils_windows.go
+++ b/cluster/utils_windows.go
@@ -1,0 +1,16 @@
+// +build !linux,!darwin
+
+package cluster
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+// setTCPUserTimeout doesn't work under Windows because Go doesn't support
+// the option and swarm doesn't support cgo
+// This is a usability enhancement. Service shouldn't fail on this error.
+func setTCPUserTimeout(conn *net.TCPConn, uto time.Duration) error {
+	return errors.New("Go doesn't have native support for TCP_USER_TIMEOUT for this platform")
+}


### PR DESCRIPTION
Swarm implements TCP user timeout for dead peer detection. A sender can break the connection within 20 seconds, comparing with Linux default 15 minutes. We don't want to introduce cgo in swarm so it makes compromise on golang experiment package. 