### PR TITLE
Enable Swarm can use the revocable resources on Mesos.

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -51,7 +51,8 @@ Options:
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}
                                     {{printf "\t * mesos.offerrefusetimeout=5s\tseconds to consider unused resources refused [$SWARM_MESOS_OFFER_REFUSE_TIMEOUT]"}}
                                     {{printf "\t * mesos.tasktimeout=5s\ttimeout for task creation [$SWARM_MESOS_TASK_TIMEOUT]"}}
-                                    {{printf "\t * mesos.user=\tframework user [$SWARM_MESOS_USER]"}}{{end}}{{ end }}
+                                    {{printf "\t * mesos.user=\tframework user [$SWARM_MESOS_USER]"}}
+                                    {{printf "\t * mesos.enablerevocable=false\tenable to use Mesos revocable resources [$SWARM_MESOS_ENABLE_REVOCABLE]"}}{{end}}{{ end }}
 `
 
 }

--- a/cluster/mesos/agent_test.go
+++ b/cluster/mesos/agent_test.go
@@ -22,7 +22,12 @@ func TestNewAgent(t *testing.T) {
 }
 
 func TestAddOffer(t *testing.T) {
-	s := newAgent("SID", nil)
+	engOps := &cluster.EngineOpts{
+		RefreshMinInterval: 0,
+		RefreshMaxInterval: 0,
+	}
+	engine := cluster.NewEngine("", 0, engOps)
+	s := newAgent("SID", engine)
 
 	assert.Empty(t, s.offers)
 	assert.True(t, s.empty())
@@ -61,7 +66,12 @@ func TestAddTask(t *testing.T) {
 }
 
 func TestRemoveOffer(t *testing.T) {
-	s := newAgent("SID", nil)
+	engOps := &cluster.EngineOpts{
+		RefreshMinInterval: 0,
+		RefreshMaxInterval: 0,
+	}
+	engine := cluster.NewEngine("", 0, engOps)
+	s := newAgent("SID", engine)
 
 	assert.Empty(t, s.offers)
 

--- a/cluster/mesos/task/task.go
+++ b/cluster/mesos/task/task.go
@@ -60,7 +60,7 @@ func (t *Task) Stop() {
 }
 
 // Build method builds the task
-func (t *Task) Build(slaveID string, offers map[string]*mesosproto.Offer) {
+func (t *Task) Build(slaveID string, offers map[string]*mesosproto.Offer, useRevocableResources bool) {
 	t.Command = &mesosproto.CommandInfo{Shell: proto.Bool(false)}
 
 	t.Container = &mesosproto.ContainerInfo{
@@ -141,6 +141,18 @@ func (t *Task) Build(slaveID string, offers map[string]*mesosproto.Offer) {
 
 	if mem := t.config.HostConfig.Memory; mem > 0 {
 		t.Resources = append(t.Resources, mesosutil.NewScalarResource("mem", float64(mem/1024/1024)))
+	}
+
+	// Add a label to the container to mark the actual type of resources it uses.
+	if useRevocableResources {
+		for i := range t.Resources {
+			mesosDefaultRole := "*"
+			t.Resources[i].Role = &mesosDefaultRole
+			t.Resources[i].Revocable = &mesosproto.Resource_RevocableInfo{}
+		}
+		t.config.Labels[cluster.SwarmLabelNamespace+".mesos.resourceType"] = "Revocable"
+	} else {
+		t.config.Labels[cluster.SwarmLabelNamespace+".mesos.resourceType"] = "Regular"
 	}
 
 	if len(t.config.Cmd) > 0 && t.config.Cmd[0] != "" {

--- a/cluster/mesos/task/task_test.go
+++ b/cluster/mesos/task/task_test.go
@@ -34,7 +34,7 @@ func TestBuild(t *testing.T) {
 	task, err := NewTask(cluster.BuildContainerConfig(containerConfig, hostConfig, networkingConfig), name, 5*time.Second)
 	assert.NoError(t, err)
 
-	task.Build("slave-id", nil)
+	task.Build("slave-id", nil, false)
 
 	assert.Equal(t, task.Container.GetType(), mesosproto.ContainerInfo_DOCKER)
 	assert.Equal(t, task.Container.Docker.GetImage(), "test-image")
@@ -47,12 +47,13 @@ func TestBuild(t *testing.T) {
 	assert.Equal(t, task.Command.GetValue(), "ls")
 	assert.Equal(t, task.Command.GetArguments(), []string{"foo", "bar"})
 
-	parameters := []string{task.Container.Docker.GetParameters()[0].GetValue(), task.Container.Docker.GetParameters()[1].GetValue()}
+	parameters := []string{task.Container.Docker.GetParameters()[0].GetValue(), task.Container.Docker.GetParameters()[1].GetValue(), task.Container.Docker.GetParameters()[2].GetValue()}
 	sort.Strings(parameters)
 
-	assert.Equal(t, len(parameters), 2)
+	assert.Equal(t, len(parameters), 3)
 	assert.Equal(t, parameters[0], "com.docker.swarm.mesos.name="+name)
-	assert.Equal(t, parameters[1], "com.docker.swarm.mesos.task="+*task.TaskId.Value)
+	assert.Equal(t, parameters[1], "com.docker.swarm.mesos.resourceType=Regular")
+	assert.Equal(t, parameters[2], "com.docker.swarm.mesos.task="+*task.TaskId.Value)
 
 	assert.Equal(t, task.SlaveId.GetValue(), "slave-id")
 }

--- a/cluster/mesos/utils.go
+++ b/cluster/mesos/utils.go
@@ -2,9 +2,11 @@ package mesos
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/docker/swarm/scheduler/filter"
 	"github.com/mesos/mesos-go/mesosproto"
 )
 
@@ -36,4 +38,80 @@ func sumScalarResourceValue(offers map[string]*mesosproto.Offer, name string) fl
 		}
 	}
 	return value
+}
+
+func sumRegularScalarResourceValue(offers map[string]*mesosproto.Offer, name string) float64 {
+	var value float64
+	for _, offer := range offers {
+		for _, resource := range offer.Resources {
+			if resource.GetRevocable() != nil {
+				continue
+			}
+			if *resource.Name == name {
+				value += *resource.Scalar.Value
+			}
+		}
+	}
+	return value
+}
+
+func sumRevocablecalarResourceValue(offers map[string]*mesosproto.Offer, name string) float64 {
+	var value float64
+	for _, offer := range offers {
+		for _, resource := range offer.Resources {
+			if resource.GetRevocable() == nil {
+				continue
+			}
+			if *resource.Name == name {
+				value += *resource.Scalar.Value
+			}
+		}
+	}
+	return value
+}
+
+func requiredResourceType(constraint filter.Expr) (string, error) {
+	var (
+		pattern        string
+		matchRegular   bool
+		matchRevocable bool
+		err            error
+	)
+
+	value := constraint.Value
+	op := constraint.Operator
+
+	if value[0] == '/' && value[len(value)-1] == '/' {
+		// regexp
+		pattern = value[1 : len(value)-1]
+	} else {
+		// simple match, create the regex for globbing (ex: ub*t* -> ^ub.*t.*$) and match.
+		pattern = "^" + strings.Replace(value, "*", ".*", -1) + "$"
+	}
+
+	if matchRegular, err = regexp.MatchString(pattern, "regular"); err != nil {
+		return "?", err
+	}
+
+	if matchRevocable, err = regexp.MatchString(pattern, "revocable"); err != nil {
+		return "?", err
+	}
+
+	if matchRegular && !matchRevocable {
+		switch op {
+		case filter.EQ:
+			return RegularResourceOnly, nil
+		case filter.NOTEQ:
+			return RevocableResourceOnly, nil
+		}
+	} else if matchRevocable && !matchRegular {
+		switch op {
+		case filter.EQ:
+			return RevocableResourceOnly, nil
+		case filter.NOTEQ:
+			return RegularResourceOnly, nil
+		}
+	}
+
+	return "?", nil
 }

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -20,20 +20,20 @@ func (f *AffinityFilter) Name() string {
 
 // Filter is exported
 func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.Node, soft bool) ([]*node.Node, error) {
-	affinities, err := parseExprs(config.Affinities())
+	affinities, err := ParseExprs(config.Affinities())
 	if err != nil {
 		return nil, err
 	}
 
 	for _, affinity := range affinities {
-		if !soft && affinity.isSoft {
+		if !soft && affinity.IsSoft {
 			continue
 		}
-		log.Debugf("matching affinity: %s%s%s (soft=%t)", affinity.key, OPERATORS[affinity.operator], affinity.value, affinity.isSoft)
+		log.Debugf("matching affinity: %s%s%s (soft=%t)", affinity.Key, OPERATORS[affinity.Operator], affinity.Value, affinity.IsSoft)
 
 		candidates := []*node.Node{}
 		for _, node := range nodes {
-			switch affinity.key {
+			switch affinity.Key {
 			case "container":
 				containers := []string{}
 				for _, container := range node.Containers {
@@ -60,7 +60,7 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 			default:
 				labels := []string{}
 				for _, container := range node.Containers {
-					labels = append(labels, container.Labels[affinity.key])
+					labels = append(labels, container.Labels[affinity.Key])
 				}
 				if affinity.Match(labels...) {
 					candidates = append(candidates, node)

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -19,27 +19,27 @@ func (f *ConstraintFilter) Name() string {
 
 // Filter is exported
 func (f *ConstraintFilter) Filter(config *cluster.ContainerConfig, nodes []*node.Node, soft bool) ([]*node.Node, error) {
-	constraints, err := parseExprs(config.Constraints())
+	constraints, err := ParseExprs(config.Constraints())
 	if err != nil {
 		return nil, err
 	}
 
 	for _, constraint := range constraints {
-		if !soft && constraint.isSoft {
+		if !soft && constraint.IsSoft {
 			continue
 		}
-		log.Debugf("matching constraint: %s%s%s (soft=%t)", constraint.key, OPERATORS[constraint.operator], constraint.value, constraint.isSoft)
+		log.Debugf("matching constraint: %s%s%s (soft=%t)", constraint.Key, OPERATORS[constraint.Operator], constraint.Value, constraint.IsSoft)
 
 		candidates := []*node.Node{}
 		for _, node := range nodes {
-			switch constraint.key {
+			switch constraint.Key {
 			case "node":
 				// "node" label is a special case pinning a container to a specific node.
 				if constraint.Match(node.ID, node.Name) {
 					candidates = append(candidates, node)
 				}
 			default:
-				if constraint.Match(node.Labels[constraint.key]) {
+				if constraint.Match(node.Labels[constraint.Key]) {
 					candidates = append(candidates, node)
 				}
 			}

--- a/scheduler/filter/expr.go
+++ b/scheduler/filter/expr.go
@@ -18,15 +18,17 @@ const (
 // OPERATORS is exported
 var OPERATORS = []string{"==", "!="}
 
-type expr struct {
-	key      string
-	operator int
-	value    string
-	isSoft   bool
+// Expr is exported
+type Expr struct {
+	Key      string
+	Operator int
+	Value    string
+	IsSoft   bool
 }
 
-func parseExprs(env []string) ([]expr, error) {
-	exprs := []expr{}
+// ParseExprs is exported to parse the filters.
+func ParseExprs(env []string) ([]Expr, error) {
+	exprs := []Expr{}
 	for _, e := range env {
 		found := false
 		for i, op := range OPERATORS {
@@ -57,9 +59,9 @@ func parseExprs(env []string) ([]expr, error) {
 					if matched == false {
 						return nil, fmt.Errorf("Value '%s' is invalid", parts[1])
 					}
-					exprs = append(exprs, expr{key: parts[0], operator: i, value: strings.TrimLeft(parts[1], "~"), isSoft: isSoft(parts[1])})
+					exprs = append(exprs, Expr{Key: parts[0], Operator: i, Value: strings.TrimLeft(parts[1], "~"), IsSoft: isSoft(parts[1])})
 				} else {
-					exprs = append(exprs, expr{key: parts[0], operator: i})
+					exprs = append(exprs, Expr{Key: parts[0], Operator: i})
 				}
 
 				found = true
@@ -73,19 +75,20 @@ func parseExprs(env []string) ([]expr, error) {
 	return exprs, nil
 }
 
-func (e *expr) Match(whats ...string) bool {
+// Match is exported.
+func (e *Expr) Match(whats ...string) bool {
 	var (
 		pattern string
 		match   bool
 		err     error
 	)
 
-	if e.value[0] == '/' && e.value[len(e.value)-1] == '/' {
+	if e.Value[0] == '/' && e.Value[len(e.Value)-1] == '/' {
 		// regexp
-		pattern = e.value[1 : len(e.value)-1]
+		pattern = e.Value[1 : len(e.Value)-1]
 	} else {
 		// simple match, create the regex for globbing (ex: ub*t* -> ^ub.*t.*$) and match.
-		pattern = "^" + strings.Replace(e.value, "*", ".*", -1) + "$"
+		pattern = "^" + strings.Replace(e.Value, "*", ".*", -1) + "$"
 	}
 
 	for _, what := range whats {
@@ -96,7 +99,7 @@ func (e *expr) Match(whats ...string) bool {
 		}
 	}
 
-	switch e.operator {
+	switch e.Operator {
 	case EQ:
 		return match
 	case NOTEQ:

--- a/scheduler/filter/expr_test.go
+++ b/scheduler/filter/expr_test.go
@@ -8,76 +8,76 @@ import (
 
 func TestParseExprs(t *testing.T) {
 	// Cannot use the leading digit for key
-	_, err := parseExprs([]string{"1node"})
+	_, err := ParseExprs([]string{"1node"})
 	assert.Error(t, err)
 
 	// Cannot use space in key
-	_, err = parseExprs([]string{"node ==node1"})
+	_, err = ParseExprs([]string{"node ==node1"})
 	assert.Error(t, err)
 
 	// Cannot use * in key
-	_, err = parseExprs([]string{"no*de==node1"})
+	_, err = ParseExprs([]string{"no*de==node1"})
 	assert.Error(t, err)
 
 	// Cannot use $ in key
-	_, err = parseExprs([]string{"no$de==node1"})
+	_, err = ParseExprs([]string{"no$de==node1"})
 	assert.Error(t, err)
 
 	// Allow CAPS in key
-	exprs, err := parseExprs([]string{"NoDe==node1"})
+	exprs, err := ParseExprs([]string{"NoDe==node1"})
 	assert.NoError(t, err)
-	assert.Equal(t, exprs[0].key, "NoDe")
-	assert.Equal(t, exprs[0].value, "node1")
+	assert.Equal(t, exprs[0].Key, "NoDe")
+	assert.Equal(t, exprs[0].Value, "node1")
 
 	// Allow dot in key
-	exprs, err = parseExprs([]string{"no.de==node1"})
+	exprs, err = ParseExprs([]string{"no.de==node1"})
 	assert.NoError(t, err)
-	assert.Equal(t, exprs[0].key, "no.de")
-	assert.Equal(t, exprs[0].value, "node1")
+	assert.Equal(t, exprs[0].Key, "no.de")
+	assert.Equal(t, exprs[0].Value, "node1")
 
 	// Allow leading underscore
-	exprs, err = parseExprs([]string{"_node==_node1"})
+	exprs, err = ParseExprs([]string{"_node==_node1"})
 	assert.NoError(t, err)
-	assert.Equal(t, exprs[0].key, "_node")
-	assert.Equal(t, exprs[0].value, "_node1")
+	assert.Equal(t, exprs[0].Key, "_node")
+	assert.Equal(t, exprs[0].Value, "_node1")
 
 	// Allow globbing
-	exprs, err = parseExprs([]string{"node==*node*"})
+	exprs, err = ParseExprs([]string{"node==*node*"})
 	assert.NoError(t, err)
-	assert.Equal(t, exprs[0].key, "node")
-	assert.Equal(t, exprs[0].value, "*node*")
+	assert.Equal(t, exprs[0].Key, "node")
+	assert.Equal(t, exprs[0].Value, "*node*")
 
 	// Allow regexp in value
-	exprs, err = parseExprs([]string{"node==/(?i)^[a-b]+c*(n|b)$/"})
+	exprs, err = ParseExprs([]string{"node==/(?i)^[a-b]+c*(n|b)$/"})
 	assert.NoError(t, err)
-	assert.Equal(t, exprs[0].key, "node")
-	assert.Equal(t, exprs[0].value, "/(?i)^[a-b]+c*(n|b)$/")
+	assert.Equal(t, exprs[0].Key, "node")
+	assert.Equal(t, exprs[0].Value, "/(?i)^[a-b]+c*(n|b)$/")
 
 	// Allow space in value
-	exprs, err = parseExprs([]string{"node==node 1"})
+	exprs, err = ParseExprs([]string{"node==node 1"})
 	assert.NoError(t, err)
-	assert.Equal(t, exprs[0].key, "node")
-	assert.Equal(t, exprs[0].value, "node 1")
+	assert.Equal(t, exprs[0].Key, "node")
+	assert.Equal(t, exprs[0].Value, "node 1")
 }
 
 func TestMatch(t *testing.T) {
-	e := expr{operator: EQ, value: "foo"}
+	e := Expr{Operator: EQ, Value: "foo"}
 	assert.True(t, e.Match("foo"))
 	assert.False(t, e.Match("bar"))
 	assert.True(t, e.Match("foo", "bar"))
 
-	e = expr{operator: NOTEQ, value: "foo"}
+	e = Expr{Operator: NOTEQ, Value: "foo"}
 	assert.False(t, e.Match("foo"))
 	assert.True(t, e.Match("bar"))
 	assert.False(t, e.Match("foo", "bar"))
 	assert.False(t, e.Match("bar", "foo"))
 
-	e = expr{operator: EQ, value: "f*o"}
+	e = Expr{Operator: EQ, Value: "f*o"}
 	assert.True(t, e.Match("foo"))
 	assert.True(t, e.Match("fuo"))
 	assert.True(t, e.Match("foo", "fuo", "bar"))
 
-	e = expr{operator: NOTEQ, value: "f*o"}
+	e = Expr{Operator: NOTEQ, Value: "f*o"}
 	assert.False(t, e.Match("foo"))
 	assert.False(t, e.Match("fuo"))
 	assert.False(t, e.Match("foo", "fuo", "bar"))


### PR DESCRIPTION
This PR handles the following things:
1. Add a new cluster option to enable swarm to receive the revocable resources from mesos.
2. Add a new constraint to let end user to use regular or revocable resources to create container.
3.(TODO) Add integration tests

Signed-off-by: Yongqiao Wang yqwyq@cn.ibm.com
