### PR TITLE
retry monitor events on EOF

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -167,7 +167,7 @@
 		},
 		{
 			"ImportPath": "github.com/samalba/dockerclient",
-			"Rev": "46becf1a81c169800ab8e5eeef2b92d799e9d785"
+			"Rev": "8328370620b71cb5acadd41f259dca96865a069b"
 		},
 		{
 			"ImportPath": "github.com/samuel/go-zookeeper/zk",

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/dockerclient.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/dockerclient.go
@@ -503,7 +503,7 @@ func (client *DockerClient) StartMonitorEvents(cb Callback, ec chan error, args 
 		for e := range eventErrChan {
 			if e.Error != nil {
 				if ec != nil {
-					ec <- err
+					ec <- e.Error
 				}
 				return
 			}

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -153,6 +153,23 @@ func (e *Engine) Connect(config *tls.Config) error {
 	return e.ConnectWithClient(c)
 }
 
+// StartMonitorEvents monitors events from the engine
+func (e *Engine) StartMonitorEvents() {
+	log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Debug("Start monitoring events")
+	ec := make(chan error)
+	e.client.StartMonitorEvents(e.handler, ec)
+
+	go func() {
+		if err := <-ec; err != nil && err.Error() != "EOF" {
+			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Error monitoring events: %s", err)
+		} else if err != nil {
+			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Debug("EOF monitoring events, restarting")
+			e.StartMonitorEvents()
+		}
+		close(ec)
+	}()
+}
+
 // ConnectWithClient is exported
 func (e *Engine) ConnectWithClient(client dockerclient.Client) error {
 	e.client = client
@@ -162,8 +179,7 @@ func (e *Engine) ConnectWithClient(client dockerclient.Client) error {
 		return err
 	}
 
-	// Start monitoring events from the engine.
-	e.client.StartMonitorEvents(e.handler, nil)
+	e.StartMonitorEvents()
 
 	// Force a state update before returning.
 	if err := e.RefreshContainers(true); err != nil {
@@ -607,7 +623,7 @@ func (e *Engine) refreshLoop() {
 				continue
 			}
 			e.client.StopAllMonitorEvents()
-			e.client.StartMonitorEvents(e.handler, nil)
+			e.StartMonitorEvents()
 		}
 
 		err = e.RefreshContainers(false)


### PR DESCRIPTION
Looks like StartMonitorEvents from dockerclient sometimes returns `EOF` when you try to monitor the events.

this should be fixed when using engine-api/client.

In the meantime, let's retry.

Fix https://github.com/docker/swarm/issues/1686
Fix https://github.com/docker/swarm/issues/1203