### PR TITLE
Docker restart event should trigger container inspect

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1003,7 +1003,7 @@ func (e *Engine) handler(ev *dockerclient.Event, _ chan error, args ...interface
 		e.RefreshImages()
 	case "container":
 		switch ev.Action {
-		case "die", "kill", "oom", "pause", "start", "stop", "unpause", "rename":
+		case "die", "kill", "oom", "pause", "start", "restart", "stop", "unpause", "rename":
 			e.refreshContainer(ev.ID, true)
 		default:
 			e.refreshContainer(ev.ID, false)


### PR DESCRIPTION
Docker restart would change container state. Should trigger container inspect to update status.

The issue is tracked by #1468. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>