### PR TITLE
Fix the swarm manager container creation (using docker-machine ssh)

### DIFF
--- a/docs/install-w-machine.md
+++ b/docs/install-w-machine.md
@@ -106,13 +106,13 @@ Here, you connect to each of the hosts and create a Swarm manager or node.
         manager   *        virtualbox   Running   tcp://192.168.99.100:2376           v1.9.1
 
 
-2. Your client should still be pointing to Docker Engine on `manager`. Use the following syntax to run a Swarm container as the primary Swarm manager on `manager`.
+2. Now we connect directly to the `manager` VM, using the `docker-machine ssh` command, to run a Swarm container as the primary Swarm manager.
 
-        $ docker run -d -p <your_selected_port>:3376 -t -v /var/lib/boot2docker:/certs:ro swarm manage -H 0.0.0.0:3376 --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/server.pem --tlskey=/certs/server-key.pem token://<cluster_id>
+        $ docker-machine ssh manager docker run -d -p <your_selected_port>:3376 -t -v /var/lib/boot2docker:/certs:ro swarm manage -H 0.0.0.0:3376 --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/server.pem --tlskey=/certs/server-key.pem token://<cluster_id>
 
     For example:
 
-        $ docker run -d -p 3376:3376 -t -v /var/lib/boot2docker:/certs:ro swarm manage -H 0.0.0.0:3376 --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/server.pem --tlskey=/certs/server-key.pem swarm manage token://0ac50ef75c9739f5bfeeaf00503d4e6e
+        $ docker-machine ssh manager docker run -d -p 3376:3376 -t -v /var/lib/boot2docker:/certs:ro swarm manage -H 0.0.0.0:3376 --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/server.pem --tlskey=/certs/server-key.pem swarm manage token://0ac50ef75c9739f5bfeeaf00503d4e6e
 
     The `-p` option maps a port 3376 on the container to port 3376 on the host. The `-v` option mounts the directory containing TLS certificates (`/var/lib/boot2docker` for the `manager` VM) into the container running Swarm manager in read-only mode.
 


### PR DESCRIPTION
Modified the step (on the "Evaluate Swarm in a sandbox" page) which tells the user how to set up the Swarm container on the manager. Running the command from the docs as it stands causes the user's machine's `/var/lib/boot2docker` directory to be mounted into the Swarm manager container, instead of the manager VM's `/var/lib/boot2docker` directory.

I'm new to this, so if I've made a mistake, all good - my apologies.