### PR TITLE
Fix typo

### DIFF
--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -106,7 +106,7 @@ To keep things simple, you are going to run a single consul daemon on the same h
 
 To start, copy the following launch command to a text file.
 
-        $ docker run -d -p 8500:8500 —name=consul progrium/consul -server -bootstrap
+        $ docker run -d -p 8500:8500 --name=consul progrium/consul -server -bootstrap
 
 Then, use SSH to connect to the "manager0 & consul0" instance. At the command line, enter `ifconfig`. From the output, copy the `eth0` IP address from `inet addr`.
 


### PR DESCRIPTION
```
vagrant@vagrant-ubuntu-wily-64:~$ docker run -d -p 8500:8500 —name=consul progrium/consul -server -bootstrap
docker: Error parsing reference: "—name=consul" is not a valid repository/tag.
See 'docker run --help'.
vagrant@vagrant-ubuntu-wily-64:~$ 
```