### PR TITLE
Ignore 404 error from old engine versions

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -342,16 +342,6 @@ func (e *Engine) CheckConnectionErr(err error) {
 		return
 	}
 
-	// Docker engine may return 404 when it doesn't recognize a command.
-	// It's not an error from the engine itself. Version validation should be done separately.
-	// This error message is not recorded here to avoid user confusion.
-	if strings.HasPrefix(err.Error(), "404 ") {
-		return
-	}
-
-	// update engine error message
-	e.setErrMsg(err.Error())
-
 	// dockerclient defines ErrConnectionRefused error. but if http client is from swarm, it's not using
 	// dockerclient. We need string matching for these cases. Remove the first character to deal with
 	// case sensitive issue
@@ -364,6 +354,8 @@ func (e *Engine) CheckConnectionErr(err error) {
 		// can track last error time. Only increase failure count if last error is
 		// not too recent, e.g., last error is at least 1 seconds ago.
 		e.incFailureCount()
+		// update engine error message
+		e.setErrMsg(err.Error())
 		return
 	}
 	// other errors may be ambiguous.

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -280,7 +280,7 @@ func (e *Engine) ValidationComplete() {
 func (e *Engine) setErrMsg(errMsg string) {
 	e.Lock()
 	defer e.Unlock()
-	e.lastError = errMsg
+	e.lastError = strings.TrimSpace(errMsg)
 	e.updatedAt = time.Now()
 }
 
@@ -339,6 +339,13 @@ func (e *Engine) CheckConnectionErr(err error) {
 			e.setState(stateHealthy)
 		}
 		e.resetFailureCount()
+		return
+	}
+
+	// Docker engine may return 404 when it doesn't recognize a command.
+	// It's not an error from the engine itself. Version validation should be done separately.
+	// This error message is not recorded here to avoid user confusion.
+	if strings.HasPrefix(err.Error(), "404 ") {
 		return
 	}
 

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -69,6 +69,11 @@ func TestCheckConnectionErr(t *testing.T) {
 	engine.CheckConnectionErr(err)
 	assert.True(t, engine.failureCount == 0)
 	assert.True(t, len(engine.ErrMsg()) == 0)
+	// Do not accept random error
+	err = fmt.Errorf("random error")
+	engine.CheckConnectionErr(err)
+	assert.True(t, engine.failureCount == 0)
+	assert.True(t, len(engine.ErrMsg()) == 0)
 }
 
 func TestEngineFailureCount(t *testing.T) {


### PR DESCRIPTION
Ignore 404 error. Also remove trailing white spaces from error, including new lines.

Fix #1727. 
Signed-off-by: Dong Chen <dongluo.chen@docker.com>