### PR TITLE
Allow more retries for node validation

### DIFF
--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -110,7 +110,7 @@ function swarm_manage() {
 	discovery_check_swarm_info "${#HOSTS[@]}" "${SWARM_HOSTS[$i]}"
 
 	# All nodes passes pending state
-	retry 5 1 nodes_validated
+	retry 15 1 nodes_validated
 }
 
 # Start the swarm manager in background.


### PR DESCRIPTION
Jenkins reported several failures from 'nodes_validated' recently while I cannot reproduce locally. It's possible that Jenkins runs at heavy loaded machine and takes more time to finish validation. 
Signed-off-by: Dong Chen <dongluo.chen@docker.com>