### PR TITLE
Allow specifying default resource constraints when running swarm manager

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -51,7 +51,9 @@ Options:
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}
                                     {{printf "\t * mesos.offerrefusetimeout=5s\tseconds to consider unused resources refused [$SWARM_MESOS_OFFER_REFUSE_TIMEOUT]"}}
                                     {{printf "\t * mesos.tasktimeout=5s\ttimeout for task creation [$SWARM_MESOS_TASK_TIMEOUT]"}}
-                                    {{printf "\t * mesos.user=\tframework user [$SWARM_MESOS_USER]"}}{{end}}{{ end }}
+                                    {{printf "\t * mesos.user=\tframework user [$SWARM_MESOS_USER]"}}
+                                    {{printf "\t * mesos.defaultcpushares=0\tDefault cpu shares [$SWARM_MESOS_DEFAULT_CPU_SHARES]"}}
+                                    {{printf "\t * mesos.defaultmemory=0\tDefault memory [$SWARM_MESOS_DEFAULT_MEMORY]"}}{{end}}{{ end }}
 `
 
 }

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -37,6 +37,8 @@ type Cluster struct {
 	offerTimeout        time.Duration
 	refuseTimeout       time.Duration
 	taskCreationTimeout time.Duration
+	defaultCpuShares    int64
+	defaultMemory       int64
 	pendingTasks        *task.Tasks
 	engineOpts          *cluster.EngineOpts
 }
@@ -49,6 +51,8 @@ const (
 	defaultOfferTimeout        = 30 * time.Second
 	defaultRefuseTimeout       = 5 * time.Second
 	defaultTaskCreationTimeout = 5 * time.Second
+	unsetDefaultCpuShares      = 0
+	unsetDefaultMemory         = 0
 )
 
 var (
@@ -75,6 +79,8 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 		taskCreationTimeout: defaultTaskCreationTimeout,
 		engineOpts:          engineOptions,
 		refuseTimeout:       defaultRefuseTimeout,
+		defaultCpuShares:    unsetDefaultCpuShares,
+		defaultMemory:       unsetDefaultMemory,
 	}
 
 	cluster.pendingTasks = task.NewTasks(cluster)
@@ -139,6 +145,14 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 		cluster.refuseTimeout = d
 	}
 
+	if defaultCpuShares, ok := options.Int("mesos.defaultcpushares", "SWARM_MESOS_DEFAULT_CPU_SHARES"); ok {
+		cluster.defaultCpuShares = defaultCpuShares
+	}
+
+	if defaultMemory, ok := options.Int("mesos.defaultmemory", "SWARM_MESOS_DEFAULT_MEMORY"); ok {
+		cluster.defaultMemory = defaultMemory
+	}
+
 	sched, err := NewScheduler(driverConfig, cluster, scheduler)
 	if err != nil {
 		return nil, err
@@ -179,6 +193,13 @@ func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 
 // CreateContainer for container creation in Mesos task
 func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*cluster.Container, error) {
+	if config.Memory == 0 {
+		config.Memory = c.defaultMemory
+	}
+	if config.CpuShares == 0 {
+		config.CpuShares = c.defaultCpuShares
+	}
+
 	if config.Memory == 0 && config.CpuShares == 0 {
 		return nil, errResourcesNeeded
 	}


### PR DESCRIPTION
Allow specifying default resource constraints with cluster options. This is very useful when using other tools interacting with swarm cannot create containers because they do not expose options for --cpu-shares or --memory.
