### PR TITLE
use apiClient for various things

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -308,7 +308,7 @@ func getVolume(c *context, w http.ResponseWriter, r *http.Request) {
 
 // GET /volumes
 func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
-	volumes := struct{ Volumes []*dockerclient.Volume }{}
+	volumes := struct{ Volumes []*apitypes.Volume }{}
 
 	for _, volume := range c.cluster.Volumes() {
 		tmp := (*volume).Volume
@@ -613,7 +613,7 @@ func postNetworksCreate(c *context, w http.ResponseWriter, r *http.Request) {
 
 // POST /volumes/create
 func postVolumesCreate(c *context, w http.ResponseWriter, r *http.Request) {
-	var request dockerclient.VolumeCreateRequest
+	var request apitypes.VolumeCreateRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		httpError(w, err.Error(), http.StatusBadRequest)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -268,7 +268,7 @@ func getNetworks(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	out := []*dockerclient.NetworkResource{}
+	out := []*apitypes.NetworkResource{}
 	networks := c.cluster.Networks().Filter(filters.Get("name"), filters.Get("id"), types)
 	for _, network := range networks {
 		tmp := (*network).NetworkResource

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -45,7 +45,7 @@ type Cluster interface {
 	RemoveNetwork(network *Network) error
 
 	// Create a volume
-	CreateVolume(request *dockerclient.VolumeCreateRequest) (*Volume, error)
+	CreateVolume(request *types.VolumeCreateRequest) (*Volume, error)
 
 	// Return all volumes
 	Volumes() Volumes

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -22,7 +22,7 @@ type Cluster interface {
 	Image(IDOrName string) *Image
 
 	// Remove images from the cluster
-	RemoveImages(name string, force bool) ([]*dockerclient.ImageDelete, error)
+	RemoveImages(name string, force bool) ([]types.ImageDelete, error)
 
 	// Return all containers
 	Containers() Containers

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -569,14 +569,14 @@ func (e *Engine) RefreshNetworks() error {
 
 // RefreshVolumes refreshes the list of volumes on the engine.
 func (e *Engine) RefreshVolumes() error {
-	volumes, err := e.client.ListVolumes()
+	volumesLsRsp, err := e.apiClient.VolumeList(context.TODO(), filters.NewArgs())
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
 	}
 	e.Lock()
 	e.volumes = make(map[string]*Volume)
-	for _, volume := range volumes {
+	for _, volume := range volumesLsRsp.Volumes {
 		e.volumes[volume.Name] = &Volume{Volume: *volume, Engine: e}
 	}
 	e.Unlock()
@@ -887,8 +887,8 @@ func (e *Engine) CreateNetwork(request *dockerclient.NetworkCreate) (*dockerclie
 }
 
 // CreateVolume creates a volume in the engine
-func (e *Engine) CreateVolume(request *dockerclient.VolumeCreateRequest) (*Volume, error) {
-	volume, err := e.client.CreateVolume(request)
+func (e *Engine) CreateVolume(request *types.VolumeCreateRequest) (*Volume, error) {
+	volume, err := e.apiClient.VolumeCreate(context.TODO(), *request)
 
 	e.RefreshVolumes()
 	e.CheckConnectionErr(err)
@@ -896,7 +896,7 @@ func (e *Engine) CreateVolume(request *dockerclient.VolumeCreateRequest) (*Volum
 	if err != nil {
 		return nil, err
 	}
-	return &Volume{Volume: *volume, Engine: e}, nil
+	return &Volume{Volume: volume, Engine: e}, nil
 
 }
 

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -477,12 +477,12 @@ func (e *Engine) updateSpecs() error {
 }
 
 // RemoveImage deletes an image from the engine.
-func (e *Engine) RemoveImage(image *Image, name string, force bool) ([]*dockerclient.ImageDelete, error) {
-	array, err := e.client.RemoveImage(name, force)
+func (e *Engine) RemoveImage(name string, force bool) ([]types.ImageDelete, error) {
+	rmOpts := types.ImageRemoveOptions{name, force, true}
+	dels, err := e.apiClient.ImageRemove(context.TODO(), rmOpts)
 	e.CheckConnectionErr(err)
 	e.RefreshImages()
-	return array, err
-
+	return dels, err
 }
 
 // RemoveNetwork removes a network from the engine.

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -487,7 +487,7 @@ func (e *Engine) RemoveImage(name string, force bool) ([]types.ImageDelete, erro
 
 // RemoveNetwork removes a network from the engine.
 func (e *Engine) RemoveNetwork(network *Network) error {
-	err := e.client.RemoveNetwork(network.ID)
+	err := e.apiClient.NetworkRemove(network.ID)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/pkg/version"
 	engineapi "github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
 	engineapinop "github.com/docker/swarm/api/nopclient"
 	"github.com/samalba/dockerclient"
 	"github.com/samalba/dockerclient/nopclient"
@@ -487,7 +488,7 @@ func (e *Engine) RemoveImage(name string, force bool) ([]types.ImageDelete, erro
 
 // RemoveNetwork removes a network from the engine.
 func (e *Engine) RemoveNetwork(network *Network) error {
-	err := e.apiClient.NetworkRemove(network.ID)
+	err := e.apiClient.NetworkRemove(context.TODO(), network.ID)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -518,7 +519,7 @@ func (e *Engine) AddNetwork(network *Network) {
 
 // RemoveVolume deletes a volume from the engine.
 func (e *Engine) RemoveVolume(name string) error {
-	err := e.apiClient.VolumeRemove(name)
+	err := e.apiClient.VolumeRemove(context.TODO(), name)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -551,7 +552,8 @@ func (e *Engine) RefreshImages() error {
 
 // RefreshNetworks refreshes the list of networks on the engine.
 func (e *Engine) RefreshNetworks() error {
-	networks, err := e.client.ListNetworks("")
+	netLsOpts := types.NetworkListOptions{filters.NewArgs()}
+	networks, err := e.apiClient.NetworkList(context.TODO(), netLsOpts)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -559,7 +561,7 @@ func (e *Engine) RefreshNetworks() error {
 	e.Lock()
 	e.networks = make(map[string]*Network)
 	for _, network := range networks {
-		e.networks[network.ID] = &Network{NetworkResource: *network, Engine: e}
+		e.networks[network.ID] = &Network{NetworkResource: network, Engine: e}
 	}
 	e.Unlock()
 	return nil

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -518,7 +518,7 @@ func (e *Engine) AddNetwork(network *Network) {
 
 // RemoveVolume deletes a volume from the engine.
 func (e *Engine) RemoveVolume(name string) error {
-	err := e.client.RemoveVolume(name)
+	err := e.apiClient.VolumeRemove(name)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -158,10 +158,12 @@ func TestEngineCpusMemory(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
@@ -184,10 +186,12 @@ func TestEngineSpecs(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
@@ -215,13 +219,16 @@ func TestEngineState(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	// The client will return one container at first, then a second one will appear.
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
 	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
@@ -267,11 +274,14 @@ func TestCreateContainer(t *testing.T) {
 	engine.setState(stateUnhealthy)
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
 	assert.True(t, engine.isConnected())
@@ -288,7 +298,6 @@ func TestCreateContainer(t *testing.T) {
 	client.On("ListContainers", true, false, fmt.Sprintf(`{"id":[%q]}`, id)).Return([]dockerclient.Container{{Id: id}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("InspectContainer", id).Return(&dockerclient.ContainerInfo{Config: &config.ContainerConfig}, nil).Once()
 	container, err := engine.Create(config, name, false, auth)
 	assert.Nil(t, err)
@@ -313,7 +322,6 @@ func TestCreateContainer(t *testing.T) {
 	client.On("ListContainers", true, false, fmt.Sprintf(`{"id":[%q]}`, id)).Return([]dockerclient.Container{{Id: id}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("InspectContainer", id).Return(&dockerclient.ContainerInfo{Config: &config.ContainerConfig}, nil).Once()
 	container, err = engine.Create(config, name, true, auth)
 	assert.Nil(t, err)
@@ -373,10 +381,13 @@ func TestUsedCpus(t *testing.T) {
 
 				apiClient.On("Info", mock.Anything).Return(mockInfo, nil).Once()
 				apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+				apiClient.On("NetworkList", mock.Anything,
+					mock.AnythingOfType("NetworkListOptions"),
+				).Return([]types.NetworkResource{}, nil)
+
 				client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 				client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
 				client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-				client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 				client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "test"}}, nil).Once()
 				client.On("InspectContainer", "test").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: cpuShares}}, nil).Once()
 
@@ -407,9 +418,12 @@ func TestContainerRemovedDuringRefresh(t *testing.T) {
 
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{container1, container2}, nil)
 	client.On("InspectContainer", "c1").Return(info1, errors.New("Not found"))
@@ -435,6 +449,10 @@ func TestDisconnect(t *testing.T) {
 
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("StopAllMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
@@ -442,7 +460,6 @@ func TestDisconnect(t *testing.T) {
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
 	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -161,9 +161,11 @@ func TestEngineCpusMemory(t *testing.T) {
 	apiClient.On("NetworkList", mock.Anything,
 		mock.AnythingOfType("NetworkListOptions"),
 	).Return([]types.NetworkResource{}, nil)
+	apiClient.On("VolumeList", mock.Anything,
+		mock.AnythingOfType("Args"),
+	).Return(types.VolumesListResponse{}, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
@@ -189,9 +191,11 @@ func TestEngineSpecs(t *testing.T) {
 	apiClient.On("NetworkList", mock.Anything,
 		mock.AnythingOfType("NetworkListOptions"),
 	).Return([]types.NetworkResource{}, nil)
+	apiClient.On("VolumeList", mock.Anything,
+		mock.AnythingOfType("Args"),
+	).Return(types.VolumesListResponse{}, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
@@ -222,13 +226,14 @@ func TestEngineState(t *testing.T) {
 	apiClient.On("NetworkList", mock.Anything,
 		mock.AnythingOfType("NetworkListOptions"),
 	).Return([]types.NetworkResource{}, nil)
-
+	apiClient.On("VolumeList", mock.Anything,
+		mock.AnythingOfType("Args"),
+	).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	// The client will return one container at first, then a second one will appear.
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
 	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
@@ -277,11 +282,12 @@ func TestCreateContainer(t *testing.T) {
 	apiClient.On("NetworkList", mock.Anything,
 		mock.AnythingOfType("NetworkListOptions"),
 	).Return([]types.NetworkResource{}, nil)
-
+	apiClient.On("VolumeList", mock.Anything,
+		mock.AnythingOfType("Args"),
+	).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
 	assert.True(t, engine.isConnected())
@@ -297,7 +303,6 @@ func TestCreateContainer(t *testing.T) {
 	client.On("CreateContainer", &mockConfig, name, auth).Return(id, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf(`{"id":[%q]}`, id)).Return([]dockerclient.Container{{Id: id}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("InspectContainer", id).Return(&dockerclient.ContainerInfo{Config: &config.ContainerConfig}, nil).Once()
 	container, err := engine.Create(config, name, false, auth)
 	assert.Nil(t, err)
@@ -321,7 +326,6 @@ func TestCreateContainer(t *testing.T) {
 	client.On("CreateContainer", &mockConfig, name, auth).Return(id, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf(`{"id":[%q]}`, id)).Return([]dockerclient.Container{{Id: id}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("InspectContainer", id).Return(&dockerclient.ContainerInfo{Config: &config.ContainerConfig}, nil).Once()
 	container, err = engine.Create(config, name, true, auth)
 	assert.Nil(t, err)
@@ -384,10 +388,11 @@ func TestUsedCpus(t *testing.T) {
 				apiClient.On("NetworkList", mock.Anything,
 					mock.AnythingOfType("NetworkListOptions"),
 				).Return([]types.NetworkResource{}, nil)
-
+				apiClient.On("VolumeList", mock.Anything,
+					mock.AnythingOfType("Args"),
+				).Return(types.VolumesListResponse{}, nil)
 				client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 				client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
-				client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 				client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "test"}}, nil).Once()
 				client.On("InspectContainer", "test").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: cpuShares}}, nil).Once()
 
@@ -421,9 +426,10 @@ func TestContainerRemovedDuringRefresh(t *testing.T) {
 	apiClient.On("NetworkList", mock.Anything,
 		mock.AnythingOfType("NetworkListOptions"),
 	).Return([]types.NetworkResource{}, nil)
-
+	apiClient.On("VolumeList", mock.Anything,
+		mock.AnythingOfType("Args"),
+	).Return(types.VolumesListResponse{}, nil)
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{container1, container2}, nil)
 	client.On("InspectContainer", "c1").Return(info1, errors.New("Not found"))
@@ -452,14 +458,15 @@ func TestDisconnect(t *testing.T) {
 	apiClient.On("NetworkList", mock.Anything,
 		mock.AnythingOfType("NetworkListOptions"),
 	).Return([]types.NetworkResource{}, nil)
-
+	apiClient.On("VolumeList", mock.Anything,
+		mock.AnythingOfType("Args"),
+	).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("StopAllMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	// The client will return one container at first, then a second one will appear.
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
 	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -299,7 +299,7 @@ func (c *Cluster) refreshNetworks() {
 }
 
 // CreateVolume creates a volume in the cluster
-func (c *Cluster) CreateVolume(request *dockerclient.VolumeCreateRequest) (*cluster.Volume, error) {
+func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*cluster.Volume, error) {
 	return nil, errNotSupported
 }
 

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -249,7 +249,7 @@ func (c *Cluster) Image(IDOrName string) *cluster.Image {
 }
 
 // RemoveImages removes images from the cluster
-func (c *Cluster) RemoveImages(name string, force bool) ([]*dockerclient.ImageDelete, error) {
+func (c *Cluster) RemoveImages(name string, force bool) ([]types.ImageDelete, error) {
 	return nil, errNotSupported
 }
 
@@ -358,7 +358,7 @@ func (c *Cluster) Container(IDOrName string) *cluster.Container {
 }
 
 // RemoveImage removes an image from the cluster
-func (c *Cluster) RemoveImage(image *cluster.Image) ([]*dockerclient.ImageDelete, error) {
+func (c *Cluster) RemoveImage(image *cluster.Image) ([]types.ImageDelete, error) {
 	return nil, errNotSupported
 }
 

--- a/cluster/network.go
+++ b/cluster/network.go
@@ -4,12 +4,12 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types"
 )
 
 // Network is exported
 type Network struct {
-	dockerclient.NetworkResource
+	types.NetworkResource
 
 	Engine *Engine
 }
@@ -98,7 +98,7 @@ func (network *Network) RemoveDuplicateEndpoints() *Network {
 	// Make a copy of the network
 	netCopy := *network
 	// clean up existing endpoints
-	netCopy.Containers = make(map[string]dockerclient.EndpointResource)
+	netCopy.Containers = make(map[string]types.EndpointResource)
 	// add the endpoint index from endpointMap
 	for _, index := range endpointMap {
 		netCopy.Containers[index] = network.Containers[index]

--- a/cluster/network_test.go
+++ b/cluster/network_test.go
@@ -3,26 +3,26 @@ package cluster
 import (
 	"testing"
 
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNetworksFilter(t *testing.T) {
 	engine := &Engine{ID: "id"}
 	networks := Networks{
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "ababababab",
 			Name: "something",
 		}, engine},
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "aaaaaaaaaa1",
 			Name: "network_name",
 		}, engine},
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "bbbbbbbbbb",
 			Name: "somethingelse",
 		}, engine},
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "aaaaaaaaa2",
 			Name: "foo",
 		}, engine},
@@ -39,31 +39,31 @@ func TestNetworkUniq(t *testing.T) {
 	engine1 := &Engine{ID: "id1"}
 	engine2 := &Engine{ID: "id2"}
 	networks := Networks{
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "global",
 			Name: "global",
-			Containers: map[string]dockerclient.EndpointResource{
+			Containers: map[string]types.EndpointResource{
 				"c1": {},
 			},
 		}, engine1},
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "global",
 			Name: "global",
-			Containers: map[string]dockerclient.EndpointResource{
+			Containers: map[string]types.EndpointResource{
 				"c2": {},
 			},
 		}, engine2},
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "local1",
 			Name: "local",
-			Containers: map[string]dockerclient.EndpointResource{
+			Containers: map[string]types.EndpointResource{
 				"c3": {},
 			},
 		}, engine1},
-		{dockerclient.NetworkResource{
+		{types.NetworkResource{
 			ID:   "local2",
 			Name: "local",
-			Containers: map[string]dockerclient.EndpointResource{
+			Containers: map[string]types.EndpointResource{
 				"c4": {},
 			},
 		}, engine2},
@@ -84,10 +84,10 @@ func TestNetworkUniq(t *testing.T) {
 func TestRemoveDuplicateEndpoints(t *testing.T) {
 	engine1 := &Engine{ID: "id1"}
 	network := Network{
-		dockerclient.NetworkResource{
+		types.NetworkResource{
 			ID:   "global",
 			Name: "voteappbase_voteapp",
-			Containers: map[string]dockerclient.EndpointResource{
+			Containers: map[string]types.EndpointResource{
 				"028771f7f6a54c486d441ecfc92aad68e0836a1f0a5a0c227c514f14848e2b54": {
 					Name:        "voteappbase_worker_1",
 					EndpointID:  "49f621862a0659f462870a6cd15874da44592e399f41da2a3019d81b7427315b",

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -419,17 +419,17 @@ func (c *Cluster) Image(IDOrName string) *cluster.Image {
 }
 
 // RemoveImages removes all the images that match `name` from the cluster
-func (c *Cluster) RemoveImages(name string, force bool) ([]*dockerclient.ImageDelete, error) {
+func (c *Cluster) RemoveImages(name string, force bool) ([]types.ImageDelete, error) {
 	c.Lock()
 	defer c.Unlock()
 
-	out := []*dockerclient.ImageDelete{}
+	out := []types.ImageDelete{}
 	errs := []string{}
 	var err error
 	for _, e := range c.engines {
 		for _, image := range e.Images() {
 			if image.Match(name, true) {
-				content, err := image.Engine.RemoveImage(image, name, force)
+				content, err := image.Engine.RemoveImage(name, force)
 				if err != nil {
 					errs = append(errs, fmt.Sprintf("%s: %s", image.Engine.Name, err.Error()))
 					continue

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -492,7 +492,7 @@ func (c *Cluster) CreateNetwork(request *dockerclient.NetworkCreate) (response *
 }
 
 // CreateVolume creates a volume in the cluster
-func (c *Cluster) CreateVolume(request *dockerclient.VolumeCreateRequest) (*cluster.Volume, error) {
+func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*cluster.Volume, error) {
 	var (
 		wg     sync.WaitGroup
 		volume *cluster.Volume

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -137,11 +137,13 @@ func TestImportImage(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
-	apiClient.On("NetworkList", mock.Anything).Return([]types.NetworkResource{}, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+	apiClient.On("VolumeList", mock.Anything, mock.Anything).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -188,11 +190,13 @@ func TestLoadImage(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
-	apiClient.On("NetworkList", mock.Anything).Return([]types.NetworkResource{}, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+	apiClient.On("VolumeList", mock.Anything, mock.Anything).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -242,11 +246,13 @@ func TestTagImage(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
-	apiClient.On("NetworkList", mock.Anything).Return([]types.NetworkResource{}, nil)
+	apiClient.On("NetworkList", mock.Anything,
+		mock.AnythingOfType("NetworkListOptions"),
+	).Return([]types.NetworkResource{}, nil)
+	apiClient.On("VolumeList", mock.Anything, mock.Anything).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return(images, nil)
-	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -137,11 +137,11 @@ func TestImportImage(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything).Return([]types.NetworkResource{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -188,11 +188,11 @@ func TestLoadImage(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything).Return([]types.NetworkResource{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -242,11 +242,11 @@ func TestTagImage(t *testing.T) {
 	apiClient := engineapimock.NewMockClient()
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
+	apiClient.On("NetworkList", mock.Anything).Return([]types.NetworkResource{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
 	client.On("ListImages", mock.Anything).Return(images, nil)
 	client.On("ListVolumes", mock.Anything).Return([]*dockerclient.Volume{}, nil)
-	client.On("ListNetworks", mock.Anything).Return([]*dockerclient.NetworkResource{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)

--- a/cluster/volume.go
+++ b/cluster/volume.go
@@ -1,10 +1,10 @@
 package cluster
 
-import "github.com/samalba/dockerclient"
+import "github.com/docker/engine-api/types"
 
 // Volume is exported
 type Volume struct {
-	dockerclient.Volume
+	types.Volume
 
 	Engine *Engine
 }

--- a/cluster/volume_test.go
+++ b/cluster/volume_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"testing"
 
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,56 +16,56 @@ func TestGet(t *testing.T) {
 	}
 	volumes := Volumes{
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t1",
 				Driver: "local",
 			},
 			Engine: engines[0],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t2",
 				Driver: "local",
 			},
 			Engine: engines[0],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t3",
 				Driver: "rexray",
 			},
 			Engine: engines[0],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t4",
 				Driver: "flocker",
 			},
 			Engine: engines[0],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t1",
 				Driver: "local",
 			},
 			Engine: engines[1],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t2",
 				Driver: "local",
 			},
 			Engine: engines[1],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t3",
 				Driver: "rexray",
 			},
 			Engine: engines[1],
 		},
 		&Volume{
-			Volume: dockerclient.Volume{
+			Volume: types.Volume{
 				Name:   "t4",
 				Driver: "flocker",
 			},


### PR DESCRIPTION
engine-api has has the prune/noprune option. The matching behavior is to prune. Not sure if we want or need to make that option available with the pass through.

Not sure if the array of pointers vs array of objects needs to be looked at or if it's fine how it is.