### PR TITLE
Remove tutorials from Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,7 +7,6 @@ RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/mach
 RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content/registry
 RUN svn checkout https://github.com/docker/toolbox/trunk/docs /docs/content/toolbox
 RUN svn checkout https://github.com/docker/kitematic/trunk/docs /docs/content/kitematic
-RUN svn checkout https://github.com/docker/tutorials/trunk/docs /docs/content/tutorials
 RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content/opensource
 
 ENV PROJECT=swarm


### PR DESCRIPTION
The "docker/tutorials" repository is now private, causing building the docs to fail.

Note that this change is also included in https://github.com/docker/swarm/pull/1817, but having a separate PR for just this change is probably faster to accept/merge