### PR TITLE
Add missing 'defer'

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -231,7 +231,7 @@ func (e *Engine) isConnected() bool {
 // IsHealthy returns true if the engine is healthy
 func (e *Engine) IsHealthy() bool {
 	e.RLock()
-	e.RUnlock()
+	defer e.RUnlock()
 	return e.state == stateHealthy
 }
 


### PR DESCRIPTION
as it stands now the lock at this spot in the code is pretty useless.
All it does it block us but since we release the lock before we check
e.state its a roadblock with no real purpose.
One could argue that a lock isn't needed at all but I think having it
there for consistency with the other funcs would be good.

Signed-off-by: Doug Davis <dug@us.ibm.com>