### PR TITLE
Changing swarm to Swarm in body text

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -11,7 +11,7 @@ weight=4
 
 # Docker Swarm Discovery
 
-Docker Swarm comes with multiple discovery backends. You use a hosted discovery service with Docker Swarm. The service maintains a list of IPs in your swarm.
+Docker Swarm comes with multiple discovery backends. You use a hosted discovery service with Docker Swarm. The service maintains a list of IPs in your cluster.
 This page describes the different types of hosted discovery available to you. These are:
 
 
@@ -29,7 +29,7 @@ For details about libkv and a detailed technical overview of the supported backe
 
 1. On each node, start the Swarm agent.
 
-    The node IP address doesn't have to be public as long as the swarm manager can access it. In a large cluster, the nodes joining swarm may trigger request spikes to discovery. For example, a large number of nodes are added by a script, or recovered from a network partition. This may result in discovery failure. You can use `--delay` option to specify a delay limit. Swarm join will add a random delay less than this limit to reduce pressure to discovery.
+    The node IP address doesn't have to be public as long as the Swarm manager can access it. In a large cluster, the nodes joining swarm may trigger request spikes to discovery. For example, a large number of nodes are added by a script, or recovered from a network partition. This may result in discovery failure. You can use `--delay` option to specify a delay limit. Swarm join will add a random delay less than this limit to reduce pressure to discovery.
 
     **Etcd**:
 
@@ -173,7 +173,7 @@ Or with node discovery:
 
 This example uses the hosted discovery service on Docker Hub. Using
 Docker Hub's hosted discovery service requires that each node in the
-swarm is connected to the public internet. To create your swarm:
+swarm is connected to the public internet. To create your cluster:
 
 1. Create a cluster.
 
@@ -182,7 +182,7 @@ swarm is connected to the public internet. To create your swarm:
 
 2. Create each node and join them to the cluster.
 
-    On each of your nodes, start the swarm agent. The <node_ip> doesn't have to be public (eg. 192.168.0.X) but the the swarm manager must be able to access it.
+    On each of your nodes, start the swarm agent. The <node_ip> doesn't have to be public (eg. 192.168.0.X) but the the Swarm manager must be able to access it.
 
         $ swarm join --advertise=<node_ip:2375> token://<cluster_id>
 
@@ -192,7 +192,7 @@ swarm is connected to the public internet. To create your swarm:
 
         $ swarm manage -H tcp://<swarm_ip:swarm_port> token://<cluster_id>
 
-4. Use regular Docker commands to interact with your swarm.
+4. Use regular Docker commands to interact with your cluster.
 
         docker -H tcp://<swarm_ip:swarm_port> info
         docker -H tcp://<swarm_ip:swarm_port> run ...

--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -209,7 +209,7 @@ After creating the discovery backend, you can create the Swarm managers. In this
 
 2. Enter `docker ps`.
 
-    From the output, verify that both a swarm and a consul container are running.
+    From the output, verify that both a Swarm cluster and a consul container are running.
     Then, disconnect from the `manager0` and `consul0` instance.
 
 3. Connect to the `manager1` node and use `ifconfig` to get its IP address.
@@ -228,7 +228,7 @@ After creating the discovery backend, you can create the Swarm managers. In this
 
     a. Get the node IP addresses with the `ifconfig` command.
 
-    b. Start a swarm container each using the following syntax:
+    b. Start a Swarm container each using the following syntax:
 
         docker run -d swarm join --advertise=<node_ip>:2375 consul://<consul_ip>:8500
 
@@ -269,7 +269,7 @@ replica.
 
 1. SSH connection to the `manager0` instance.
 
-2. Get the container id or name of the swarm container:
+2. Get the container id or name of the `swarm` container:
 
         $ docker ps
 

--- a/docs/multi-manager-setup.md
+++ b/docs/multi-manager-setup.md
@@ -11,7 +11,7 @@ weight=3
 
 # High availability in Docker Swarm
 
-In Docker Swarm, the **swarm manager** is responsible for the entire cluster and manages the resources of multiple *Docker hosts* at scale. If the swarm manager dies, you must create a new one and deal with an interruption of service.
+In Docker Swarm, the **Swarm manager** is responsible for the entire cluster and manages the resources of multiple *Docker hosts* at scale. If the Swarm manager dies, you must create a new one and deal with an interruption of service.
 
 The *High Availability* feature allows a Docker Swarm to gracefully handle the failover of a manager instance. Using this feature, you can create a single **primary manager** instance and multiple **replica** instances.
 
@@ -23,7 +23,7 @@ This section explains how to set up Docker Swarm using multiple **managers**.
 
 ### Assumptions
 
-You need either a `Consul`, `etcd`, or `Zookeeper` cluster. This procedure is written assuming a `Consul` server running on address `192.168.42.10:8500`. All hosts will have a Docker Engine configured to listen on port 2375.  We will be configuring the Managers to operate on port 4000. The sample swarm configuration has three machines:
+You need either a `Consul`, `etcd`, or `Zookeeper` cluster. This procedure is written assuming a `Consul` server running on address `192.168.42.10:8500`. All hosts will have a Docker Engine configured to listen on port 2375.  We will be configuring the Managers to operate on port 4000. The sample Swarm configuration has three machines:
 
 - `manager-1` on `192.168.42.200`
 - `manager-2` on `192.168.42.201`
@@ -40,7 +40,7 @@ You use the `swarm manage` command with the `--replication` and `--advertise` fl
       [...]
 
 
-The  `--replication` flag tells swarm that the manager is part of a a multi-manager configuration and that this primary manager competes with other manager instances for the primary role. The primary manager has the authority to manage cluster, replicate logs, and replicate events happening inside the cluster.
+The  `--replication` flag tells Swarm that the manager is part of a a multi-manager configuration and that this primary manager competes with other manager instances for the primary role. The primary manager has the authority to manage cluster, replicate logs, and replicate events happening inside the cluster.
 
 The `--advertise` option specifies the primary manager address. Swarm uses this address to advertise to the cluster when the node is elected as the primary. As you see in the command's output, the address you provided now appears to be the one of the elected Primary manager.
 
@@ -65,7 +65,7 @@ Create an additional, third *manager* instance:
     INFO[0000] New leader elected: 192.168.42.200:4000
     [...]
 
-Once you have established your primary manager and the replicas, create **swarm agents** as you normally would.
+Once you have established your primary manager and the replicas, create **Swarm agents** as you normally would.
 
 
 ### List machines in the cluster

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -42,7 +42,7 @@ ready to create a network.
 ## List networks
 
 This example assumes there are two nodes `node-0` and `node-1` in the cluster.
-From a swarm node, list the networks:
+From a Swarm node, list the networks:
 
 ```bash
 $ docker network ls
@@ -60,7 +60,7 @@ As you can see, each network name is prefixed by the node name.
 ## Create a network
 
 By default, Swarm is using the `overlay` network driver, a global-scope network
-driver. A global-scope network driver creates a network across an entire swarm.
+driver. A global-scope network driver creates a network across an entire Swarm cluster.
 When you create an `overlay` network under Swarm, you can omit the `-d` option:
 
 ```bash
@@ -80,7 +80,7 @@ NETWORK ID          NAME                   DRIVER
 
 As you can see here, both the `node-0/swarm_network` and the
 `node-1/swarm_network` have the same ID.  This is because when you create a
-network on the swarm, it is accessible from all the nodes.
+network on the cluster, it is accessible from all the nodes.
 
 To create a local scope network (for example with the `bridge` network driver) you
 should use `<node>/<name>` otherwise your network is created on a random node.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,17 +29,23 @@ principle. As initial development settles, an API will develop to enable
 pluggable backends.  This means you can swap out the scheduling backend
 Docker Swarm uses out-of-the-box with a backend you prefer. Swarm's swappable design provides a smooth out-of-box experience for most use cases, and allows large-scale production deployments to swap for more powerful backends, like Mesos.
 
-## Understand swarm creation
+## Understand Swarm cluster creation
 
-The first step to creating a swarm on your network is to pull the Docker Swarm image. Then, using Docker, you configure the swarm manager and all the nodes to run Docker Swarm. This method requires that you:
+The first step to creating a Swarm cluster on your network is to pull the Docker Swarm image. Then, using Docker, you configure the Swarm manager and all the nodes to run Docker Swarm. This method requires that you:
 
-* open a TCP port on each node for communication with the swarm manager
+* open a TCP port on each node for communication with the Swarm manager
 * install Docker on each node
-* create and manage TLS certificates to secure your swarm
+* create and manage TLS certificates to secure your cluster
 
-As a starting point, the manual method is best suited for experienced administrators or programmers contributing to Docker Swarm. The alternative is to use `docker-machine` to install a swarm.
+As a starting point, the manual method is best suited for experienced
+administrators or programmers contributing to Docker Swarm. The alternative is
+to use `docker-machine` to install a cluster.
 
-Using Docker Machine, you can quickly install a Docker Swarm on cloud providers or inside your own data center. If you have VirtualBox installed on your local machine, you can quickly build and explore Docker Swarm in your local environment. This method automatically generates a certificate to secure your swarm.
+Using Docker Machine, you can quickly install a Docker Swarm on cloud providers
+or inside your own data center. If you have VirtualBox installed on your local
+machine, you can quickly build and explore Docker Swarm in your local
+environment. This method automatically generates a certificate to secure your
+cluster.
 
 Using Docker Machine is the best method for users getting started with Swarm for the first time. To try the recommended method of getting started, see [Get Started with Docker Swarm](install-w-machine.md).
 

--- a/docs/reference/join.md
+++ b/docs/reference/join.md
@@ -36,7 +36,7 @@ The `join` command has only one argument:
 
 Before you create a Swarm node, [create a discovery token](create.md) or [set up a discovery backend](../discovery.md) for your cluster.
 
-When you create the swarm node, use the `<discovery>` argument to specify one of the following discovery backends:
+When you create the Swarm node, use the `<discovery>` argument to specify one of the following discovery backends:
 
 * `token://<token>`
 * `consul://<ip1>/<path>`

--- a/docs/reference/manage.md
+++ b/docs/reference/manage.md
@@ -118,7 +118,7 @@ Use `--replication-ttl "<delay>s"` to specify the delay, in seconds, before noti
 
 ### `--advertise`, `--addr` — Advertise Docker Engine's IP and port number
 
-Use `--advertise <ip>:<port>` or `--addr <ip>:<port>` to advertise the IP address and port number of the Docker Engine. For example, `--advertise 172.30.0.161:4000`. Other swarm managers MUST be able to reach this swarm manager at this address.
+Use `--advertise <ip>:<port>` or `--addr <ip>:<port>` to advertise the IP address and port number of the Docker Engine. For example, `--advertise 172.30.0.161:4000`. Other Swarm managers MUST be able to reach this Swarm manager at this address.
 
 The environment variable for `--advertise` is `$SWARM_ADVERTISE`.
 

--- a/docs/scheduler/strategy.md
+++ b/docs/scheduler/strategy.md
@@ -28,7 +28,7 @@ available CPU, its RAM, and the number of containers it has. The `random`
 strategy uses no computation. It selects a node at random and is primarily
 intended for debugging.
 
-Your goal in choosing a strategy is to best optimize your swarm according to
+Your goal in choosing a strategy is to best optimize your cluster according to
 your company's needs.
 
 Under the `spread` strategy, Swarm optimizes for the node with the least number
@@ -55,13 +55,13 @@ If you do not specify a `--strategy` Swarm uses `spread` by default.
 
 ## Spread strategy example
 
-In this example, your swarm is using the `spread` strategy which optimizes for
-nodes that have the fewest containers. In this swarm, both `node-1` and `node-2`
+In this example, your cluster is using the `spread` strategy which optimizes for
+nodes that have the fewest containers. In this cluster, both `node-1` and `node-2`
 have 2G of RAM, 2 CPUs, and neither node is running a container. Under this strategy
 `node-1` and `node-2` have the same ranking.
 
-When you run a new container, the system chooses `node-1` at random from the swarm
-of two equally ranked nodes:
+When you run a new container, the system chooses `node-1` at random from the
+Swarm cluster of two equally ranked nodes:
 
       $ docker tcp://<manager_ip:manager_port> run -d -P -m 1G --name db mysql
       f8b693db9cd6
@@ -90,7 +90,7 @@ CPUs, the `spread` strategy prefers the node with least containers.
 
 In this example, let's says that both `node-1` and `node-2` have 2G of RAM and
 neither is running a container. Again, the nodes are equal. When you run a new
-container, the system chooses `node-1` at random from the swarm:
+container, the system chooses `node-1` at random from the cluster:
 
 
     $ docker tcp://<manager_ip:manager_port> run -d -P -m 1G --name db mysql

--- a/docs/swarm-api.md
+++ b/docs/swarm-api.md
@@ -100,7 +100,7 @@ POST "/images/create" : "docker import" flow not implement
 
 ## Registry Authentication
 
-During container create calls, the swarm API will optionally accept an `X-Registry-Auth` header.
+During container create calls, the Swarm API will optionally accept an `X-Registry-Auth` header.
 If provided, this header is passed down to the engine if the image must be pulled
 to complete the create operation.
 


### PR DESCRIPTION
Change `swarm` to `Swarm` in body text where it was used to refer to cluster or nodes in the cluster.

Signed-off-by: Mary Anthony <mary@docker.com>