### PR TITLE
Fix integration test - label affinity in parallel

### DIFF
--- a/test/integration/affinities.bats
+++ b/test/integration/affinities.bats
@@ -149,7 +149,7 @@ function teardown() {
 	swarm_manage
 
 	# Run 3 tests in parallel. One of them must fail.
-	run parallel docker -H "${SWARM_HOSTS[0]}" run --label test.label=true -e affinity:test.label!=true -d busybox:latest ::: sh sh sh
+	run parallel docker -H "${SWARM_HOSTS[0]}" run --label test.label=true -e affinity:test.label!=true -d busybox:latest ::: top top top
 	[ "$status" -ne 0 ]
 	[[ "${output}" == *'unable to find a node that satisfies test.label!=true'* ]]
 


### PR DESCRIPTION
Fixes #1709. The issue is that the created containers using `sh` command exit before running `ps -q`, so the number of running containers ends up being 0 and not 2 as required. Not sure why this started happening recently, but changing the command from `sh` to `top` ensures they keep running.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>