### PR TITLE
Adding default name (unknown) for pending engine

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -837,7 +837,11 @@ func (c *Cluster) Info() [][2]string {
 	sort.Sort(cluster.EngineSorter(engines))
 
 	for _, engine := range engines {
-		info = append(info, [2]string{" " + engine.Name, engine.Addr})
+		engineName := "(unknown)"
+		if engine.Name != "" {
+			engineName = engine.Name
+		}
+		info = append(info, [2]string{" " + engineName, engine.Addr})
 		info = append(info, [2]string{"  └ Status", engine.Status()})
 		info = append(info, [2]string{"  └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
 		info = append(info, [2]string{"  └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})


### PR DESCRIPTION
Fixes #1689. This change only adds a default name to Engines whose validation is pending. We should open another issue to further discuss about what information needs to be shown (or hidden) for pending engines.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>