### PR TITLE
Deleting redundant code from volume.go

### DIFF
--- a/cluster/volume.go
+++ b/cluster/volume.go
@@ -48,9 +48,5 @@ func (volumes Volumes) Get(name string) *Volume {
 		}
 	}
 
-	if len(candidates) == 1 {
-		return candidates[0]
-	}
-
 	return nil
 }


### PR DESCRIPTION
Some code in `volume.go` is not needed, and was likely left behind.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>