### PR TITLE
tests: increase zookeeper discovery retry count in CI

### DIFF
--- a/test/integration/discovery/zk.bats
+++ b/test/integration/discovery/zk.bats
@@ -36,11 +36,11 @@ function teardown() {
 	# Start 2 engines and make them join the cluster.
 	start_docker 2
 	swarm_join "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 20 1 discovery_check_swarm_list "$DISCOVERY"
 
 	# Then, start a manager and ensure it sees all the engines.
 	swarm_manage "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_info
+	retry 20 1 discovery_check_swarm_info
 }
 
 @test "zk discovery: watch for changes" {
@@ -50,13 +50,13 @@ function teardown() {
 
 	# Start a manager with no engines.
 	swarm_manage "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_info
+	retry 20 1 discovery_check_swarm_info
 
 	# Add engines to the cluster and make sure it's picked up by swarm.
 	start_docker 2
 	swarm_join "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_list "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_info
+	retry 20 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 20 1 discovery_check_swarm_info
 }
 
 @test "zk discovery: node removal" {
@@ -68,24 +68,24 @@ function teardown() {
 
 	# Start 2 engines and make them join the cluster.
 	swarm_manage "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_info
+	retry 20 1 discovery_check_swarm_info
 
 	# Add Engines to the cluster and make sure it's picked by swarm
 	start_docker 2
 	swarm_join "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_list "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_info
+	retry 20 1 discovery_check_swarm_list "$DISCOVERY"
+	retry 20 1 discovery_check_swarm_info
 
 	# Removes all the swarm agents
 	swarm_join_cleanup
 
 	# Check if previously registered engines are all gone
-	retry 20 1 discovery_check_swarm_info 0
+	retry 30 1 discovery_check_swarm_info 0
 
 	# Check that we can add instances back to the cluster
 	start_docker 2
 	swarm_join "$DISCOVERY"
-	retry 10 1 discovery_check_swarm_info 2
+	retry 30 1 discovery_check_swarm_info 2
 }
 
 @test "zk discovery: failure" {


### PR DESCRIPTION
Zookeeper tests seems a bit flaky since we added more travis instances or since the changes in node management. Because we have a variable timer now to connect to the Agents.

This increases the retry count to match the ones of other tests to give a bit more window to discover the nodes. Let's try with `20` for now.

Signed-off-by: Alexandre Beslic <alexandre.beslic@gmail.com>