### PR TITLE
Return a 404 error when an image is not available / not accessible on run

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -9,7 +9,7 @@ import (
 // Cluster is exported
 type Cluster interface {
 	// Create a container
-	CreateContainer(config *ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*Container, error)
+	CreateContainer(config *ContainerConfig, name string) (*Container, error)
 
 	// Remove a container
 	RemoveContainer(container *Container, force, volumes bool) error

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -740,7 +740,7 @@ func (e *Engine) TotalCpus() int64 {
 }
 
 // Create a new container
-func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, authConfig *dockerclient.AuthConfig) (*Container, error) {
+func (e *Engine) Create(config *ContainerConfig, name string) (*Container, error) {
 	var (
 		err    error
 		id     string
@@ -761,20 +761,7 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, au
 	id, err = client.CreateContainer(&dockerConfig, name, nil)
 	e.CheckConnectionErr(err)
 	if err != nil {
-		// If the error is other than not found, abort immediately.
-		if err != dockerclient.ErrImageNotFound || !pullImage {
-			return nil, err
-		}
-		// Otherwise, try to pull the image...
-		if err = e.Pull(config.Image, authConfig); err != nil {
-			return nil, err
-		}
-		// ...And try again.
-		id, err = client.CreateContainer(&dockerConfig, name, nil)
-		e.CheckConnectionErr(err)
-		if err != nil {
-			return nil, err
-		}
+	  return nil, err
 	}
 
 	// Register the container immediately while waiting for a state refresh.

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -188,7 +188,7 @@ func (c *Cluster) StartContainer(container *cluster.Container) error {
 }
 
 // CreateContainer for container creation in Mesos task
-func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*cluster.Container, error) {
+func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string) (*cluster.Container, error) {
 	if config.Memory == 0 && config.CpuShares == 0 {
 		return nil, errResourcesNeeded
 	}

--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -73,7 +73,7 @@ func (w *Watchdog) rescheduleContainers(e *Engine) {
 		// will abort because the name is already taken.
 		c.Engine.removeContainer(c)
 
-		newContainer, err := w.cluster.CreateContainer(c.Config, c.Info.Name, nil)
+		newContainer, err := w.cluster.CreateContainer(c.Config, c.Info.Name)
 
 		if err != nil {
 			log.Errorf("Failed to reschedule container %s: %v", c.Id, err)

--- a/docs/swarm-api.md
+++ b/docs/swarm-api.md
@@ -46,49 +46,6 @@ POST "/images/create" : "docker import" flow not implement
 
 * `POST "/containers/create"`: `CpuShares` in `HostConfig` sets the number of CPU cores allocated to the container.
 
-# Registry Authentication
-
-During container create calls, the swarm API will optionally accept a X-Registry-Config header.
-If provided, this header will be passed down to the engine if the image must be pulled
-to complete the create operation.
-
-The following two examples demonstrate how to utilize this using the existing docker CLI
-
-* CLI usage example using username/password:
-
-    ```bash
-# Calculate the header
-REPO_USER=yourusername
-read -s PASSWORD
-HEADER=$(echo "{\"username\":\"${REPO_USER}\",\"password\":\"${PASSWORD}\"}"|base64 -w 0 )
-unset PASSWORD
-echo HEADER=$HEADER
-
-# Then add the following to your ~/.docker/config.json
-"HttpHeaders": {
-    "X-Registry-Auth": "<HEADER string from above>"
-}
-
-# Now run a private image against swarm:
-docker run --rm -it yourprivateimage:latest
-```
-
-* CLI usage example using registry tokens: (Requires engine 1.10 with new auth token support)
-
-    ```bash
-REPO=yourrepo/yourimage
-REPO_USER=yourusername
-read -s PASSWORD
-AUTH_URL=https://auth.docker.io/token
-TOKEN=$(curl -s -u "${REPO_USER}:${PASSWORD}" "${AUTH_URL}?scope=repository:${REPO}:pull&service=registry.docker.io" |
-    jq -r ".token")
-HEADER=$(echo "{\"registrytoken\":\"${TOKEN}\"}"|base64 -w 0 )
-echo HEADER=$HEADER
-
-# Update the docker config as above, but the token will expire quickly...
-```
-
-
 ## Docker Swarm documentation index
 
 - [Docker Swarm overview](https://docs.docker.com/swarm/)


### PR DESCRIPTION
On a run return the same 404 error as the docker engine would when an image is not available / not accessible.
The client can then automatically try to pull the image (including the auth header if defined).
