### PR TITLE
validate duration flags: --delay, --timeout,--replication-ttl

### DIFF
--- a/cli/join.go
+++ b/cli/join.go
@@ -39,6 +39,9 @@ func join(c *cli.Context) {
 	if err != nil {
 		log.Fatalf("invalid --delay: %v", err)
 	}
+	if joinDelay < time.Duration(0)*time.Second {
+		log.Fatalf("--delay should not be a negative number")
+	}
 
 	hb, err := time.ParseDuration(c.String("heartbeat"))
 	if err != nil {
@@ -60,6 +63,8 @@ func join(c *cli.Context) {
 		log.Fatal(err)
 	}
 
+	// if joinDelay is 0, no delay will be executed
+	// if joinDelay is larger than 0,
 	// add a random delay between 0s and joinDelay at start to avoid synchronized registration
 	if joinDelay > 0 {
 		r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))

--- a/cli/list.go
+++ b/cli/list.go
@@ -18,6 +18,9 @@ func list(c *cli.Context) {
 	if err != nil {
 		log.Fatalf("invalid --timeout: %v", err)
 	}
+	if timeout <= time.Duration(0)*time.Second {
+		log.Fatalf("--timeout should be a positive number")
+	}
 
 	d, err := discovery.New(dflag, timeout, 0, getDiscoveryOpt(c))
 	if err != nil {

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -319,6 +319,9 @@ func manage(c *cli.Context) {
 		if err != nil {
 			log.Fatalf("invalid --replication-ttl: %v", err)
 		}
+		if leaderTTL <= time.Duration(0)*time.Second {
+			log.Fatalf("--replication-ttl should be a positive number")
+		}
 
 		setupReplication(c, cl, server, discovery, addr, leaderTTL, tlsConfig)
 	} else {

--- a/test/integration/cli_join.bats
+++ b/test/integration/cli_join.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# Discovery parameter for Swarm
+DISCOVERY="consul://127.0.0.1:5555/test"
+
+@test "swarm join" {
+	# --advertise
+	run swarm join --heartbeat=1s --ttl=10s --delay=1s --advertise="" "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"missing mandatory --advertise flag"* ]]
+
+	run swarm join --heartbeat=1s --ttl=10s --delay=1s --advertise=127.0.0.1ac:sh25 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--advertise should be of the form ip:port or hostname:port"* ]]
+
+	# --delay
+	run swarm join --heartbeat=1s --ttl=10s --delay=asdf --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+
+	run swarm join --heartbeat=1s --ttl=10s --delay=-30s --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--delay should not be a negative number"* ]]
+
+	# --heartbeat
+	run swarm join --heartbeat=asdf --ttl=10s --delay=1s --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+
+	run swarm join --heartbeat=-10s --ttl=10s --delay=1s --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--heartbeat should be at least one second"* ]]
+
+	# --ttl
+	run swarm join --heartbeat=1s --ttl=asdf --delay=1s --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+
+	run swarm join --heartbeat=1s --ttl=-10s --delay=1s --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--ttl must be strictly superior to the heartbeat value"* ]]
+
+	run swarm join --heartbeat=2s --ttl=1s --delay=1s --advertise=127.0.0.1:2376 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--ttl must be strictly superior to the heartbeat value"* ]]
+}

--- a/test/integration/cli_list.bats
+++ b/test/integration/cli_list.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# Discovery parameter for Swarm
+DISCOVERY="consul://127.0.0.1:5555/test"
+
+@test "swarm list" {
+	# --timeout
+	run swarm list --timeout "-10s" "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--timeout should be a positive number"* ]]
+
+	# --timeout
+	run swarm list --timeout "0s" "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--timeout should be a positive number"* ]]
+}

--- a/test/integration/replication.bats
+++ b/test/integration/replication.bats
@@ -32,6 +32,24 @@ function teardown() {
 	stop_store
 }
 
+@test "replication options" {
+	# Bring up one manager
+	# --advertise
+	run swarm manage --replication --replication-ttl "4s" --advertise "" "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--advertise address must be provided when using --leader-election"* ]]
+
+	# --advertise
+	run swarm manage --replication --replication-ttl "4s" --advertise 127.0.0.1ab:1bcde "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--advertise should be of the form ip:port or hostname:port"* ]]
+
+	# --replication-ttl
+	run swarm manage --replication --replication-ttl "-20s" --advertise 127.0.0.1:$SWARM_BASE_PORT "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--replication-ttl should be a positive number"* ]]
+}
+
 @test "leader election" {
 	local i=${#SWARM_MANAGE_PID[@]}
 	local port=$(($SWARM_BASE_PORT + $i))


### PR DESCRIPTION
validate duration flags:
1.--delay, must not be a negative number
2.--timeout, must be a positive number
3.--replication-ttl, must be a postive number

Add test details.
1. add test cases realated to --replication-ttl in replication.bats
2. add a test file cli_list.bats 
3. add a test file cli_join.bats

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>