### PR TITLE
Extracting apiversion from HTTP request

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -18,6 +18,7 @@ type context struct {
 	statusHandler StatusHandler
 	debug         bool
 	tlsConfig     *tls.Config
+	apiVersion    string
 }
 
 type handler func(c *context, w http.ResponseWriter, r *http.Request)
@@ -149,11 +150,12 @@ func setupPrimaryRouter(r *mux.Router, context *context, enableCors bool) {
 				if enableCors {
 					writeCorsHeaders(w, r)
 				}
+				context.apiVersion = mux.Vars(r)["version"]
 				localFct(context, w, r)
 			}
 			localMethod := method
 
-			r.Path("/v{version:[0-9.]+}" + localRoute).Methods(localMethod).HandlerFunc(wrap)
+			r.Path("/v{version:[0-9]+.[0-9]+}" + localRoute).Methods(localMethod).HandlerFunc(wrap)
 			r.Path(localRoute).Methods(localMethod).HandlerFunc(wrap)
 
 			if enableCors {
@@ -169,7 +171,7 @@ func setupPrimaryRouter(r *mux.Router, context *context, enableCors bool) {
 					localFct(context, w, r)
 				}
 
-				r.Path("/v{version:[0-9.]+}" + localRoute).
+				r.Path("/v{version:[0-9]+.[0-9]+}" + localRoute).
 					Methods(optionsMethod).HandlerFunc(wrap)
 				r.Path(localRoute).Methods(optionsMethod).
 					HandlerFunc(wrap)

--- a/api/primary_test.go
+++ b/api/primary_test.go
@@ -11,8 +11,9 @@ import (
 func TestRequest(t *testing.T) {
 	t.Parallel()
 
+	context := &context{}
 	r := mux.NewRouter()
-	setupPrimaryRouter(r, nil, false)
+	setupPrimaryRouter(r, context, false)
 	w := httptest.NewRecorder()
 
 	req, e := http.NewRequest("GET", "/version", nil)


### PR DESCRIPTION
We need the API version supplied by the HTTP request for #1625. This also improves the regex that defines allowed version values. Previously malformed versions like `v1.2323.535` etc were allowed, now they'll be well formed decimals.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>