### PR TITLE
Enforce minimum backoff to avoid simultaneous validation on one engine

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -239,7 +239,9 @@ func (e *Engine) TimeToValidate() bool {
 	}
 	sinceLastUpdate := time.Since(e.updatedAt)
 	// Increase check interval for a pending engine according to failureCount and cap it at a limit
-	if sinceLastUpdate > validationLimit || sinceLastUpdate > time.Duration(e.failureCount)*failureBackoff {
+	// '+1' would enforce a minimum backoff because e.failureCount could be 0 at first join, or
+	// the engine has a duplicate ID
+	if sinceLastUpdate > validationLimit || sinceLastUpdate > time.Duration(e.failureCount+1)*failureBackoff {
 		return true
 	}
 	return false

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -231,7 +231,7 @@ func (e *Engine) setState(state engineState) {
 // TimeToValidate returns true if a pending node is up for validation
 func (e *Engine) TimeToValidate() bool {
 	const validationLimit time.Duration = 4 * time.Hour
-	const failureBackoff time.Duration = 30 * time.Second
+	const minFailureBackoff time.Duration = 30 * time.Second
 	e.Lock()
 	defer e.Unlock()
 	if e.state != statePending {
@@ -239,9 +239,10 @@ func (e *Engine) TimeToValidate() bool {
 	}
 	sinceLastUpdate := time.Since(e.updatedAt)
 	// Increase check interval for a pending engine according to failureCount and cap it at a limit
-	// '+1' would enforce a minimum backoff because e.failureCount could be 0 at first join, or
-	// the engine has a duplicate ID
-	if sinceLastUpdate > validationLimit || sinceLastUpdate > time.Duration(e.failureCount+1)*failureBackoff {
+	// it's exponential backoff = 2 ^ failureCount + minFailureBackoff. A minimum backoff is
+	// needed because e.failureCount could be 0 at first join, or the engine has a duplicate ID
+	if sinceLastUpdate > validationLimit ||
+		sinceLastUpdate > (1<<uint(e.failureCount))*time.Second+minFailureBackoff {
 		return true
 	}
 	return false


### PR DESCRIPTION
`validatePendingEngine` can be called at first join, or from a monitoring thread. Current code allows both happen on the same engine simultaneously. The monitoring thread has a logic to check if it's the right time to do validation. It shouldn't validate an engine when it's just joined. This change is to enforce that.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>