### PR TITLE
fix two swarm apis' response status code

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -587,6 +587,7 @@ func postNetworksCreate(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(response)
 }
 
@@ -606,6 +607,7 @@ func postVolumesCreate(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(volume)
 }
 


### PR DESCRIPTION
Fix two swarm apis' response status code.
Make them compatible with Docker Remote API.
fix #1929 
Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>