### PR TITLE
Swarm new navigation for 1.10

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -1,15 +1,15 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm discovery"
+title = "Discovery"
 description = "Swarm discovery"
 keywords = ["docker, swarm, clustering,  discovery"]
 [menu.main]
-parent="smn_workw_swarm"
+parent="workw_swarm"
 weight=4
 +++
 <![end-metadata]-->
 
-# Discovery
+# Docker Swarm Discovery
 
 Docker Swarm comes with multiple discovery backends. You use a hosted discovery service with Docker Swarm. The service maintains a list of IPs in your swarm.
 This page describes the different types of hosted discovery available to you. These are:
@@ -218,4 +218,4 @@ github.com/docker/docker/pkg/discovery</a>.
 - [Docker Swarm overview](index.md)
 - [Scheduler strategies](scheduler/strategy.md)
 - [Scheduler filters](scheduler/filter.md)
-- [Swarm API](api/swarm-api.md)
+- [Swarm API](swarm-api.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,76 +1,18 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm"
+title = "Swarm"
 description = "Swarm: a Docker-native clustering system"
 keywords = ["docker, swarm,  clustering"]
 [menu.main]
-parent="smn_workw_swarm"
+identifier="workw_swarm"
+weight=-75
 +++
 <![end-metadata]-->
 
-# Docker Swarm overview
 
-Docker Swarm is native clustering for Docker. It turns a pool of Docker hosts
-into a single, virtual Docker host. Because Docker Swarm serves the standard
-Docker API, any tool that already communicates with a Docker daemon can use
-Swarm to transparently scale to multiple hosts. Supported tools include, but
-are not limited to, the following:
+# Docker Swarm
 
-- Dokku
-- Docker Compose
-- Krane
-- Jenkins
-
-And of course, the Docker client itself is also supported.
-
-Like other Docker projects, Docker Swarm follows the "swap, plug, and play"
-principle. As initial development settles, an API will develop to enable
-pluggable backends.  This means you can swap out the scheduling backend
-Docker Swarm uses out-of-the-box with a backend you prefer. Swarm's swappable design provides a smooth out-of-box experience for most use cases, and allows large-scale production deployments to swap for more powerful backends, like Mesos.
-
-## Understand swarm creation
-
-The first step to creating a swarm on your network is to pull the Docker Swarm image. Then, using Docker, you configure the swarm manager and all the nodes to run Docker Swarm. This method requires that you:
-
-* open a TCP port on each node for communication with the swarm manager
-* install Docker on each node
-* create and manage TLS certificates to secure your swarm
-
-As a starting point, the manual method is best suited for experienced administrators or programmers contributing to Docker Swarm. The alternative is to use `docker-machine` to install a swarm.
-
-Using Docker Machine, you can quickly install a Docker Swarm on cloud providers or inside your own data center. If you have VirtualBox installed on your local machine, you can quickly build and explore Docker Swarm in your local environment. This method automatically generates a certificate to secure your swarm.
-
-Using Docker Machine is the best method for users getting started with Swarm for the first time. To try the recommended method of getting started, see [Get Started with Docker Swarm](install-w-machine.md).
-
-If you are interested manually installing or interested in contributing, see [Create a swarm for development](install-manual.md).
-
-## Discovery services
-
-To dynamically configure and manage the services in your containers, you use a discovery backend with Docker Swarm. For information on which backends are available, see the [Discovery service](discovery.md) documentation.
-
-## Advanced Scheduling
-
-To learn more about advanced scheduling, see the
-[strategies](scheduler/strategy.md) and [filters](scheduler/filter.md)
-documents.
-
-## Swarm API
-
-The [Docker Swarm API](api/swarm-api.md) is compatible with
-the [Docker remote
-API](http://docs.docker.com/reference/api/docker_remote_api/), and extends it
-with some new endpoints.
-
-# Getting help
-
-Docker Swarm is still in its infancy and under active development. If you need
-help, would like to contribute, or simply want to talk about the project with
-like-minded individuals, we have a number of open channels for communication.
-
-* To report bugs or file feature requests: please use the [issue tracker on Github](https://github.com/docker/swarm/issues).
-
-* To talk about the project with people in real time: please join the `#docker-swarm` channel on IRC.
-
-* To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/swarm/pulls).
-
-For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/project/get-help/).
+- [Docker Swarm overview](overview.md)
+- [Scheduler strategies](scheduler/strategy.md)
+- [Scheduler filters](scheduler/filter.md)
+- [Swarm API](swarm-api.md)

--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -4,8 +4,7 @@ title = "Create a swarm for development"
 description = "Swarm: a Docker-native clustering system"
 keywords = ["docker, swarm,  clustering"]
 [menu.main]
-parent="smn_workw_swarm"
-weight=2
+parent="workw_swarm"
 +++
 <![end-metadata]-->
 
@@ -15,7 +14,7 @@ This section tells you how to create a Docker Swarm on your network to use only 
 
 > **Caution**: Only use this set up if your network environment is secured by a firewall or other measures.
 
-## Prerequisites 
+## Prerequisites
 
 You install Docker Swarm on a single system which is known as your Docker Swarm
 manager. You create the cluster, or swarm, on one or more additional nodes on
@@ -56,7 +55,7 @@ The easiest way to get started with Swarm is to use the
 1. Create a Swarm cluster using the `docker` command.
 
 		$ docker run --rm swarm create
-		6856663cdefdec325839a4b7e1de38e8 # 
+		6856663cdefdec325839a4b7e1de38e8 #
 
 	The `create` command returns a unique cluster ID (`cluster_id`). You'll need
 	this ID when starting the Docker Swarm agent on a node.
@@ -90,7 +89,7 @@ available in default docker installs.
 
 Once you have your nodes established, set up a manager to control the swarm.
 
-1. Start the Swarm manager on any machine or your laptop. 
+1. Start the Swarm manager on any machine or your laptop.
 
 	The following command illustrates how to do this:
 
@@ -124,7 +123,7 @@ Once you have your nodes established, set up a manager to control the swarm.
   In that case, be sure to unset `DOCKER_TLS_VERIFY` with:
 
     $ unset DOCKER_TLS_VERIFY
-  
+
 ## Using the docker CLI
 
 You can now use the regular Docker CLI to access your nodes:

--- a/docs/install-w-machine.md
+++ b/docs/install-w-machine.md
@@ -1,12 +1,10 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm"
+title = "Install and use Swarm"
 description = "Swarm release notes"
 keywords = ["docker, swarm, clustering, discovery, release,  notes"]
 [menu.main]
-identifier="swm_install"
-parent="mn_install"
-weight=9
+parent="workw_swarm"
 +++
 <![end-metadata]-->
 

--- a/docs/multi-manager-setup.md
+++ b/docs/multi-manager-setup.md
@@ -1,10 +1,10 @@
 <!--[metadata]>
 +++
-title = "High availability in Docker Swarm"
-description = "High availability in Docker Swarm"
+title = "High availability in Swarm"
+description = "High availability in Swarm"
 keywords = ["docker, swarm,  clustering"]
 [menu.main]
-parent="smn_workw_swarm"
+parent="workw_swarm"
 weight=3
 +++
 <![end-metadata]-->

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,15 +1,14 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm Networking"
-description = "Swarm Networking"
+title = "Swarm and container networks"
+description = "Swarm and container networks"
 keywords = ["docker, swarm, clustering,  networking"]
 [menu.main]
-parent="smn_workw_swarm"
-weight=4
+parent="workw_swarm"
 +++
 <![end-metadata]-->
 
-# Networking
+# Swarm and container networks
 
 Docker Swarm is fully compatible with Docker's networking features. This
 includes the multi-host networking feature which allows creation of custom
@@ -133,4 +132,4 @@ from `node-0`.
 - [Docker Swarm overview](index.md)
 - [Scheduler strategies](scheduler/strategy.md)
 - [Scheduler filters](scheduler/filter.md)
-- [Swarm API](api/swarm-api.md)
+- [Swarm API](swarm-api.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,77 @@
+<!--[metadata]>
++++
+title = "Swarm Overview"
+description = "Swarm: a Docker-native clustering system"
+keywords = ["docker, swarm,  clustering"]
+[menu.main]
+parent="workw_swarm"
+weight=-99
++++
+<![end-metadata]-->
+
+# Docker Swarm overview
+
+Docker Swarm is native clustering for Docker. It turns a pool of Docker hosts
+into a single, virtual Docker host. Because Docker Swarm serves the standard
+Docker API, any tool that already communicates with a Docker daemon can use
+Swarm to transparently scale to multiple hosts. Supported tools include, but
+are not limited to, the following:
+
+- Dokku
+- Docker Compose
+- Krane
+- Jenkins
+
+And of course, the Docker client itself is also supported.
+
+Like other Docker projects, Docker Swarm follows the "swap, plug, and play"
+principle. As initial development settles, an API will develop to enable
+pluggable backends.  This means you can swap out the scheduling backend
+Docker Swarm uses out-of-the-box with a backend you prefer. Swarm's swappable design provides a smooth out-of-box experience for most use cases, and allows large-scale production deployments to swap for more powerful backends, like Mesos.
+
+## Understand swarm creation
+
+The first step to creating a swarm on your network is to pull the Docker Swarm image. Then, using Docker, you configure the swarm manager and all the nodes to run Docker Swarm. This method requires that you:
+
+* open a TCP port on each node for communication with the swarm manager
+* install Docker on each node
+* create and manage TLS certificates to secure your swarm
+
+As a starting point, the manual method is best suited for experienced administrators or programmers contributing to Docker Swarm. The alternative is to use `docker-machine` to install a swarm.
+
+Using Docker Machine, you can quickly install a Docker Swarm on cloud providers or inside your own data center. If you have VirtualBox installed on your local machine, you can quickly build and explore Docker Swarm in your local environment. This method automatically generates a certificate to secure your swarm.
+
+Using Docker Machine is the best method for users getting started with Swarm for the first time. To try the recommended method of getting started, see [Get Started with Docker Swarm](install-w-machine.md).
+
+If you are interested manually installing or interested in contributing, see [Create a swarm for development](install-manual.md).
+
+## Discovery services
+
+To dynamically configure and manage the services in your containers, you use a discovery backend with Docker Swarm. For information on which backends are available, see the [Discovery service](discovery.md) documentation.
+
+## Advanced Scheduling
+
+To learn more about advanced scheduling, see the
+[strategies](scheduler/strategy.md) and [filters](scheduler/filter.md)
+documents.
+
+## Swarm API
+
+The [Docker Swarm API](swarm-api.md) is compatible with
+the [Docker remote
+API](http://docs.docker.com/reference/api/docker_remote_api/), and extends it
+with some new endpoints.
+
+# Getting help
+
+Docker Swarm is still in its infancy and under active development. If you need
+help, would like to contribute, or simply want to talk about the project with
+like-minded individuals, we have a number of open channels for communication.
+
+* To report bugs or file feature requests: please use the [issue tracker on Github](https://github.com/docker/swarm/issues).
+
+* To talk about the project with people in real time: please join the `#docker-swarm` channel on IRC.
+
+* To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/swarm/pulls).
+
+For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/project/get-help/).

--- a/docs/scheduler/filter.md
+++ b/docs/scheduler/filter.md
@@ -1,15 +1,15 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm filters"
+title = "Filters"
 description = "Swarm filters"
 keywords = ["docker, swarm, clustering,  filters"]
 [menu.main]
-parent="smn_workw_swarm"
+parent="swarm_sched"
 weight=4
 +++
 <![end-metadata]-->
 
-# Filters
+# Swarm filters
 
 Filters tell Docker Swarm scheduler which nodes to use when creating and running
 a container.
@@ -505,4 +505,4 @@ without a container that satisfies `redis*`
 - [Docker Swarm overview](../index.md)
 - [Discovery options](../discovery.md)
 - [Scheduler strategies](strategy.md)
-- [Swarm API](../api/swarm-api.md)
+- [Swarm API](../swarm-api.md)

--- a/docs/scheduler/index.md
+++ b/docs/scheduler/index.md
@@ -1,10 +1,12 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm Scheduling"
+title = "Scheduling"
 description = "Swarm: a Docker-native clustering system"
 keywords = ["docker, swarm, clustering, scheduling"]
 [menu.main]
-parent="smn_workw_swarm"
+identifier="swarm_sched"
+parent="workw_swarm"
+weight=80
 +++
 <![end-metadata]-->
 

--- a/docs/scheduler/strategy.md
+++ b/docs/scheduler/strategy.md
@@ -1,15 +1,15 @@
 <!--[metadata]>
 +++
-title = "Docker Swarm strategies"
+title = "Strategies"
 description = "Swarm strategies"
 keywords = ["docker, swarm, clustering,  strategies"]
 [menu.main]
-parent="smn_workw_swarm"
+parent="swarm_sched"
 weight=5
 +++
 <![end-metadata]-->
 
-# Strategies
+# Docker Swarm strategies
 
 The Docker Swarm scheduler features multiple strategies for ranking nodes. The
 strategy you choose determines how Swarm computes ranking. When you run a new
@@ -125,4 +125,4 @@ strategy prefers the node with most containers.
 - [Docker Swarm overview](../index.md)
 - [Discovery options](../discovery.md)
 - [Scheduler filters](filter.md)
-- [Swarm API](../api/swarm-api.md)
+- [Swarm API](../swarm-api.md)

--- a/docs/swarm-api.md
+++ b/docs/swarm-api.md
@@ -1,11 +1,12 @@
 <!--[metadata]>
 +++
+aliases = ["api/swarm-api/", "/swarm/api/"]
 title = "Docker Swarm API"
 description = "Swarm API"
 keywords = ["docker, swarm, clustering,  api"]
-aliases = ["/swarm/api/"]
 [menu.main]
-parent="smn_swarm_ref"
+parent="workw_swarm"
+weight=99
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
For 1.10 we are changing the taxonomy to product-specific menus.  The items on this menu **will change ** (especially in regards to the create a swarm) when Rolfe finishes his work. I want to merge this PR so he can rebase against it. 

![image](https://cloud.githubusercontent.com/assets/1347209/12537544/9cb6294a-c276-11e5-88b8-2403d4e8ac09.png)


- Adding new navigation
- Moving API to top level

Signed-off-by: Mary Anthony <mary@docker.com>