### PR TITLE
fix image matching via id

### DIFF
--- a/cluster/image.go
+++ b/cluster/image.go
@@ -43,6 +43,13 @@ func (image *Image) Match(IDOrName string, matchTag bool) bool {
 		return true
 	}
 
+	// trim sha256: and retry
+	if parts := strings.SplitN(image.Id, ":", 2); len(parts) == 2 {
+		if parts[1] == IDOrName || (size > 2 && strings.HasPrefix(parts[1], IDOrName)) {
+			return true
+		}
+	}
+
 	repoName, tag := ParseRepositoryTag(IDOrName)
 
 	// match repotag

--- a/test/integration/api/rmi.bats
+++ b/test/integration/api/rmi.bats
@@ -125,6 +125,20 @@ function teardown() {
 	[[ "${output}" != *"sha256:649374debd26307573564fcf9748d39db33ef61fbf88ee84c3af10fd7e08765d"* ]]
 }
 
+@test "docker rmi via id" {
+	start_docker_with_busybox 1
+	swarm_manage
+
+	# get busybox image id
+	busybox_id=`docker_swarm images -q`
+
+	docker_swarm rmi $busybox_id
+
+	run docker_swarm images -q
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 0 ]
+}
+
 @test "docker rmi --force with image tag" {
 	start_docker_with_busybox 1
 	start_docker 1


### PR DESCRIPTION
fix #1974

Since docker 1.10 `/images` now returns images IDs prefixed by `sha256:` (it's hidden in the cli)