### PR TITLE
Fix a race condition in pending engine validation

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -271,6 +271,11 @@ func (c *Cluster) validatePendingEngine(engine *cluster.Engine) bool {
 	c.Lock()
 	defer c.Unlock()
 
+	// Only validate engines from pendingEngines list
+	if _, exists := c.pendingEngines[engine.Addr]; !exists {
+		return false
+	}
+
 	// Make sure the engine ID is unique.
 	if old, exists := c.engines[engine.ID]; exists {
 		if old.Addr != engine.Addr {


### PR DESCRIPTION
To speed up engine validation with many nodes, swarm allows engine validation in parallel so that different engines can go thru validation quickly. But the current code allows validation of the same engine to run in parallel and they interfere with each other. This change is to use the first validation result. 

Fix #1649, #1650.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>