### PR TITLE
Bump API version

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -26,7 +26,7 @@ import (
 )
 
 // APIVERSION is the API version supported by swarm manager
-const APIVERSION = "1.21"
+const APIVERSION = "1.22"
 
 // GET /info
 func getInfo(c *context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Updated `APIVERSION` to 1.22 for 1.10 release.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>