### PR TITLE
Adding .DS_Store to .gitignore for Mac developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /swarm
+.DS_Store


### PR DESCRIPTION
Mac filesystem creates `.DS_Store` files to keep track of folder attributes, and we don't want these to be committed to the repo. Many developers don't have global git settings to ignore these files. `docker/docker` explicitly ignores them too.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>