### PR TITLE
Disallow outdated API versions

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -25,9 +25,11 @@ import (
 	"github.com/samalba/dockerclient"
 )
 
-// APIVERSION is the API version supported by swarm manager
+// MINAPIVERSION is the minimum API version supported by swarm manager
 const MINAPIVERSION = "1.18"
-const APIVERSION = "1.21"
+
+// APIVERSION is the API version supported by swarm manager
+const APIVERSION = "1.22"
 
 // GET /info
 func getInfo(c *context, w http.ResponseWriter, r *http.Request) {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -26,6 +26,7 @@ import (
 )
 
 // APIVERSION is the API version supported by swarm manager
+const MINAPIVERSION = "1.18"
 const APIVERSION = "1.21"
 
 // GET /info

--- a/api/primary.go
+++ b/api/primary.go
@@ -141,7 +141,7 @@ func NewPrimary(cluster cluster.Cluster, tlsConfig *tls.Config, status StatusHan
 
 func versionCheckMiddleware(c *context, w http.ResponseWriter, r *http.Request, handlerFunc handler) {
 	if c.apiVersion != "" && versionpkg.Version(c.apiVersion).LessThan(MINAPIVERSION) {
-		httpError(w, fmt.Sprintf("API Version %s is too old. Supported versions > %s.", c.apiVersion, MINAPIVERSION), http.StatusBadRequest)
+		httpError(w, fmt.Sprintf("API Version %s is too old. Supported versions >= %s.", c.apiVersion, MINAPIVERSION), http.StatusBadRequest)
 		return
 	}
 	// API version passes checks, now call the handler

--- a/api/primary_test.go
+++ b/api/primary_test.go
@@ -59,3 +59,29 @@ func TestCorsRequest(t *testing.T) {
 		t.Fatalf("failed not found")
 	}
 }
+
+func TestOutdatedVersion(t *testing.T) {
+	t.Parallel()
+
+	context := &context{}
+	r := mux.NewRouter()
+	setupPrimaryRouter(r, context, false)
+	w := httptest.NewRecorder()
+
+	req, e := http.NewRequest("GET", "/v1.10/version", nil)
+	if nil != e {
+		t.Fatalf("couldn't set up test request")
+	}
+
+	r.ServeHTTP(w, req)
+
+	t.Logf("%d - %s", w.Code, w.Body.String())
+	t.Log("Expecting no extra Headers")
+	for k, v := range w.Header() {
+		t.Log(k, " : ", v)
+	}
+
+	if w.Code != 400 {
+		t.Fatalf("outdated version accepted")
+	}
+}


### PR DESCRIPTION
Fixes #1733. Disallows outdated API versions using a `MINAPIVERSION` field that tracks the oldest engine version supported (in this case 1.18 corresponding to engine version 1.6.x). Also bumping up APIVERSION to 1.22 for the 1.1.0 release.
