### PR TITLE
Passing HostConfig for /start endpoint

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -740,6 +740,26 @@ func getEvents(c *context, w http.ResponseWriter, r *http.Request) {
 
 // POST /containers/{name:.*}/start
 func postContainersStart(c *context, w http.ResponseWriter, r *http.Request) {
+	hostConfig := &dockerclient.HostConfig{
+		MemorySwappiness: -1,
+	}
+
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	r.Body.Close()
+
+	if len(buf) == 0 {
+		hostConfig = nil
+	} else {
+		if err := json.Unmarshal(buf, hostConfig); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	name := mux.Vars(r)["name"]
 	container := c.cluster.Container(name)
 	if container == nil {
@@ -747,7 +767,7 @@ func postContainersStart(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := c.cluster.StartContainer(container); err != nil {
+	if err := c.cluster.StartContainer(container, hostConfig); err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -27,7 +27,7 @@ type Cluster interface {
 	Containers() Containers
 
 	// Start a container
-	StartContainer(container *Container) error
+	StartContainer(container *Container, hostConfig *dockerclient.HostConfig) error
 
 	// Return container the matching `IDOrName`
 	// TODO: remove this method from the interface as we can use

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1038,8 +1038,8 @@ func (e *Engine) cleanupContainers() {
 }
 
 // StartContainer starts a container
-func (e *Engine) StartContainer(id string) error {
-	err := e.client.StartContainer(id, nil)
+func (e *Engine) StartContainer(id string, hostConfig *dockerclient.HostConfig) error {
+	err := e.client.StartContainer(id, hostConfig)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -179,10 +179,10 @@ func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 }
 
 // StartContainer starts a container
-func (c *Cluster) StartContainer(container *cluster.Container) error {
+func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *dockerclient.HostConfig) error {
 	// if the container was started less than a second ago in detach mode, do not start it
 	if time.Now().Unix()-container.Created > 1 || container.Config.Labels[cluster.SwarmLabelNamespace+".mesos.detach"] != "true" {
-		return container.Engine.StartContainer(container.Id)
+		return container.Engine.StartContainer(container.Id, hostConfig)
 	}
 	return nil
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -125,8 +125,8 @@ func (c *Cluster) generateUniqueID() string {
 }
 
 // StartContainer starts a container
-func (c *Cluster) StartContainer(container *cluster.Container) error {
-	return container.Engine.StartContainer(container.Id)
+func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *dockerclient.HostConfig) error {
+	return container.Engine.StartContainer(container.Id, hostConfig)
 }
 
 // CreateContainer aka schedule a brand new container into the cluster.

--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -83,7 +83,7 @@ func (w *Watchdog) rescheduleContainers(e *Engine) {
 			log.Infof("Rescheduled container %s from %s to %s as %s", c.Id, c.Engine.Name, newContainer.Engine.Name, newContainer.Id)
 			if c.Info.State.Running {
 				log.Infof("Container %s was running, starting container %s", c.Id, newContainer.Id)
-				if err := w.cluster.StartContainer(newContainer); err != nil {
+				if err := w.cluster.StartContainer(newContainer, nil); err != nil {
 					log.Errorf("Failed to start rescheduled container %s", newContainer.Id)
 				}
 			}

--- a/test/integration/api/start.bats
+++ b/test/integration/api/start.bats
@@ -25,3 +25,26 @@ function teardown() {
 	# Verify
 	[ -n $(docker_swarm ps -q --filter=name=test_container --filter=status=running) ]
 }
+
+@test "docker start with hostConfig" {
+	start_docker_with_busybox 2
+	swarm_manage
+	# create
+	docker_swarm create --name test_container busybox sleep 1000
+
+	# make sure created container exists
+	# new created container has no status
+	run docker_swarm ps -l
+	[ "${#lines[@]}" -eq 2 ]
+	[[ "${lines[1]}" ==  *"test_container"* ]]
+
+	# start
+	curl -s -H "Content-Type: application/json" -X POST -d '{"PublishAllPorts": true}' ${SWARM_HOSTS[0]}/v1.23/containers/test_container/start
+	
+	# Verify
+	[ -n $(docker_swarm ps -q --filter=name=test_container --filter=status=running) ]
+	
+	# Inspect HostConfig of container, should have PublishAllPorts set to true
+	run docker_swarm inspect test_container
+	[[ "${output}" == *'"PublishAllPorts": true'* ]]
+}


### PR DESCRIPTION
Fixes #1781. `HostConfig` is being deprecated for the `/start` endpoint, but we must support it until Engine does.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>