### PR TITLE
Increase max thread count to 50k

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime/debug"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -13,6 +14,8 @@ import (
 
 // Run the Swarm CLI.
 func Run() {
+	setProgramLimits()
+
 	app := cli.NewApp()
 	app.Name = path.Base(os.Args[0])
 	app.Usage = "A Docker-native clustering system"
@@ -65,4 +68,12 @@ func Run() {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func setProgramLimits() {
+	// Swarm runnable threads could be large when the number of nodes is large
+	// or under request bursts. Most threads are occupied by network connections.
+	// Increase max thread count from 10k default to 50k to accommodate it.
+	const maxThreadCount int = 50 * 1000
+	debug.SetMaxThreads(maxThreadCount)
 }


### PR DESCRIPTION
Swarm runnable threads could be large when the number of nodes is large or under request bursts. Most threads are occupied by network connections. Increase max thread count from 10k default to 50k to accommodate it.

Fix #1859, along with other fixes. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>