### PR TITLE
Provide error when engine version is unsupported

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -369,7 +369,9 @@ func (e *Engine) updateSpecs() error {
 	// Older versions of Docker don't expose the ID field, Labels and are not supported
 	// by Swarm.  Catch the error ASAP and refuse to connect.
 	if engineVersion.LessThan(minSupportedVersion) {
-		return fmt.Errorf("engine %s is running an unsupported version of Docker Engine. Please upgrade to at least %s", e.Addr, minSupportedVersion)
+		err = fmt.Errorf("engine %s is running an unsupported version of Docker Engine. Please upgrade to at least %s", e.Addr, minSupportedVersion)
+		e.CheckConnectionErr(err)
+		return err
 	}
 
 	e.Lock()

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -825,7 +825,7 @@ func (c *Cluster) Info() [][]string {
 	info := [][]string{
 		{"\bStrategy", c.scheduler.Strategy()},
 		{"\bFilters", c.scheduler.Filters()},
-		{"\bNodes", fmt.Sprintf("%d", len(c.engines))},
+		{"\bNodes", fmt.Sprintf("%d", len(c.engines)+len(c.pendingEngines))},
 	}
 
 	engines := c.listEngines()


### PR DESCRIPTION
Also fix node count in swarm info. Fix #1675.
Signed-off-by: Dong Chen <dongluo.chen@docker.com>