### PR TITLE
Fix #1873 force to validate engine's label format

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -423,6 +423,10 @@ func (e *Engine) updateSpecs() error {
 	}
 	for _, label := range info.Labels {
 		kv := strings.SplitN(label, "=", 2)
+		if len(kv) != 2 {
+			message := fmt.Sprintf("Engine (ID: %s, Addr: %s) contains an invalid label (%s) not formatted as \"key=value\".", e.ID, e.Addr, label)
+			return fmt.Errorf(message)
+		}
 		e.Labels[kv[0]] = kv[1]
 	}
 	return nil


### PR DESCRIPTION
Fix #1873 

force to validate whether engine's label is like format "key=value"

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>