### PR TITLE
Lock engine to prevent read/write conflict on engine `containers` map

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -585,7 +585,10 @@ func (e *Engine) refreshContainer(ID string, full bool) (*Container, error) {
 	}
 
 	_, err = e.updateContainer(containers[0], e.containers, full)
-	return e.containers[containers[0].Id], err
+	e.RLock()
+	container := e.containers[containers[0].Id]
+	e.RUnlock()
+	return container, err
 }
 
 func (e *Engine) updateContainer(c dockerclient.Container, containers map[string]*Container, full bool) (map[string]*Container, error) {


### PR DESCRIPTION
Thank @vieux for the discussion. 
Fix #1805. It's not very sure but we don't have reproduce steps available. 
Signed-off-by: Dong Chen <dongluo.chen@docker.com>