### PR TITLE
Remove internal retry in discovery_check_swarm_info 

### DIFF
--- a/test/integration/discovery/zk.bats
+++ b/test/integration/discovery/zk.bats
@@ -85,6 +85,8 @@ function teardown() {
 	# Check that we can add instances back to the cluster
 	start_docker 2
 	swarm_join "$DISCOVERY"
+	run docker_swarm info
+	echo $output
 	retry 10 1 discovery_check_swarm_info 2
 }
 
@@ -106,5 +108,7 @@ function teardown() {
 
 	# After a while, `join` and `manage` should reach the store.
 	retry 20 1 discovery_check_swarm_list "$DISCOVERY"
+	run docker_swarm info
+	echo $output
 	retry 20 1 discovery_check_swarm_info
 }

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -92,7 +92,7 @@ function discovery_check_swarm_info() {
 	local host="$2"
 	[ -z "$host" ] && host="${SWARM_HOSTS[0]}"
 
-	retry 10 1 eval "docker -H $host info | grep -q -e \"Nodes: $total\" -e \"Offers: $total\""
+	eval "docker -H $host info | grep -q -e \"Nodes: $total\" -e \"Offers: $total\""
 }
 
 # Return true if all nodes has been validated
@@ -107,7 +107,7 @@ function swarm_manage() {
 	swarm_manage_no_wait "$@"
 
 	# Wait for nodes to be discovered
-	discovery_check_swarm_info "${#HOSTS[@]}" "${SWARM_HOSTS[$i]}"
+	retry 10 1 discovery_check_swarm_info "${#HOSTS[@]}" "${SWARM_HOSTS[$i]}"
 
 	# All nodes passes pending state
 	retry 15 1 nodes_validated


### PR DESCRIPTION
Caller retries are already in place, for example
```
./test/integration/discovery/consul.bats:43:	retry 5 1 discovery_check_swarm_info
./test/integration/discovery/consul.bats:53:	retry 10 1 discovery_check_swarm_info
```
Add outputs to frequently failing `zk` tests.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>