### PR TITLE
Add method HEAD in options response headers

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -98,7 +98,7 @@ var routes = map[string]map[string]handler{
 func writeCorsHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Access-Control-Allow-Origin", "*")
 	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
-	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
+	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS, HEAD")
 }
 
 func profilerSetup(mainRouter *mux.Router, path string) {


### PR DESCRIPTION
In swarm apis, there is a request with method HEAD:
/containers/{name:.*}/archive
So, it is necessary to add method HEAD in options response headers.

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>