### PR TITLE
Updating info function to use engine-api

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -47,7 +47,7 @@ func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 		ServerVersion:     "swarm/" + version.VERSION,
 		OperatingSystem:   runtime.GOOS,
 		Architecture:      runtime.GOARCH,
-		NCPU:              int(c.cluster.TotalCpus()),
+		NCPU:              c.cluster.TotalCpus(),
 		MemTotal:          c.cluster.TotalMemory(),
 		HTTPProxy:         os.Getenv("http_proxy"),
 		HTTPSProxy:        os.Getenv("https_proxy"),

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -78,7 +78,7 @@ type Cluster interface {
 	TotalMemory() int64
 
 	// Return the number of CPUs in the cluster
-	TotalCpus() int64
+	TotalCpus() int
 
 	// Register an event handler for cluster-wide events.
 	RegisterEventHandler(h EventHandler) error

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -100,7 +100,7 @@ type Engine struct {
 	IP     string
 	Addr   string
 	Name   string
-	Cpus   int64
+	Cpus   int
 	Memory int64
 	Labels map[string]string
 
@@ -408,7 +408,7 @@ func (e *Engine) CheckConnectionErr(err error) {
 
 // Gather engine specs (CPU, memory, constraints, ...).
 func (e *Engine) updateSpecs() error {
-	info, err := e.client.Info()
+	info, err := e.apiClient.Info()
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -665,7 +665,7 @@ func (e *Engine) updateContainer(c dockerclient.Container, containers map[string
 		container.Config = BuildContainerConfig(*info.Config)
 
 		// FIXME remove "duplicate" lines and move this to cluster/config.go
-		container.Config.CpuShares = container.Config.CpuShares * e.Cpus / 1024.0
+		container.Config.CpuShares = container.Config.CpuShares * int64(e.Cpus) / 1024.0
 		container.Config.HostConfig.CpuShares = container.Config.CpuShares
 
 		// Save the entire inspect back into the container.
@@ -774,8 +774,8 @@ func (e *Engine) TotalMemory() int64 {
 }
 
 // TotalCpus returns the total cpus + overcommit
-func (e *Engine) TotalCpus() int64 {
-	return e.Cpus + (e.Cpus * e.overcommitRatio / 100)
+func (e *Engine) TotalCpus() int {
+	return e.Cpus + (e.Cpus * int(e.overcommitRatio) / 100)
 }
 
 // Create a new container

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -446,12 +446,12 @@ func (c *Cluster) TotalMemory() int64 {
 }
 
 // TotalCpus return the total memory of the cluster
-func (c *Cluster) TotalCpus() int64 {
+func (c *Cluster) TotalCpus() int {
 	c.RLock()
 	defer c.RUnlock()
-	var totalCpus int64
+	var totalCpus int
 	for _, s := range c.agents {
-		totalCpus += int64(sumScalarResourceValue(s.offers, "cpus"))
+		totalCpus += int(sumScalarResourceValue(s.offers, "cpus"))
 	}
 	return totalCpus
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -824,8 +824,8 @@ func (c *Cluster) TotalMemory() int64 {
 }
 
 // TotalCpus return the total memory of the cluster
-func (c *Cluster) TotalCpus() int64 {
-	var totalCpus int64
+func (c *Cluster) TotalCpus() int {
+	var totalCpus int
 	for _, engine := range c.engines {
 		totalCpus += engine.TotalCpus()
 	}

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -26,7 +26,7 @@ func (nopCloser) Close() error {
 }
 
 var (
-	mockInfo = &dockerclient.Info{
+	mockInfo = types.Info{
 		ID:              "test-engine",
 		Name:            "name",
 		NCPU:            10,
@@ -135,14 +135,13 @@ func TestImportImage(t *testing.T) {
 	// create mock client
 	client := mockclient.NewMockClient()
 	apiClient := engineapimock.NewMockClient()
-	client.On("Info").Return(mockInfo, nil)
+	apiClient.On("Info").Return(mockInfo, nil)
+	apiClient.On("ServerVersion").Return(mockVersion, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
-
-	apiClient.On("ServerVersion").Return(mockVersion, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -187,14 +186,13 @@ func TestLoadImage(t *testing.T) {
 	// create mock client
 	client := mockclient.NewMockClient()
 	apiClient := engineapimock.NewMockClient()
-	client.On("Info").Return(mockInfo, nil)
+	apiClient.On("Info").Return(mockInfo, nil)
+	apiClient.On("ServerVersion").Return(mockVersion, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
-
-	apiClient.On("ServerVersion").Return(mockVersion, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -242,14 +240,13 @@ func TestTagImage(t *testing.T) {
 	// create mock client
 	client := mockclient.NewMockClient()
 	apiClient := engineapimock.NewMockClient()
-	client.On("Info").Return(mockInfo, nil)
+	apiClient.On("Info").Return(mockInfo, nil)
+	apiClient.On("ServerVersion").Return(mockVersion, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return(images, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
-
-	apiClient.On("ServerVersion").Return(mockVersion, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)

--- a/scheduler/node/node.go
+++ b/scheduler/node/node.go
@@ -37,7 +37,7 @@ func NewNode(e *cluster.Engine) *Node {
 		UsedMemory:      e.UsedMemory(),
 		UsedCpus:        e.UsedCpus(),
 		TotalMemory:     e.TotalMemory(),
-		TotalCpus:       e.TotalCpus(),
+		TotalCpus:       int64(e.TotalCpus()),
 		HealthIndicator: e.HealthIndicator(),
 	}
 }


### PR DESCRIPTION
This PR moves over the `Info()` function call over to use `engine-api`, along with corresponding tests. Some mismatch between `int` and `int64` values needed to be adjusted.

This is part of #1879.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>