### PR TITLE
Removing backspaces in /info output for new API version

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -168,6 +168,7 @@ func setupPrimaryRouter(r *mux.Router, context *context, enableCors bool) {
 					if enableCors {
 						writeCorsHeaders(w, r)
 					}
+					context.apiVersion = mux.Vars(r)["version"]
 					localFct(context, w, r)
 				}
 

--- a/api/primary_test.go
+++ b/api/primary_test.go
@@ -37,8 +37,9 @@ func TestRequest(t *testing.T) {
 func TestCorsRequest(t *testing.T) {
 	t.Parallel()
 
+	context := &context{}
 	primary := mux.NewRouter()
-	setupPrimaryRouter(primary, nil, true)
+	setupPrimaryRouter(primary, context, true)
 	w := httptest.NewRecorder()
 
 	r, e := http.NewRequest("OPTIONS", "/version", nil)

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -54,12 +54,12 @@ func (h *statusHandler) Status() [][2]string {
 
 	if h.candidate != nil && !h.candidate.IsLeader() {
 		status = [][2]string{
-			{"\bRole", "replica"},
-			{"\bPrimary", h.follower.Leader()},
+			{"Role", "replica"},
+			{"Primary", h.follower.Leader()},
 		}
 	} else {
 		status = [][2]string{
-			{"\bRole", "primary"},
+			{"Role", "primary"},
 		}
 	}
 

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -399,17 +399,17 @@ func (c *Cluster) TotalCpus() int64 {
 func (c *Cluster) Info() [][2]string {
 	offers := c.listOffers()
 	info := [][2]string{
-		{"\bStrategy", c.scheduler.Strategy()},
-		{"\bFilters", c.scheduler.Filters()},
-		{"\bOffers", fmt.Sprintf("%d", len(offers))},
+		{"Strategy", c.scheduler.Strategy()},
+		{"Filters", c.scheduler.Filters()},
+		{"Offers", fmt.Sprintf("%d", len(offers))},
 	}
 
 	sort.Sort(offerSorter(offers))
 
 	for _, offer := range offers {
-		info = append(info, [2]string{" Offer", offer.Id.GetValue()})
+		info = append(info, [2]string{"  Offer", offer.Id.GetValue()})
 		for _, resource := range offer.Resources {
-			info = append(info, [2]string{"  └ " + resource.GetName(), formatResource(resource)})
+			info = append(info, [2]string{"   └ " + resource.GetName(), formatResource(resource)})
 		}
 	}
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -823,32 +823,32 @@ func (c *Cluster) TotalCpus() int64 {
 // Info returns some info about the cluster, like nb or containers / images
 func (c *Cluster) Info() [][2]string {
 	info := [][2]string{
-		{"\bStrategy", c.scheduler.Strategy()},
-		{"\bFilters", c.scheduler.Filters()},
-		{"\bNodes", fmt.Sprintf("%d", len(c.engines)+len(c.pendingEngines))},
+		{"Strategy", c.scheduler.Strategy()},
+		{"Filters", c.scheduler.Filters()},
+		{"Nodes", fmt.Sprintf("%d", len(c.engines)+len(c.pendingEngines))},
 	}
 
 	engines := c.listEngines()
 	sort.Sort(cluster.EngineSorter(engines))
 
 	for _, engine := range engines {
-		info = append(info, [2]string{engine.Name, engine.Addr})
-		info = append(info, [2]string{" └ Status", engine.Status()})
-		info = append(info, [2]string{" └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
-		info = append(info, [2]string{" └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})
-		info = append(info, [2]string{" └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(engine.UsedMemory())), units.BytesSize(float64(engine.TotalMemory())))})
+		info = append(info, [2]string{" " + engine.Name, engine.Addr})
+		info = append(info, [2]string{"  └ Status", engine.Status()})
+		info = append(info, [2]string{"  └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
+		info = append(info, [2]string{"  └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})
+		info = append(info, [2]string{"  └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(engine.UsedMemory())), units.BytesSize(float64(engine.TotalMemory())))})
 		labels := make([]string, 0, len(engine.Labels))
 		for k, v := range engine.Labels {
 			labels = append(labels, k+"="+v)
 		}
 		sort.Strings(labels)
-		info = append(info, [2]string{" └ Labels", fmt.Sprintf("%s", strings.Join(labels, ", "))})
+		info = append(info, [2]string{"  └ Labels", fmt.Sprintf("%s", strings.Join(labels, ", "))})
 		errMsg := engine.ErrMsg()
 		if len(errMsg) == 0 {
 			errMsg = "(none)"
 		}
-		info = append(info, [2]string{" └ Error", errMsg})
-		info = append(info, [2]string{" └ UpdatedAt", engine.UpdatedAt().UTC().Format(time.RFC3339)})
+		info = append(info, [2]string{"  └ Error", errMsg})
+		info = append(info, [2]string{"  └ UpdatedAt", engine.UpdatedAt().UTC().Format(time.RFC3339)})
 	}
 
 	return info


### PR DESCRIPTION
Starting with API Version 1.22 (release 1.10), cluster information is returned inside a new field called `SystemStatus` instead of `DriverStatus`. Also `\b` characters are removed and formatting updated. Other corresponding PRs are https://github.com/docker/docker/pull/19646 and https://github.com/docker/engine-api/pull/46.

This commit also adds a minor change that was missed in #1696 (extracting API version with `enableCors = true`)

Fixes #1625.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>