### PR TITLE
Added node discovery warning

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -101,7 +101,9 @@ This works the same way for the Swarm `manage` and `list` commands.
 
 ## A static file or list of nodes
 
-> ***Warning*** This discovery method is inompatible with replicating swarm masters. If you require replication, you should use a hosted discovery key store.
+> **Note***: This discovery method is incompatible with replicating Swarm
+managers. If you require replication, you should use a hosted discovery key
+store.
 
 You can use a static file or list of nodes for your discovery backend. The file must be stored on a host that is accessible from the Swarm manager. You can also pass a node list as an option when you start Swarm.
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -101,7 +101,7 @@ This works the same way for the Swarm `manage` and `list` commands.
 
 ## A static file or list of nodes
 
-> ***Warning*** This discovery method is not compatible with replicating swarm masters, so if you require replication, you will need to use a hosted discovery key store.
+> ***Warning*** This discovery method is inompatible with replicating swarm masters. If you require replication, you should use a hosted discovery key store.
 
 You can use a static file or list of nodes for your discovery backend. The file must be stored on a host that is accessible from the Swarm manager. You can also pass a node list as an option when you start Swarm.
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -101,6 +101,8 @@ This works the same way for the Swarm `manage` and `list` commands.
 
 ## A static file or list of nodes
 
+> ***Warning*** This discovery method is not compatible with replicating swarm masters, so if you require replication, you will need to use a hosted discovery key store.
+
 You can use a static file or list of nodes for your discovery backend. The file must be stored on a host that is accessible from the Swarm manager. You can also pass a node list as an option when you start Swarm.
 
 Both the static file and the `nodes` option support a IP address ranges. To specify a range supply a pattern, for example, `10.0.0.[10:200]` refers to nodes starting from `10.0.0.10` to `10.0.0.200`.  For example for the `file` discovery method.


### PR DESCRIPTION
Signed-off-by: Troy Fontaine <tfontaine@troyfontaine.com>

I came across the detail that Swarm doesn't support replicating masters when using a discovery file due to an error in a container when I was setting it up.  This makes sense-but it wasn't stated in the documentation.

I hope this is acceptable.  Thanks!