### PR TITLE
update travis to go 1.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.2
+  - 1.5.3
 
 # let us have speedy Docker-based Travis workers
 sudo: false


### PR DESCRIPTION
Signed-off-by: Victor Vieux <vieux@docker.com>