### PR TITLE
Updating ContainerConfig to use engine-api

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -39,6 +39,16 @@
 			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 		},
 		{
+			"ImportPath": "github.com/docker/distribution/digest",
+			"Comment": "v2.3.0-rc.2-191-gee8450f",
+			"Rev": "ee8450ff13538d829a9a7909da9b979764d56865"
+		},
+		{
+			"ImportPath": "github.com/docker/distribution/reference",
+			"Comment": "v2.3.0-rc.2-191-gee8450f",
+			"Rev": "ee8450ff13538d829a9a7909da9b979764d56865"
+		},
+		{
 			"ImportPath": "github.com/docker/docker/pkg/discovery",
 			"Comment": "v1.4.1-10581-gb65fd8e",
 			"Rev": "b65fd8e879545e8c9b859ea9b6b825ac50c79e46"

--- a/Godeps/_workspace/src/github.com/docker/distribution/LICENSE
+++ b/Godeps/_workspace/src/github.com/docker/distribution/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/Godeps/_workspace/src/github.com/docker/distribution/digest/digest.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/digest/digest.go
@@ -1,0 +1,139 @@
+package digest
+
+import (
+	"fmt"
+	"hash"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const (
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// Digest allows simple protection of hex formatted digest strings, prefixed
+// by their algorithm. Strings of type Digest have some guarantee of being in
+// the correct format and it provides quick access to the components of a
+// digest string.
+//
+// The following is an example of the contents of Digest types:
+//
+// 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//
+// This allows to abstract the digest behind this type and work only in those
+// terms.
+type Digest string
+
+// NewDigest returns a Digest from alg and a hash.Hash object.
+func NewDigest(alg Algorithm, h hash.Hash) Digest {
+	return NewDigestFromBytes(alg, h.Sum(nil))
+}
+
+// NewDigestFromBytes returns a new digest from the byte contents of p.
+// Typically, this can come from hash.Hash.Sum(...) or xxx.SumXXX(...)
+// functions. This is also useful for rebuilding digests from binary
+// serializations.
+func NewDigestFromBytes(alg Algorithm, p []byte) Digest {
+	return Digest(fmt.Sprintf("%s:%x", alg, p))
+}
+
+// NewDigestFromHex returns a Digest from alg and a the hex encoded digest.
+func NewDigestFromHex(alg, hex string) Digest {
+	return Digest(fmt.Sprintf("%s:%s", alg, hex))
+}
+
+// DigestRegexp matches valid digest types.
+var DigestRegexp = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
+
+// DigestRegexpAnchored matches valid digest types, anchored to the start and end of the match.
+var DigestRegexpAnchored = regexp.MustCompile(`^` + DigestRegexp.String() + `$`)
+
+var (
+	// ErrDigestInvalidFormat returned when digest format invalid.
+	ErrDigestInvalidFormat = fmt.Errorf("invalid checksum digest format")
+
+	// ErrDigestInvalidLength returned when digest has invalid length.
+	ErrDigestInvalidLength = fmt.Errorf("invalid checksum digest length")
+
+	// ErrDigestUnsupported returned when the digest algorithm is unsupported.
+	ErrDigestUnsupported = fmt.Errorf("unsupported digest algorithm")
+)
+
+// ParseDigest parses s and returns the validated digest object. An error will
+// be returned if the format is invalid.
+func ParseDigest(s string) (Digest, error) {
+	d := Digest(s)
+
+	return d, d.Validate()
+}
+
+// FromReader returns the most valid digest for the underlying content using
+// the canonical digest algorithm.
+func FromReader(rd io.Reader) (Digest, error) {
+	return Canonical.FromReader(rd)
+}
+
+// FromBytes digests the input and returns a Digest.
+func FromBytes(p []byte) Digest {
+	return Canonical.FromBytes(p)
+}
+
+// Validate checks that the contents of d is a valid digest, returning an
+// error if not.
+func (d Digest) Validate() error {
+	s := string(d)
+
+	if !DigestRegexpAnchored.MatchString(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	i := strings.Index(s, ":")
+	if i < 0 {
+		return ErrDigestInvalidFormat
+	}
+
+	// case: "sha256:" with no hex.
+	if i+1 == len(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	switch algorithm := Algorithm(s[:i]); algorithm {
+	case SHA256, SHA384, SHA512:
+		if algorithm.Size()*2 != len(s[i+1:]) {
+			return ErrDigestInvalidLength
+		}
+		break
+	default:
+		return ErrDigestUnsupported
+	}
+
+	return nil
+}
+
+// Algorithm returns the algorithm portion of the digest. This will panic if
+// the underlying digest is not in a valid format.
+func (d Digest) Algorithm() Algorithm {
+	return Algorithm(d[:d.sepIndex()])
+}
+
+// Hex returns the hex digest portion of the digest. This will panic if the
+// underlying digest is not in a valid format.
+func (d Digest) Hex() string {
+	return string(d[d.sepIndex()+1:])
+}
+
+func (d Digest) String() string {
+	return string(d)
+}
+
+func (d Digest) sepIndex() int {
+	i := strings.Index(string(d), ":")
+
+	if i < 0 {
+		panic("could not find ':' in digest: " + d)
+	}
+
+	return i
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/digest/digester.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/digest/digester.go
@@ -1,0 +1,155 @@
+package digest
+
+import (
+	"crypto"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// Algorithm identifies and implementation of a digester by an identifier.
+// Note the that this defines both the hash algorithm used and the string
+// encoding.
+type Algorithm string
+
+// supported digest types
+const (
+	SHA256 Algorithm = "sha256" // sha256 with hex encoding
+	SHA384 Algorithm = "sha384" // sha384 with hex encoding
+	SHA512 Algorithm = "sha512" // sha512 with hex encoding
+
+	// Canonical is the primary digest algorithm used with the distribution
+	// project. Other digests may be used but this one is the primary storage
+	// digest.
+	Canonical = SHA256
+)
+
+var (
+	// TODO(stevvooe): Follow the pattern of the standard crypto package for
+	// registration of digests. Effectively, we are a registerable set and
+	// common symbol access.
+
+	// algorithms maps values to hash.Hash implementations. Other algorithms
+	// may be available but they cannot be calculated by the digest package.
+	algorithms = map[Algorithm]crypto.Hash{
+		SHA256: crypto.SHA256,
+		SHA384: crypto.SHA384,
+		SHA512: crypto.SHA512,
+	}
+)
+
+// Available returns true if the digest type is available for use. If this
+// returns false, New and Hash will return nil.
+func (a Algorithm) Available() bool {
+	h, ok := algorithms[a]
+	if !ok {
+		return false
+	}
+
+	// check availability of the hash, as well
+	return h.Available()
+}
+
+func (a Algorithm) String() string {
+	return string(a)
+}
+
+// Size returns number of bytes returned by the hash.
+func (a Algorithm) Size() int {
+	h, ok := algorithms[a]
+	if !ok {
+		return 0
+	}
+	return h.Size()
+}
+
+// Set implemented to allow use of Algorithm as a command line flag.
+func (a *Algorithm) Set(value string) error {
+	if value == "" {
+		*a = Canonical
+	} else {
+		// just do a type conversion, support is queried with Available.
+		*a = Algorithm(value)
+	}
+
+	return nil
+}
+
+// New returns a new digester for the specified algorithm. If the algorithm
+// does not have a digester implementation, nil will be returned. This can be
+// checked by calling Available before calling New.
+func (a Algorithm) New() Digester {
+	return &digester{
+		alg:  a,
+		hash: a.Hash(),
+	}
+}
+
+// Hash returns a new hash as used by the algorithm. If not available, the
+// method will panic. Check Algorithm.Available() before calling.
+func (a Algorithm) Hash() hash.Hash {
+	if !a.Available() {
+		// NOTE(stevvooe): A missing hash is usually a programming error that
+		// must be resolved at compile time. We don't import in the digest
+		// package to allow users to choose their hash implementation (such as
+		// when using stevvooe/resumable or a hardware accelerated package).
+		//
+		// Applications that may want to resolve the hash at runtime should
+		// call Algorithm.Available before call Algorithm.Hash().
+		panic(fmt.Sprintf("%v not available (make sure it is imported)", a))
+	}
+
+	return algorithms[a].New()
+}
+
+// FromReader returns the digest of the reader using the algorithm.
+func (a Algorithm) FromReader(rd io.Reader) (Digest, error) {
+	digester := a.New()
+
+	if _, err := io.Copy(digester.Hash(), rd); err != nil {
+		return "", err
+	}
+
+	return digester.Digest(), nil
+}
+
+// FromBytes digests the input and returns a Digest.
+func (a Algorithm) FromBytes(p []byte) Digest {
+	digester := a.New()
+
+	if _, err := digester.Hash().Write(p); err != nil {
+		// Writes to a Hash should never fail. None of the existing
+		// hash implementations in the stdlib or hashes vendored
+		// here can return errors from Write. Having a panic in this
+		// condition instead of having FromBytes return an error value
+		// avoids unnecessary error handling paths in all callers.
+		panic("write to hash function returned error: " + err.Error())
+	}
+
+	return digester.Digest()
+}
+
+// TODO(stevvooe): Allow resolution of verifiers using the digest type and
+// this registration system.
+
+// Digester calculates the digest of written data. Writes should go directly
+// to the return value of Hash, while calling Digest will return the current
+// value of the digest.
+type Digester interface {
+	Hash() hash.Hash // provides direct access to underlying hash instance.
+	Digest() Digest
+}
+
+// digester provides a simple digester definition that embeds a hasher.
+type digester struct {
+	alg  Algorithm
+	hash hash.Hash
+}
+
+func (d *digester) Hash() hash.Hash {
+	return d.hash
+}
+
+func (d *digester) Digest() Digest {
+	return NewDigest(d.alg, d.hash)
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/digest/doc.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/digest/doc.go
@@ -1,0 +1,42 @@
+// Package digest provides a generalized type to opaquely represent message
+// digests and their operations within the registry. The Digest type is
+// designed to serve as a flexible identifier in a content-addressable system.
+// More importantly, it provides tools and wrappers to work with
+// hash.Hash-based digests with little effort.
+//
+// Basics
+//
+// The format of a digest is simply a string with two parts, dubbed the
+// "algorithm" and the "digest", separated by a colon:
+//
+// 	<algorithm>:<digest>
+//
+// An example of a sha256 digest representation follows:
+//
+// 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//
+// In this case, the string "sha256" is the algorithm and the hex bytes are
+// the "digest".
+//
+// Because the Digest type is simply a string, once a valid Digest is
+// obtained, comparisons are cheap, quick and simple to express with the
+// standard equality operator.
+//
+// Verification
+//
+// The main benefit of using the Digest type is simple verification against a
+// given digest. The Verifier interface, modeled after the stdlib hash.Hash
+// interface, provides a common write sink for digest verification. After
+// writing is complete, calling the Verifier.Verified method will indicate
+// whether or not the stream of bytes matches the target digest.
+//
+// Missing Features
+//
+// In addition to the above, we intend to add the following features to this
+// package:
+//
+// 1. A Digester type that supports write sink digest calculation.
+//
+// 2. Suspend and resume of ongoing digest calculations to support efficient digest verification in the registry.
+//
+package digest

--- a/Godeps/_workspace/src/github.com/docker/distribution/digest/set.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/digest/set.go
@@ -1,0 +1,245 @@
+package digest
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+)
+
+var (
+	// ErrDigestNotFound is used when a matching digest
+	// could not be found in a set.
+	ErrDigestNotFound = errors.New("digest not found")
+
+	// ErrDigestAmbiguous is used when multiple digests
+	// are found in a set. None of the matching digests
+	// should be considered valid matches.
+	ErrDigestAmbiguous = errors.New("ambiguous digest string")
+)
+
+// Set is used to hold a unique set of digests which
+// may be easily referenced by easily  referenced by a string
+// representation of the digest as well as short representation.
+// The uniqueness of the short representation is based on other
+// digests in the set. If digests are omitted from this set,
+// collisions in a larger set may not be detected, therefore it
+// is important to always do short representation lookups on
+// the complete set of digests. To mitigate collisions, an
+// appropriately long short code should be used.
+type Set struct {
+	mutex   sync.RWMutex
+	entries digestEntries
+}
+
+// NewSet creates an empty set of digests
+// which may have digests added.
+func NewSet() *Set {
+	return &Set{
+		entries: digestEntries{},
+	}
+}
+
+// checkShortMatch checks whether two digests match as either whole
+// values or short values. This function does not test equality,
+// rather whether the second value could match against the first
+// value.
+func checkShortMatch(alg Algorithm, hex, shortAlg, shortHex string) bool {
+	if len(hex) == len(shortHex) {
+		if hex != shortHex {
+			return false
+		}
+		if len(shortAlg) > 0 && string(alg) != shortAlg {
+			return false
+		}
+	} else if !strings.HasPrefix(hex, shortHex) {
+		return false
+	} else if len(shortAlg) > 0 && string(alg) != shortAlg {
+		return false
+	}
+	return true
+}
+
+// Lookup looks for a digest matching the given string representation.
+// If no digests could be found ErrDigestNotFound will be returned
+// with an empty digest value. If multiple matches are found
+// ErrDigestAmbiguous will be returned with an empty digest value.
+func (dst *Set) Lookup(d string) (Digest, error) {
+	dst.mutex.RLock()
+	defer dst.mutex.RUnlock()
+	if len(dst.entries) == 0 {
+		return "", ErrDigestNotFound
+	}
+	var (
+		searchFunc func(int) bool
+		alg        Algorithm
+		hex        string
+	)
+	dgst, err := ParseDigest(d)
+	if err == ErrDigestInvalidFormat {
+		hex = d
+		searchFunc = func(i int) bool {
+			return dst.entries[i].val >= d
+		}
+	} else {
+		hex = dgst.Hex()
+		alg = dgst.Algorithm()
+		searchFunc = func(i int) bool {
+			if dst.entries[i].val == hex {
+				return dst.entries[i].alg >= alg
+			}
+			return dst.entries[i].val >= hex
+		}
+	}
+	idx := sort.Search(len(dst.entries), searchFunc)
+	if idx == len(dst.entries) || !checkShortMatch(dst.entries[idx].alg, dst.entries[idx].val, string(alg), hex) {
+		return "", ErrDigestNotFound
+	}
+	if dst.entries[idx].alg == alg && dst.entries[idx].val == hex {
+		return dst.entries[idx].digest, nil
+	}
+	if idx+1 < len(dst.entries) && checkShortMatch(dst.entries[idx+1].alg, dst.entries[idx+1].val, string(alg), hex) {
+		return "", ErrDigestAmbiguous
+	}
+
+	return dst.entries[idx].digest, nil
+}
+
+// Add adds the given digest to the set. An error will be returned
+// if the given digest is invalid. If the digest already exists in the
+// set, this operation will be a no-op.
+func (dst *Set) Add(d Digest) error {
+	if err := d.Validate(); err != nil {
+		return err
+	}
+	dst.mutex.Lock()
+	defer dst.mutex.Unlock()
+	entry := &digestEntry{alg: d.Algorithm(), val: d.Hex(), digest: d}
+	searchFunc := func(i int) bool {
+		if dst.entries[i].val == entry.val {
+			return dst.entries[i].alg >= entry.alg
+		}
+		return dst.entries[i].val >= entry.val
+	}
+	idx := sort.Search(len(dst.entries), searchFunc)
+	if idx == len(dst.entries) {
+		dst.entries = append(dst.entries, entry)
+		return nil
+	} else if dst.entries[idx].digest == d {
+		return nil
+	}
+
+	entries := append(dst.entries, nil)
+	copy(entries[idx+1:], entries[idx:len(entries)-1])
+	entries[idx] = entry
+	dst.entries = entries
+	return nil
+}
+
+// Remove removes the given digest from the set. An err will be
+// returned if the given digest is invalid. If the digest does
+// not exist in the set, this operation will be a no-op.
+func (dst *Set) Remove(d Digest) error {
+	if err := d.Validate(); err != nil {
+		return err
+	}
+	dst.mutex.Lock()
+	defer dst.mutex.Unlock()
+	entry := &digestEntry{alg: d.Algorithm(), val: d.Hex(), digest: d}
+	searchFunc := func(i int) bool {
+		if dst.entries[i].val == entry.val {
+			return dst.entries[i].alg >= entry.alg
+		}
+		return dst.entries[i].val >= entry.val
+	}
+	idx := sort.Search(len(dst.entries), searchFunc)
+	// Not found if idx is after or value at idx is not digest
+	if idx == len(dst.entries) || dst.entries[idx].digest != d {
+		return nil
+	}
+
+	entries := dst.entries
+	copy(entries[idx:], entries[idx+1:])
+	entries = entries[:len(entries)-1]
+	dst.entries = entries
+
+	return nil
+}
+
+// All returns all the digests in the set
+func (dst *Set) All() []Digest {
+	dst.mutex.RLock()
+	defer dst.mutex.RUnlock()
+	retValues := make([]Digest, len(dst.entries))
+	for i := range dst.entries {
+		retValues[i] = dst.entries[i].digest
+	}
+
+	return retValues
+}
+
+// ShortCodeTable returns a map of Digest to unique short codes. The
+// length represents the minimum value, the maximum length may be the
+// entire value of digest if uniqueness cannot be achieved without the
+// full value. This function will attempt to make short codes as short
+// as possible to be unique.
+func ShortCodeTable(dst *Set, length int) map[Digest]string {
+	dst.mutex.RLock()
+	defer dst.mutex.RUnlock()
+	m := make(map[Digest]string, len(dst.entries))
+	l := length
+	resetIdx := 0
+	for i := 0; i < len(dst.entries); i++ {
+		var short string
+		extended := true
+		for extended {
+			extended = false
+			if len(dst.entries[i].val) <= l {
+				short = dst.entries[i].digest.String()
+			} else {
+				short = dst.entries[i].val[:l]
+				for j := i + 1; j < len(dst.entries); j++ {
+					if checkShortMatch(dst.entries[j].alg, dst.entries[j].val, "", short) {
+						if j > resetIdx {
+							resetIdx = j
+						}
+						extended = true
+					} else {
+						break
+					}
+				}
+				if extended {
+					l++
+				}
+			}
+		}
+		m[dst.entries[i].digest] = short
+		if i >= resetIdx {
+			l = length
+		}
+	}
+	return m
+}
+
+type digestEntry struct {
+	alg    Algorithm
+	val    string
+	digest Digest
+}
+
+type digestEntries []*digestEntry
+
+func (d digestEntries) Len() int {
+	return len(d)
+}
+
+func (d digestEntries) Less(i, j int) bool {
+	if d[i].val != d[j].val {
+		return d[i].val < d[j].val
+	}
+	return d[i].alg < d[j].alg
+}
+
+func (d digestEntries) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/digest/verifiers.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/digest/verifiers.go
@@ -1,0 +1,44 @@
+package digest
+
+import (
+	"hash"
+	"io"
+)
+
+// Verifier presents a general verification interface to be used with message
+// digests and other byte stream verifications. Users instantiate a Verifier
+// from one of the various methods, write the data under test to it then check
+// the result with the Verified method.
+type Verifier interface {
+	io.Writer
+
+	// Verified will return true if the content written to Verifier matches
+	// the digest.
+	Verified() bool
+}
+
+// NewDigestVerifier returns a verifier that compares the written bytes
+// against a passed in digest.
+func NewDigestVerifier(d Digest) (Verifier, error) {
+	if err := d.Validate(); err != nil {
+		return nil, err
+	}
+
+	return hashVerifier{
+		hash:   d.Algorithm().Hash(),
+		digest: d,
+	}, nil
+}
+
+type hashVerifier struct {
+	digest Digest
+	hash   hash.Hash
+}
+
+func (hv hashVerifier) Write(p []byte) (n int, err error) {
+	return hv.hash.Write(p)
+}
+
+func (hv hashVerifier) Verified() bool {
+	return hv.digest == NewDigest(hv.digest.Algorithm(), hv.hash)
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/reference/reference.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/reference/reference.go
@@ -1,0 +1,334 @@
+// Package reference provides a general type to represent any way of referencing images within the registry.
+// Its main purpose is to abstract tags and digests (content-addressable hash).
+//
+// Grammar
+//
+// 	reference                       := name [ ":" tag ] [ "@" digest ]
+//	name                            := [hostname '/'] component ['/' component]*
+//	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
+//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+//	port-number                     := /[0-9]+/
+//	component                       := alpha-numeric [separator alpha-numeric]*
+// 	alpha-numeric                   := /[a-z0-9]+/
+//	separator                       := /[_.]|__|[-]*/
+//
+//	tag                             := /[\w][\w.-]{0,127}/
+//
+//	digest                          := digest-algorithm ":" digest-hex
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm-separator      := /[+.-_]/
+//	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+//	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+package reference
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/docker/distribution/digest"
+)
+
+const (
+	// NameTotalLengthMax is the maximum total number of characters in a repository name.
+	NameTotalLengthMax = 255
+)
+
+var (
+	// ErrReferenceInvalidFormat represents an error while trying to parse a string as a reference.
+	ErrReferenceInvalidFormat = errors.New("invalid reference format")
+
+	// ErrTagInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrTagInvalidFormat = errors.New("invalid tag format")
+
+	// ErrDigestInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrDigestInvalidFormat = errors.New("invalid digest format")
+
+	// ErrNameEmpty is returned for empty, invalid repository names.
+	ErrNameEmpty = errors.New("repository name must have at least one component")
+
+	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
+	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+)
+
+// Reference is an opaque object reference identifier that may include
+// modifiers such as a hostname, name, tag, and digest.
+type Reference interface {
+	// String returns the full reference
+	String() string
+}
+
+// Field provides a wrapper type for resolving correct reference types when
+// working with encoding.
+type Field struct {
+	reference Reference
+}
+
+// AsField wraps a reference in a Field for encoding.
+func AsField(reference Reference) Field {
+	return Field{reference}
+}
+
+// Reference unwraps the reference type from the field to
+// return the Reference object. This object should be
+// of the appropriate type to further check for different
+// reference types.
+func (f Field) Reference() Reference {
+	return f.reference
+}
+
+// MarshalText serializes the field to byte text which
+// is the string of the reference.
+func (f Field) MarshalText() (p []byte, err error) {
+	return []byte(f.reference.String()), nil
+}
+
+// UnmarshalText parses text bytes by invoking the
+// reference parser to ensure the appropriately
+// typed reference object is wrapped by field.
+func (f *Field) UnmarshalText(p []byte) error {
+	r, err := Parse(string(p))
+	if err != nil {
+		return err
+	}
+
+	f.reference = r
+	return nil
+}
+
+// Named is an object with a full name
+type Named interface {
+	Reference
+	Name() string
+}
+
+// Tagged is an object which has a tag
+type Tagged interface {
+	Reference
+	Tag() string
+}
+
+// NamedTagged is an object including a name and tag.
+type NamedTagged interface {
+	Named
+	Tag() string
+}
+
+// Digested is an object which has a digest
+// in which it can be referenced by
+type Digested interface {
+	Reference
+	Digest() digest.Digest
+}
+
+// Canonical reference is an object with a fully unique
+// name including a name with hostname and digest
+type Canonical interface {
+	Named
+	Digest() digest.Digest
+}
+
+// SplitHostname splits a named reference into a
+// hostname and name string. If no valid hostname is
+// found, the hostname is empty and the full value
+// is returned as name
+func SplitHostname(named Named) (string, string) {
+	name := named.Name()
+	match := anchoredNameRegexp.FindStringSubmatch(name)
+	if match == nil || len(match) != 3 {
+		return "", name
+	}
+	return match[1], match[2]
+}
+
+// Parse parses s and returns a syntactically valid Reference.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: Parse will not handle short digests.
+func Parse(s string) (Reference, error) {
+	matches := ReferenceRegexp.FindStringSubmatch(s)
+	if matches == nil {
+		if s == "" {
+			return nil, ErrNameEmpty
+		}
+		// TODO(dmcgowan): Provide more specific and helpful error
+		return nil, ErrReferenceInvalidFormat
+	}
+
+	if len(matches[1]) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
+	ref := reference{
+		name: matches[1],
+		tag:  matches[2],
+	}
+	if matches[3] != "" {
+		var err error
+		ref.digest, err = digest.ParseDigest(matches[3])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	r := getBestReferenceType(ref)
+	if r == nil {
+		return nil, ErrNameEmpty
+	}
+
+	return r, nil
+}
+
+// ParseNamed parses s and returns a syntactically valid reference implementing
+// the Named interface. The reference must have a name, otherwise an error is
+// returned.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: ParseNamed will not handle short digests.
+func ParseNamed(s string) (Named, error) {
+	ref, err := Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	named, isNamed := ref.(Named)
+	if !isNamed {
+		return nil, fmt.Errorf("reference %s has no name", ref.String())
+	}
+	return named, nil
+}
+
+// WithName returns a named object representing the given string. If the input
+// is invalid ErrReferenceInvalidFormat will be returned.
+func WithName(name string) (Named, error) {
+	if len(name) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+	if !anchoredNameRegexp.MatchString(name) {
+		return nil, ErrReferenceInvalidFormat
+	}
+	return repository(name), nil
+}
+
+// WithTag combines the name from "name" and the tag from "tag" to form a
+// reference incorporating both the name and the tag.
+func WithTag(name Named, tag string) (NamedTagged, error) {
+	if !anchoredTagRegexp.MatchString(tag) {
+		return nil, ErrTagInvalidFormat
+	}
+	return taggedReference{
+		name: name.Name(),
+		tag:  tag,
+	}, nil
+}
+
+// WithDigest combines the name from "name" and the digest from "digest" to form
+// a reference incorporating both the name and the digest.
+func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
+	if !anchoredDigestRegexp.MatchString(digest.String()) {
+		return nil, ErrDigestInvalidFormat
+	}
+	return canonicalReference{
+		name:   name.Name(),
+		digest: digest,
+	}, nil
+}
+
+func getBestReferenceType(ref reference) Reference {
+	if ref.name == "" {
+		// Allow digest only references
+		if ref.digest != "" {
+			return digestReference(ref.digest)
+		}
+		return nil
+	}
+	if ref.tag == "" {
+		if ref.digest != "" {
+			return canonicalReference{
+				name:   ref.name,
+				digest: ref.digest,
+			}
+		}
+		return repository(ref.name)
+	}
+	if ref.digest == "" {
+		return taggedReference{
+			name: ref.name,
+			tag:  ref.tag,
+		}
+	}
+
+	return ref
+}
+
+type reference struct {
+	name   string
+	tag    string
+	digest digest.Digest
+}
+
+func (r reference) String() string {
+	return r.name + ":" + r.tag + "@" + r.digest.String()
+}
+
+func (r reference) Name() string {
+	return r.name
+}
+
+func (r reference) Tag() string {
+	return r.tag
+}
+
+func (r reference) Digest() digest.Digest {
+	return r.digest
+}
+
+type repository string
+
+func (r repository) String() string {
+	return string(r)
+}
+
+func (r repository) Name() string {
+	return string(r)
+}
+
+type digestReference digest.Digest
+
+func (d digestReference) String() string {
+	return d.String()
+}
+
+func (d digestReference) Digest() digest.Digest {
+	return digest.Digest(d)
+}
+
+type taggedReference struct {
+	name string
+	tag  string
+}
+
+func (t taggedReference) String() string {
+	return t.name + ":" + t.tag
+}
+
+func (t taggedReference) Name() string {
+	return t.name
+}
+
+func (t taggedReference) Tag() string {
+	return t.tag
+}
+
+type canonicalReference struct {
+	name   string
+	digest digest.Digest
+}
+
+func (c canonicalReference) String() string {
+	return c.name + "@" + c.digest.String()
+}
+
+func (c canonicalReference) Name() string {
+	return c.name
+}
+
+func (c canonicalReference) Digest() digest.Digest {
+	return c.digest
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/reference/regexp.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/reference/regexp.go
@@ -1,0 +1,124 @@
+package reference
+
+import "regexp"
+
+var (
+	// alphaNumericRegexp defines the alpha numeric atom, typically a
+	// component of names. This only allows lower case characters and digits.
+	alphaNumericRegexp = match(`[a-z0-9]+`)
+
+	// separatorRegexp defines the separators allowed to be embedded in name
+	// components. This allow one period, one or two underscore and multiple
+	// dashes.
+	separatorRegexp = match(`(?:[._]|__|[-]*)`)
+
+	// nameComponentRegexp restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one period, one or two underscore and multiple dashes.
+	nameComponentRegexp = expression(
+		alphaNumericRegexp,
+		optional(repeated(separatorRegexp, alphaNumericRegexp)))
+
+	// hostnameComponentRegexp restricts the registry hostname component of a
+	// repository name to start with a component as defined by hostnameRegexp
+	// and followed by an optional port.
+	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+
+	// hostnameRegexp defines the structure of potential hostname components
+	// that may be part of image names. This is purposely a subset of what is
+	// allowed by DNS to ensure backwards compatibility with Docker image
+	// names.
+	hostnameRegexp = expression(
+		hostnameComponentRegexp,
+		optional(repeated(literal(`.`), hostnameComponentRegexp)),
+		optional(literal(`:`), match(`[0-9]+`)))
+
+	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
+	TagRegexp = match(`[\w][\w.-]{0,127}`)
+
+	// anchoredTagRegexp matches valid tag names, anchored at the start and
+	// end of the matched string.
+	anchoredTagRegexp = anchored(TagRegexp)
+
+	// DigestRegexp matches valid digests.
+	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
+
+	// anchoredDigestRegexp matches valid digests, anchored at the start and
+	// end of the matched string.
+	anchoredDigestRegexp = anchored(DigestRegexp)
+
+	// NameRegexp is the format for the name component of references. The
+	// regexp has capturing groups for the hostname and name part omitting
+	// the separating forward slash from either.
+	NameRegexp = expression(
+		optional(hostnameRegexp, literal(`/`)),
+		nameComponentRegexp,
+		optional(repeated(literal(`/`), nameComponentRegexp)))
+
+	// anchoredNameRegexp is used to parse a name value, capturing the
+	// hostname and trailing components.
+	anchoredNameRegexp = anchored(
+		optional(capture(hostnameRegexp), literal(`/`)),
+		capture(nameComponentRegexp,
+			optional(repeated(literal(`/`), nameComponentRegexp))))
+
+	// ReferenceRegexp is the full supported format of a reference. The regexp
+	// is anchored and has capturing groups for name, tag, and digest
+	// components.
+	ReferenceRegexp = anchored(capture(NameRegexp),
+		optional(literal(":"), capture(TagRegexp)),
+		optional(literal("@"), capture(DigestRegexp)))
+)
+
+// match compiles the string to a regular expression.
+var match = regexp.MustCompile
+
+// literal compiles s into a literal regular expression, escaping any regexp
+// reserved characters.
+func literal(s string) *regexp.Regexp {
+	re := match(regexp.QuoteMeta(s))
+
+	if _, complete := re.LiteralPrefix(); !complete {
+		panic("must be a literal")
+	}
+
+	return re
+}
+
+// expression defines a full expression, where each regular expression must
+// follow the previous.
+func expression(res ...*regexp.Regexp) *regexp.Regexp {
+	var s string
+	for _, re := range res {
+		s += re.String()
+	}
+
+	return match(s)
+}
+
+// optional wraps the expression in a non-capturing group and makes the
+// production optional.
+func optional(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `?`)
+}
+
+// repeated wraps the regexp in a non-capturing group to get one or more
+// matches.
+func repeated(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `+`)
+}
+
+// group wraps the regexp in a non-capturing group.
+func group(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `)`)
+}
+
+// capture wraps the expression in a capturing group.
+func capture(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(` + expression(res...).String() + `)`)
+}
+
+// anchored anchors the regular expression by adding start and end delimiters.
+func anchored(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`^` + expression(res...).String() + `$`)
+}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -647,7 +647,7 @@ func postImagesCreate(c *context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if image := r.Form.Get("fromImage"); image != "" { //pull
-		authConfig := dockerclient.AuthConfig{}
+		authConfig := apitypes.AuthConfig{}
 		buf, err := base64.URLEncoding.DecodeString(r.Header.Get("X-Registry-Auth"))
 		if err == nil {
 			json.Unmarshal(buf, &authConfig)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -57,7 +57,7 @@ type Cluster interface {
 	// `callback` can be called multiple time
 	//  `where` is where it is being pulled
 	//  `status` is the current status, like "", "in progress" or "downloaded
-	Pull(name string, authConfig *dockerclient.AuthConfig, callback func(where, status string, err error))
+	Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error))
 
 	// Import image
 	// `callback` can be called multiple time

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -10,7 +10,7 @@ import (
 // Cluster is exported
 type Cluster interface {
 	// Create a container
-	CreateContainer(config *ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*Container, error)
+	CreateContainer(config *ContainerConfig, name string, authConfig *types.AuthConfig) (*Container, error)
 
 	// Remove a container
 	RemoveContainer(container *Container, force, volumes bool) error

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
 )
 
 // SwarmLabelNamespace defines the key prefix in all custom labels
@@ -15,7 +16,10 @@ const SwarmLabelNamespace = "com.docker.swarm"
 // ContainerConfig is exported
 // TODO store affinities and constraints in their own fields
 type ContainerConfig struct {
-	dockerclient.ContainerConfig
+	// dockerclient.ContainerConfig
+	container.Config
+	container.HostConfig
+	network.NetworkingConfig
 }
 
 func parseEnv(e string) (bool, string, string) {
@@ -26,44 +30,8 @@ func parseEnv(e string) (bool, string, string) {
 	return false, "", ""
 }
 
-// FIXME: Temporary fix to handle forward/backward compatibility between Docker <1.6 and >=1.7
-// ContainerConfig should be handling converting to/from different docker versions
-func consolidateResourceFields(c *dockerclient.ContainerConfig) {
-	if c.Memory != c.HostConfig.Memory {
-		if c.Memory != 0 {
-			c.HostConfig.Memory = c.Memory
-		} else {
-			c.Memory = c.HostConfig.Memory
-		}
-	}
-
-	if c.MemorySwap != c.HostConfig.MemorySwap {
-		if c.MemorySwap != 0 {
-			c.HostConfig.MemorySwap = c.MemorySwap
-		} else {
-			c.MemorySwap = c.HostConfig.MemorySwap
-		}
-	}
-
-	if c.CpuShares != c.HostConfig.CpuShares {
-		if c.CpuShares != 0 {
-			c.HostConfig.CpuShares = c.CpuShares
-		} else {
-			c.CpuShares = c.HostConfig.CpuShares
-		}
-	}
-
-	if c.Cpuset != c.HostConfig.CpusetCpus {
-		if c.Cpuset != "" {
-			c.HostConfig.CpusetCpus = c.Cpuset
-		} else {
-			c.Cpuset = c.HostConfig.CpusetCpus
-		}
-	}
-}
-
-// BuildContainerConfig creates a cluster.ContainerConfig from a dockerclient.ContainerConfig
-func BuildContainerConfig(c dockerclient.ContainerConfig) *ContainerConfig {
+// BuildContainerConfig creates a cluster.ContainerConfig from a Config, HostConfig, and NetworkingConfig
+func BuildContainerConfig(c container.Config, h container.HostConfig, n network.NetworkingConfig) *ContainerConfig {
 	var (
 		affinities         []string
 		constraints        []string
@@ -128,9 +96,7 @@ func BuildContainerConfig(c dockerclient.ContainerConfig) *ContainerConfig {
 		}
 	}
 
-	consolidateResourceFields(&c)
-
-	return &ContainerConfig{c}
+	return &ContainerConfig{c, h, n}
 }
 
 func (c *ContainerConfig) extractExprs(key string) []string {

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -16,10 +16,9 @@ const SwarmLabelNamespace = "com.docker.swarm"
 // ContainerConfig is exported
 // TODO store affinities and constraints in their own fields
 type ContainerConfig struct {
-	// dockerclient.ContainerConfig
 	container.Config
-	container.HostConfig
-	network.NetworkingConfig
+	HostConfig       container.HostConfig
+	NetworkingConfig network.NetworkingConfig
 }
 
 func parseEnv(e string) (bool, string, string) {

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -21,12 +21,49 @@ type ContainerConfig struct {
 	NetworkingConfig network.NetworkingConfig
 }
 
+// OldContainerConfig contains additional fields for backward compatibility
+// This should be removed after we stop supporting API versions <= 1.8
+type OldContainerConfig struct {
+	ContainerConfig
+	Memory     int64
+	MemorySwap int64
+	CPUShares  int64  `json:"CpuShares"`
+	CPUSet     string `json:"Cpuset"`
+}
+
 func parseEnv(e string) (bool, string, string) {
 	parts := strings.SplitN(e, ":", 2)
 	if len(parts) == 2 {
 		return true, parts[0], parts[1]
 	}
 	return false, "", ""
+}
+
+// ConsolidateResourceFields is a temporary fix to handle forward/backward compatibility between Docker <1.6 and >=1.7
+func ConsolidateResourceFields(c *OldContainerConfig) {
+	if c.Memory != c.HostConfig.Memory {
+		if c.Memory != 0 {
+			c.HostConfig.Memory = c.Memory
+		}
+	}
+
+	if c.MemorySwap != c.HostConfig.MemorySwap {
+		if c.MemorySwap != 0 {
+			c.HostConfig.MemorySwap = c.MemorySwap
+		}
+	}
+
+	if c.CPUShares != c.HostConfig.CPUShares {
+		if c.CPUShares != 0 {
+			c.HostConfig.CPUShares = c.CPUShares
+		}
+	}
+
+	if c.CPUSet != c.HostConfig.CpusetCpus {
+		if c.CPUSet != "" {
+			c.HostConfig.CpusetCpus = c.CPUSet
+		}
+	}
 }
 
 // BuildContainerConfig creates a cluster.ContainerConfig from a Config, HostConfig, and NetworkingConfig

--- a/cluster/config_test.go
+++ b/cluster/config_test.go
@@ -69,10 +69,10 @@ func TestAffinities(t *testing.T) {
 func TestConsolidateResourceFields(t *testing.T) {
 
 	config := BuildContainerConfig(container.Config{}, container.HostConfig{Resources: container.Resources{Memory: 4242, MemorySwap: 4343, CPUShares: 4444, CpusetCpus: "1-2"}}, network.NetworkingConfig{})
-	assert.Equal(t, config.Memory, int64(4242))
-	assert.Equal(t, config.MemorySwap, int64(4343))
-	assert.Equal(t, config.CPUShares, int64(4444))
-	assert.Equal(t, config.CpusetCpus, "1-2")
+	assert.Equal(t, config.HostConfig.Memory, int64(4242))
+	assert.Equal(t, config.HostConfig.MemorySwap, int64(4343))
+	assert.Equal(t, config.HostConfig.CPUShares, int64(4444))
+	assert.Equal(t, config.HostConfig.CpusetCpus, "1-2")
 }
 
 func TestAddAffinity(t *testing.T) {

--- a/cluster/config_test.go
+++ b/cluster/config_test.go
@@ -3,87 +3,80 @@ package cluster
 import (
 	"testing"
 
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildContainerConfig(t *testing.T) {
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Env)
 	assert.Empty(t, config.Labels)
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"test=true"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"test=true"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Len(t, config.Env, 1)
 	assert.Empty(t, config.Labels)
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:test==true"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"constraint:test==true"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Env)
 	assert.Len(t, config.Labels, 1)
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"affinity:container==test"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"affinity:container==test"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Env)
 	assert.Len(t, config.Labels, 1)
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"test=true", "constraint:test==true", "affinity:container==test"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"test=true", "constraint:test==true", "affinity:container==test"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Len(t, config.Env, 1)
 	assert.Len(t, config.Labels, 2)
 }
 
 func TestSwarmID(t *testing.T) {
 	// Getter / Setter
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.SwarmID())
 	config.SetSwarmID("foo")
 	assert.Equal(t, config.SwarmID(), "foo")
 	assert.Equal(t, config.Labels[SwarmLabelNamespace+".id"], "foo")
 
 	// Retrieve an existing ID.
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Labels: map[string]string{SwarmLabelNamespace + ".id": "test"}})
+	config = BuildContainerConfig(container.Config{Labels: map[string]string{SwarmLabelNamespace + ".id": "test"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Equal(t, config.SwarmID(), "test")
 }
 
 func TestConstraints(t *testing.T) {
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Constraints())
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:test==true"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"constraint:test==true"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Len(t, config.Constraints(), 1)
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"test=true", "constraint:test==true", "affinity:container==test"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"test=true", "constraint:test==true", "affinity:container==test"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Len(t, config.Constraints(), 1)
 }
 
 func TestAffinities(t *testing.T) {
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Affinities())
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"affinity:container==test"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"affinity:container==test"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Len(t, config.Affinities(), 1)
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"test=true", "constraint:test==true", "affinity:container==test"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"test=true", "constraint:test==true", "affinity:container==test"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Len(t, config.Affinities(), 1)
 	assert.Equal(t, len(config.Affinities()), 1)
 }
 
 func TestConsolidateResourceFields(t *testing.T) {
-	for _, config := range []*ContainerConfig{
-		BuildContainerConfig(dockerclient.ContainerConfig{Memory: 4242, MemorySwap: 4343, CpuShares: 4444, Cpuset: "1-2"}),
-		BuildContainerConfig(dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{Memory: 4242, MemorySwap: 4343, CpuShares: 4444, CpusetCpus: "1-2"}}),
-	} {
-		assert.Equal(t, config.Memory, int64(4242))
-		assert.Equal(t, config.MemorySwap, int64(4343))
-		assert.Equal(t, config.CpuShares, int64(4444))
-		assert.Equal(t, config.Cpuset, "1-2")
-		assert.Equal(t, config.HostConfig.Memory, int64(4242))
-		assert.Equal(t, config.HostConfig.MemorySwap, int64(4343))
-		assert.Equal(t, config.HostConfig.CpuShares, int64(4444))
-		assert.Equal(t, config.HostConfig.CpusetCpus, "1-2")
-	}
 
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{Resources: container.Resources{Memory: 4242, MemorySwap: 4343, CPUShares: 4444, CpusetCpus: "1-2"}}, network.NetworkingConfig{})
+	assert.Equal(t, config.Memory, int64(4242))
+	assert.Equal(t, config.MemorySwap, int64(4343))
+	assert.Equal(t, config.CPUShares, int64(4444))
+	assert.Equal(t, config.CpusetCpus, "1-2")
 }
 
 func TestAddAffinity(t *testing.T) {
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Affinities())
 
 	config.AddAffinity("image==~testimage")
@@ -91,7 +84,7 @@ func TestAddAffinity(t *testing.T) {
 }
 
 func TestRemoveAffinity(t *testing.T) {
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.Empty(t, config.Affinities())
 
 	config.AddAffinity("image==~testimage1")
@@ -105,9 +98,9 @@ func TestRemoveAffinity(t *testing.T) {
 }
 
 func TestHaveNodeConstraint(t *testing.T) {
-	config := BuildContainerConfig(dockerclient.ContainerConfig{})
+	config := BuildContainerConfig(container.Config{}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.False(t, config.HaveNodeConstraint())
 
-	config = BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==node1"}})
+	config = BuildContainerConfig(container.Config{Env: []string{"constraint:node==node1"}}, container.HostConfig{}, network.NetworkingConfig{})
 	assert.True(t, config.HaveNodeConstraint())
 }

--- a/cluster/container.go
+++ b/cluster/container.go
@@ -4,21 +4,21 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types"
 )
 
 // Container is exported
 type Container struct {
-	dockerclient.Container
+	types.Container
 
 	Config *ContainerConfig
-	Info   dockerclient.ContainerInfo
+	Info   types.ContainerJSON
 	Engine *Engine
 }
 
 // Refresh container
 func (c *Container) Refresh() (*Container, error) {
-	return c.Engine.refreshContainer(c.Id, true)
+	return c.Engine.refreshContainer(c.ID, true)
 }
 
 // Containers represents a list of containers
@@ -33,7 +33,7 @@ func (containers Containers) Get(IDOrName string) *Container {
 
 	// Match exact or short Container ID.
 	for _, container := range containers {
-		if container.Id == IDOrName || stringid.TruncateID(container.Id) == IDOrName {
+		if container.ID == IDOrName || stringid.TruncateID(container.ID) == IDOrName {
 			return container
 		}
 	}
@@ -68,7 +68,7 @@ func (containers Containers) Get(IDOrName string) *Container {
 
 	// Match Container ID prefix.
 	for _, container := range containers {
-		if strings.HasPrefix(container.Id, IDOrName) {
+		if strings.HasPrefix(container.ID, IDOrName) {
 			candidates = append(candidates, container)
 		}
 	}

--- a/cluster/container.go
+++ b/cluster/container.go
@@ -21,6 +21,7 @@ type Container struct {
 
 // StateString returns a single string to describe state
 func StateString(state *types.ContainerState) string {
+	startedAt, _ := time.Parse(time.RFC3339Nano, state.StartedAt)
 	if state.Running {
 		if state.Paused {
 			return "paused"
@@ -33,6 +34,10 @@ func StateString(state *types.ContainerState) string {
 
 	if state.Dead {
 		return "dead"
+	}
+
+	if startedAt.IsZero() {
+		return "created"
 	}
 
 	return "exited"
@@ -54,6 +59,10 @@ func FullStateString(state *types.ContainerState) string {
 
 	if state.Dead {
 		return "Dead"
+	}
+
+	if startedAt.IsZero() {
+		return "Created"
 	}
 
 	if finishedAt.IsZero() {

--- a/cluster/container_test.go
+++ b/cluster/container_test.go
@@ -3,33 +3,35 @@ package cluster
 import (
 	"testing"
 
-	"github.com/samalba/dockerclient"
+	"github.com/docker/engine-api/types"
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContainersGet(t *testing.T) {
 	containers := Containers([]*Container{{
-		Container: dockerclient.Container{
-			Id:    "container1-id",
+		Container: types.Container{
+			ID:    "container1-id",
 			Names: []string{"/container1-name1", "/container1-name2"},
 		},
 		Engine: &Engine{ID: "test-engine"},
-		Config: BuildContainerConfig(dockerclient.ContainerConfig{
+		Config: BuildContainerConfig(containertypes.Config{
 			Labels: map[string]string{
 				"com.docker.swarm.id": "swarm1-id",
 			},
-		}),
+		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
 	}, {
-		Container: dockerclient.Container{
-			Id:    "container2-id",
+		Container: types.Container{
+			ID:    "container2-id",
 			Names: []string{"/con"},
 		},
 		Engine: &Engine{ID: "test-engine"},
-		Config: BuildContainerConfig(dockerclient.ContainerConfig{
+		Config: BuildContainerConfig(containertypes.Config{
 			Labels: map[string]string{
 				"com.docker.swarm.id": "swarm2-id",
 			},
-		}),
+		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
 	}})
 
 	// Invalid lookup
@@ -54,5 +56,5 @@ func TestContainersGet(t *testing.T) {
 	// Get name before ID prefix
 	cc := containers.Get("con")
 	assert.NotNil(t, cc)
-	assert.Equal(t, cc.Id, "container2-id")
+	assert.Equal(t, cc.ID, "container2-id")
 }

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -989,22 +989,18 @@ func (e *Engine) Pull(image string, authConfig *types.AuthConfig) error {
 
 	// wait until the image download is finished
 	dec := json.NewDecoder(pullResponse)
+	m := map[string]interface{}{}
 	for {
-		m := map[string]interface{}{}
-		err := dec.Decode(&m)
-		if err != nil {
+		if err := dec.Decode(&m); err != nil {
 			if err == io.EOF {
 				break
 			}
 			return err
 		}
-		// if the stream contains an error, return it
-		if val, ok := m["error"]; ok {
-			if errmsg, strok := val.(string); strok {
-				return errors.New(errmsg)
-			}
-			return errors.New("Error while downloading image")
-		}
+	}
+	// if the final stream object contained an error, return it
+	if errMsg, ok := m["error"]; ok {
+		return fmt.Errorf("%v", errMsg)
 	}
 
 	// force refresh images

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -728,7 +728,7 @@ func (e *Engine) updateContainer(c types.Container, containers map[string]*Conta
 		// Convert the ContainerConfig from inspect into our own
 		// cluster.ContainerConfig.
 
-		info.HostConfig.CPUShares = info.HostConfig.CPUShares * int64(e.Cpus) / 1024.0
+		// info.HostConfig.CPUShares = info.HostConfig.CPUShares * int64(e.Cpus) / 1024.0
 		networkingConfig := networktypes.NetworkingConfig{
 			EndpointsConfig: info.NetworkSettings.Networks,
 		}
@@ -878,7 +878,7 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, au
 	e.CheckConnectionErr(err)
 	if err != nil {
 		// If the error is other than not found, abort immediately.
-		if err != dockerclient.ErrImageNotFound || !pullImage {
+		if (err != dockerclient.ErrImageNotFound && !engineapi.IsErrImageNotFound(err)) || !pullImage {
 			return nil, err
 		}
 		// Otherwise, try to pull the image...

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -991,11 +991,19 @@ func (e *Engine) Pull(image string, authConfig *types.AuthConfig) error {
 	dec := json.NewDecoder(pullResponse)
 	for {
 		m := map[string]interface{}{}
-		if err := dec.Decode(&m); err != nil {
+		err := dec.Decode(&m)
+		if err != nil {
 			if err == io.EOF {
 				break
 			}
 			return err
+		}
+		// if the stream contains an error, return it
+		if val, ok := m["error"]; ok {
+			if errmsg, strok := val.(string); strok {
+				return errors.New(errmsg)
+			}
+			return errors.New("Error while downloading image")
 		}
 	}
 

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -20,6 +20,7 @@ import (
 	engineapi "github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	networktypes "github.com/docker/engine-api/types/network"
 	engineapinop "github.com/docker/swarm/api/nopclient"
 	"github.com/samalba/dockerclient"
 	"github.com/samalba/dockerclient/nopclient"
@@ -627,7 +628,11 @@ func (e *Engine) RefreshVolumes() error {
 // true, each container will be inspected.
 // FIXME: unexport this method after mesos scheduler stops using it directly
 func (e *Engine) RefreshContainers(full bool) error {
-	containers, err := e.client.ListContainers(true, false, "")
+	opts := types.ContainerListOptions{
+		All:  true,
+		Size: false,
+	}
+	containers, err := e.apiClient.ContainerList(opts)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -637,7 +642,7 @@ func (e *Engine) RefreshContainers(full bool) error {
 	for _, c := range containers {
 		mergedUpdate, err := e.updateContainer(c, merged, full)
 		if err != nil {
-			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Unable to update state of container %q: %v", c.Id, err)
+			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Unable to update state of container %q: %v", c.ID, err)
 		} else {
 			merged = mergedUpdate
 		}
@@ -653,7 +658,14 @@ func (e *Engine) RefreshContainers(full bool) error {
 // Refresh the status of a container running on the engine. If `full` is true,
 // the container will be inspected.
 func (e *Engine) refreshContainer(ID string, full bool) (*Container, error) {
-	containers, err := e.client.ListContainers(true, false, fmt.Sprintf("{%q:[%q]}", "id", ID))
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("id", ID)
+	opts := types.ContainerListOptions{
+		All:    true,
+		Size:   false,
+		Filter: filterArgs,
+	}
+	containers, err := e.apiClient.ContainerList(opts)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return nil, err
@@ -676,16 +688,16 @@ func (e *Engine) refreshContainer(ID string, full bool) (*Container, error) {
 
 	_, err = e.updateContainer(containers[0], e.containers, full)
 	e.RLock()
-	container := e.containers[containers[0].Id]
+	container := e.containers[containers[0].ID]
 	e.RUnlock()
 	return container, err
 }
 
-func (e *Engine) updateContainer(c dockerclient.Container, containers map[string]*Container, full bool) (map[string]*Container, error) {
+func (e *Engine) updateContainer(c types.Container, containers map[string]*Container, full bool) (map[string]*Container, error) {
 	var container *Container
 
 	e.RLock()
-	if current, exists := e.containers[c.Id]; exists {
+	if current, exists := e.containers[c.ID]; exists {
 		// The container is already known.
 		container = current
 		// Restarting is a transit state. Unfortunately Docker doesn't always emit
@@ -708,30 +720,30 @@ func (e *Engine) updateContainer(c dockerclient.Container, containers map[string
 
 	// Update ContainerInfo.
 	if full {
-		info, err := e.client.InspectContainer(c.Id)
+		info, err := e.apiClient.ContainerInspect(c.ID)
 		e.CheckConnectionErr(err)
 		if err != nil {
 			return nil, err
 		}
 		// Convert the ContainerConfig from inspect into our own
 		// cluster.ContainerConfig.
-		if info.HostConfig != nil {
-			info.Config.HostConfig = *info.HostConfig
-		}
-		container.Config = BuildContainerConfig(*info.Config)
 
-		// FIXME remove "duplicate" lines and move this to cluster/config.go
-		container.Config.CpuShares = container.Config.CpuShares * int64(e.Cpus) / 1024.0
-		container.Config.HostConfig.CpuShares = container.Config.CpuShares
+		info.HostConfig.CPUShares = info.HostConfig.CPUShares * int64(e.Cpus) / 1024.0
+		networkingConfig := networktypes.NetworkingConfig{
+			EndpointsConfig: info.NetworkSettings.Networks,
+		}
+		container.Config = BuildContainerConfig(*info.Config, *info.HostConfig, networkingConfig)
+		// FIXME remove "duplicate" line and move this to cluster/config.go
+		container.Config.CPUShares = container.Config.CPUShares * int64(e.Cpus) / 1024.0
 
 		// Save the entire inspect back into the container.
-		container.Info = *info
+		container.Info = info
 	}
 
 	// Update its internal state.
 	e.Lock()
 	container.Container = c
-	containers[container.Id] = container
+	containers[container.ID] = container
 	e.Unlock()
 
 	return containers, nil
@@ -829,7 +841,7 @@ func (e *Engine) UsedCpus() int64 {
 	var r int64
 	e.RLock()
 	for _, c := range e.containers {
-		r += c.Config.CpuShares
+		r += c.Config.CPUShares
 	}
 	e.RUnlock()
 	return r
@@ -848,23 +860,21 @@ func (e *Engine) TotalCpus() int {
 // Create a new container
 func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, authConfig *dockerclient.AuthConfig) (*Container, error) {
 	var (
-		err    error
-		id     string
-		client = e.client
+		err        error
+		createResp types.ContainerCreateResponse
 	)
 
 	// Convert our internal ContainerConfig into something Docker will
 	// understand.  Start by making a copy of the internal ContainerConfig as
 	// we don't want to mess with the original.
-	dockerConfig := config.ContainerConfig
+	dockerConfig := config
 
 	// nb of CPUs -> real CpuShares
 
 	// FIXME remove "duplicate" lines and move this to cluster/config.go
-	dockerConfig.CpuShares = int64(math.Ceil(float64(config.CpuShares*1024) / float64(e.Cpus)))
-	dockerConfig.HostConfig.CpuShares = dockerConfig.CpuShares
+	dockerConfig.CPUShares = int64(math.Ceil(float64(config.CPUShares*1024) / float64(e.Cpus)))
 
-	id, err = client.CreateContainer(&dockerConfig, name, nil)
+	createResp, err = e.apiClient.ContainerCreate(&dockerConfig.Config, &dockerConfig.HostConfig, &dockerConfig.NetworkingConfig, name)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		// If the error is other than not found, abort immediately.
@@ -876,7 +886,7 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, au
 			return nil, err
 		}
 		// ...And try again.
-		id, err = client.CreateContainer(&dockerConfig, name, nil)
+		createResp, err = e.apiClient.ContainerCreate(&dockerConfig.Config, &dockerConfig.HostConfig, &dockerConfig.NetworkingConfig, name)
 		e.CheckConnectionErr(err)
 		if err != nil {
 			return nil, err
@@ -885,12 +895,12 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, au
 
 	// Register the container immediately while waiting for a state refresh.
 	// Force a state refresh to pick up the newly created container.
-	e.refreshContainer(id, true)
+	e.refreshContainer(createResp.ID, true)
 	e.RefreshVolumes()
 	e.RefreshNetworks()
 
 	e.Lock()
-	container := e.containers[id]
+	container := e.containers[createResp.ID]
 	e.Unlock()
 
 	if container == nil {
@@ -901,7 +911,7 @@ func (e *Engine) Create(config *ContainerConfig, name string, pullImage bool, au
 
 // RemoveContainer removes a container from the engine.
 func (e *Engine) RemoveContainer(container *Container, force, volumes bool) error {
-	err := e.client.RemoveContainer(container.Id, force, volumes)
+	err := e.client.RemoveContainer(container.ID, force, volumes)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -911,7 +921,7 @@ func (e *Engine) RemoveContainer(container *Container, force, volumes bool) erro
 	// will rewrite this.
 	e.Lock()
 	defer e.Unlock()
-	delete(e.containers, container.Id)
+	delete(e.containers, container.ID)
 
 	return nil
 }
@@ -1112,10 +1122,10 @@ func (e *Engine) AddContainer(container *Container) error {
 	e.Lock()
 	defer e.Unlock()
 
-	if _, ok := e.containers[container.Id]; ok {
+	if _, ok := e.containers[container.ID]; ok {
 		return errors.New("container already exists")
 	}
-	e.containers[container.Id] = container
+	e.containers[container.ID] = container
 	return nil
 }
 
@@ -1132,10 +1142,10 @@ func (e *Engine) removeContainer(container *Container) error {
 	e.Lock()
 	defer e.Unlock()
 
-	if _, ok := e.containers[container.Id]; !ok {
+	if _, ok := e.containers[container.ID]; !ok {
 		return errors.New("container not found")
 	}
-	delete(e.containers, container.Id)
+	delete(e.containers, container.ID)
 	return nil
 }
 
@@ -1162,14 +1172,14 @@ func (e *Engine) StartContainer(id string, hostConfig *dockerclient.HostConfig) 
 // RenameContainer renames a container
 func (e *Engine) RenameContainer(container *Container, newName string) error {
 	// send rename request
-	err := e.client.RenameContainer(container.Id, newName)
+	err := e.client.RenameContainer(container.ID, newName)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
 	}
 
 	// refresh container
-	_, err = e.refreshContainer(container.Id, true)
+	_, err = e.refreshContainer(container.ID, true)
 	return err
 }
 

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -314,8 +314,8 @@ func TestCreateContainer(t *testing.T) {
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
 	assert.True(t, engine.isConnected())
 
-	mockConfig := config
-	mockConfig.CPUShares = int64(math.Ceil(float64(config.CPUShares*1024) / float64(mockInfo.NCPU)))
+	mockConfig := *config
+	mockConfig.HostConfig.CPUShares = int64(math.Ceil(float64(config.HostConfig.CPUShares*1024) / float64(mockInfo.NCPU)))
 
 	// Everything is ok
 	name := "test1"
@@ -334,7 +334,7 @@ func TestCreateContainer(t *testing.T) {
 
 	// Image not found, pullImage == false
 	name = "test2"
-	mockConfig.CPUShares = int64(math.Ceil(float64(config.CPUShares*1024) / float64(mockInfo.NCPU)))
+	mockConfig.HostConfig.CPUShares = int64(math.Ceil(float64(config.HostConfig.CPUShares*1024) / float64(mockInfo.NCPU)))
 	// FIXMEENGINEAPI : below should return an engine-api error, or something custom
 	apiClient.On("ContainerCreate", mock.Anything, &mockConfig.Config, &mockConfig.HostConfig, &mockConfig.NetworkingConfig, name).Return(types.ContainerCreateResponse{}, dockerclient.ErrImageNotFound).Once()
 	container, err = engine.Create(config, name, false, auth)
@@ -345,7 +345,7 @@ func TestCreateContainer(t *testing.T) {
 	name = "test3"
 	id = "id3"
 	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
-	mockConfig.CPUShares = int64(math.Ceil(float64(config.CPUShares*1024) / float64(mockInfo.NCPU)))
+	mockConfig.HostConfig.CPUShares = int64(math.Ceil(float64(config.HostConfig.CPUShares*1024) / float64(mockInfo.NCPU)))
 	apiClient.On("ImagePull", mock.Anything, types.ImagePullOptions{ImageID: config.Image, Tag: "latest"}, mock.Anything).Return(readCloser, nil).Once()
 	// FIXMEENGINEAPI : below should return an engine-api error, or something custom
 	apiClient.On("ContainerCreate", mock.Anything, &mockConfig.Config, &mockConfig.HostConfig, &mockConfig.NetworkingConfig, name).Return(types.ContainerCreateResponse{}, dockerclient.ErrImageNotFound).Once()

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -346,7 +346,7 @@ func TestCreateContainer(t *testing.T) {
 	id = "id3"
 	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 	mockConfig.CPUShares = int64(math.Ceil(float64(config.CPUShares*1024) / float64(mockInfo.NCPU)))
-	apiClient.On("ImagePull", mock.Anything, types.ImagePullOptions{ImageID: config.Image + ":latest"}, mock.Anything).Return(readCloser, nil).Once()
+	apiClient.On("ImagePull", mock.Anything, types.ImagePullOptions{ImageID: config.Image}, mock.Anything).Return(readCloser, nil).Once()
 	// FIXMEENGINEAPI : below should return an engine-api error, or something custom
 	apiClient.On("ContainerCreate", mock.Anything, &mockConfig.Config, &mockConfig.HostConfig, &mockConfig.NetworkingConfig, name).Return(types.ContainerCreateResponse{}, dockerclient.ErrImageNotFound).Once()
 	// FIXMEENGINEAPI : below should return an engine-api error, or something custom

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -293,7 +293,7 @@ func TestCreateContainer(t *testing.T) {
 		engine     = NewEngine("test", 0, engOpts)
 		client     = mockclient.NewMockClient()
 		apiClient  = engineapimock.NewMockClient()
-		readCloser = nopCloser{bytes.NewBufferString("ok")}
+		readCloser = nopCloser{bytes.NewBufferString("")}
 	)
 
 	engine.setState(stateUnhealthy)
@@ -346,7 +346,7 @@ func TestCreateContainer(t *testing.T) {
 	id = "id3"
 	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 	mockConfig.CPUShares = int64(math.Ceil(float64(config.CPUShares*1024) / float64(mockInfo.NCPU)))
-	apiClient.On("ImagePull", mock.Anything, types.ImagePullOptions{ImageID: config.Image}, mock.Anything).Return(readCloser, nil).Once()
+	apiClient.On("ImagePull", mock.Anything, types.ImagePullOptions{ImageID: config.Image, Tag: "latest"}, mock.Anything).Return(readCloser, nil).Once()
 	// FIXMEENGINEAPI : below should return an engine-api error, or something custom
 	apiClient.On("ContainerCreate", mock.Anything, &mockConfig.Config, &mockConfig.HostConfig, &mockConfig.NetworkingConfig, name).Return(types.ContainerCreateResponse{}, dockerclient.ErrImageNotFound).Once()
 	// FIXMEENGINEAPI : below should return an engine-api error, or something custom

--- a/cluster/mesos/agent_test.go
+++ b/cluster/mesos/agent_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/cluster/mesos/task"
 	"github.com/mesos/mesos-go/mesosutil"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,11 +44,11 @@ func TestAddTask(t *testing.T) {
 	assert.Empty(t, s.tasks)
 	assert.True(t, s.empty())
 
-	t1, err := task.NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{}), "task1", 5*time.Second)
+	t1, err := task.NewTask(cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), "task1", 5*time.Second)
 	assert.NoError(t, err)
 	s.addTask(t1)
 
-	t2, err := task.NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{}), "task1", 5*time.Second)
+	t2, err := task.NewTask(cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), "task1", 5*time.Second)
 	assert.NoError(t, err)
 	s.addTask(t2)
 	assert.Equal(t, len(s.tasks), 2)
@@ -81,11 +82,11 @@ func TestRemoveTask(t *testing.T) {
 
 	assert.Empty(t, s.tasks)
 
-	t1, err := task.NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{}), "task1", 5*time.Second)
+	t1, err := task.NewTask(cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), "task1", 5*time.Second)
 	assert.NoError(t, err)
 	s.addTask(t1)
 
-	t2, err := task.NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{}), "task1", 5*time.Second)
+	t2, err := task.NewTask(cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), "task1", 5*time.Second)
 	assert.NoError(t, err)
 	s.addTask(t2)
 	assert.Equal(t, len(s.tasks), 2)

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -192,7 +192,7 @@ func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *docke
 
 // CreateContainer for container creation in Mesos task
 func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *types.AuthConfig) (*cluster.Container, error) {
-	if config.Memory == 0 && config.CPUShares == 0 {
+	if config.HostConfig.Memory == 0 && config.HostConfig.CPUShares == 0 {
 		return nil, errResourcesNeeded
 	}
 

--- a/cluster/mesos/cluster_test.go
+++ b/cluster/mesos/cluster_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/engine-api/types"
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,38 +33,39 @@ func TestContainerLookup(t *testing.T) {
 	c := &Cluster{
 		agents: make(map[string]*agent),
 	}
+
 	container1 := &cluster.Container{
-		Container: dockerclient.Container{
-			Id:    "container1-id",
+		Container: types.Container{
+			ID:    "container1-id",
 			Names: []string{"/container1-name1", "/container1-name2"},
 		},
-		Config: cluster.BuildContainerConfig(dockerclient.ContainerConfig{
+		Config: cluster.BuildContainerConfig(containertypes.Config{
 			Labels: map[string]string{
 				"com.docker.swarm.mesos.task": "task1-id",
-				"com.docker.swarm.mesos.name": "container1-name1",
+				"com.docker.swarm.mesos.name": "container1-name",
 			},
-		}),
+		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
 	}
 
 	container2 := &cluster.Container{
-		Container: dockerclient.Container{
-			Id:    "container2-id",
+		Container: types.Container{
+			ID:    "container2-id",
 			Names: []string{"/con"},
 		},
-		Config: cluster.BuildContainerConfig(dockerclient.ContainerConfig{
+		Config: cluster.BuildContainerConfig(containertypes.Config{
 			Labels: map[string]string{
 				"com.docker.swarm.mesos.task": "task2-id",
 				"com.docker.swarm.mesos.name": "con",
 			},
-		}),
+		}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
 	}
 
 	container3 := &cluster.Container{
-		Container: dockerclient.Container{
-			Id:    "container3-id",
+		Container: types.Container{
+			ID:    "container3-id",
 			Names: []string{"/container3-name"},
 		},
-		Config: cluster.BuildContainerConfig(dockerclient.ContainerConfig{}),
+		Config: cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}),
 	}
 
 	s := createAgent(t, "test-engine", container1, container2, container3)
@@ -88,5 +91,5 @@ func TestContainerLookup(t *testing.T) {
 	// Match name before ID prefix
 	cc := c.Container("con")
 	assert.NotNil(t, cc)
-	assert.Equal(t, cc.Id, "container2-id")
+	assert.Equal(t, cc.ID, "container2-id")
 }

--- a/cluster/mesos/task/task.go
+++ b/cluster/mesos/task/task.go
@@ -135,11 +135,11 @@ func (t *Task) Build(slaveID string, offers map[string]*mesosproto.Offer) {
 		t.Container.Docker.Network = mesosproto.ContainerInfo_DockerInfo_BRIDGE.Enum()
 	}
 
-	if cpus := t.config.CPUShares; cpus > 0 {
+	if cpus := t.config.HostConfig.CPUShares; cpus > 0 {
 		t.Resources = append(t.Resources, mesosutil.NewScalarResource("cpus", float64(cpus)))
 	}
 
-	if mem := t.config.Memory; mem > 0 {
+	if mem := t.config.HostConfig.Memory; mem > 0 {
 		t.Resources = append(t.Resources, mesosutil.NewScalarResource("mem", float64(mem/1024/1024)))
 	}
 

--- a/cluster/mesos/task/task.go
+++ b/cluster/mesos/task/task.go
@@ -91,7 +91,7 @@ func (t *Task) Build(slaveID string, offers map[string]*mesosproto.Offer) {
 
 		for containerProtoPort, bindings := range t.config.HostConfig.PortBindings {
 			for _, binding := range bindings {
-				containerInfo := strings.SplitN(containerProtoPort, "/", 2)
+				containerInfo := strings.SplitN(string(containerProtoPort), "/", 2)
 				containerPort, err := strconv.ParseUint(containerInfo[0], 10, 32)
 				if err != nil {
 					log.Warn(err)
@@ -135,7 +135,7 @@ func (t *Task) Build(slaveID string, offers map[string]*mesosproto.Offer) {
 		t.Container.Docker.Network = mesosproto.ContainerInfo_DockerInfo_BRIDGE.Enum()
 	}
 
-	if cpus := t.config.CpuShares; cpus > 0 {
+	if cpus := t.config.CPUShares; cpus > 0 {
 		t.Resources = append(t.Resources, mesosutil.NewScalarResource("cpus", float64(cpus)))
 	}
 

--- a/cluster/mesos/task/task_test.go
+++ b/cluster/mesos/task/task_test.go
@@ -6,22 +6,32 @@ import (
 	"testing"
 	"time"
 
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesos/mesos-go/mesosutil"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
 const name = "mesos-swarm-task-name"
 
+var (
+	containerConfig = containertypes.Config{
+		Image: "test-image",
+		Cmd:   []string{"ls", "foo", "bar"},
+	}
+	hostConfig = containertypes.HostConfig{
+		Resources: containertypes.Resources{
+			CPUShares: 42,
+			Memory:    2097152,
+		},
+	}
+	networkingConfig = networktypes.NetworkingConfig{}
+)
+
 func TestBuild(t *testing.T) {
-	task, err := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{
-		Image:     "test-image",
-		CpuShares: 42,
-		Memory:    2097152,
-		Cmd:       []string{"ls", "foo", "bar"},
-	}), name, 5*time.Second)
+	task, err := NewTask(cluster.BuildContainerConfig(containerConfig, hostConfig, networkingConfig), name, 5*time.Second)
 	assert.NoError(t, err)
 
 	task.Build("slave-id", nil)
@@ -48,7 +58,7 @@ func TestBuild(t *testing.T) {
 }
 
 func TestNewTask(t *testing.T) {
-	task, err := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{}), name, 5*time.Second)
+	task, err := NewTask(cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), name, 5*time.Second)
 	assert.NoError(t, err)
 
 	assert.Equal(t, *task.Name, name)
@@ -57,7 +67,7 @@ func TestNewTask(t *testing.T) {
 }
 
 func TestSendGetStatus(t *testing.T) {
-	task, err := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{}), "", 5*time.Second)
+	task, err := NewTask(cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), "", 5*time.Second)
 	assert.NoError(t, err)
 
 	status := mesosutil.NewTaskStatus(nil, mesosproto.TaskState_TASK_RUNNING)

--- a/cluster/mesos/task/tasks_test.go
+++ b/cluster/mesos/task/tasks_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/docker/swarm/cluster"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,19 +20,9 @@ func (t *testLauncher) LaunchTask(_ *Task) bool {
 func TestAdd(t *testing.T) {
 	q := NewTasks(&testLauncher{count: 1})
 
-	task1, _ := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{
-		Image:     "test-image",
-		CpuShares: 42,
-		Memory:    2097152,
-		Cmd:       []string{"ls", "foo", "bar"},
-	}), "name1", 5*time.Second)
+	task1, _ := NewTask(cluster.BuildContainerConfig(containerConfig, hostConfig, networkingConfig), "name1", 5*time.Second)
 
-	task2, _ := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{
-		Image:     "test-image",
-		CpuShares: 42,
-		Memory:    2097152,
-		Cmd:       []string{"ls", "foo", "bar"},
-	}), "name2", 5*time.Second)
+	task2, _ := NewTask(cluster.BuildContainerConfig(containerConfig, hostConfig, networkingConfig), "name2", 5*time.Second)
 	q.Add(task1)
 	assert.Equal(t, len(q.Tasks), 0)
 
@@ -44,12 +33,7 @@ func TestAdd(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	q := NewTasks(&testLauncher{count: 2})
-	task1, _ := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{
-		Image:     "test-image",
-		CpuShares: 42,
-		Memory:    2097152,
-		Cmd:       []string{"ls", "foo", "bar"},
-	}), "name1", 5*time.Second)
+	task1, _ := NewTask(cluster.BuildContainerConfig(containerConfig, hostConfig, networkingConfig), "name1", 5*time.Second)
 
 	q.Add(task1)
 	assert.Equal(t, len(q.Tasks), 1)
@@ -60,12 +44,7 @@ func TestRemove(t *testing.T) {
 
 func TestProcess(t *testing.T) {
 	q := NewTasks(&testLauncher{count: 3})
-	task1, _ := NewTask(cluster.BuildContainerConfig(dockerclient.ContainerConfig{
-		Image:     "test-image",
-		CpuShares: 42,
-		Memory:    2097152,
-		Cmd:       []string{"ls", "foo", "bar"},
-	}), "name1", 5*time.Second)
+	task1, _ := NewTask(cluster.BuildContainerConfig(containerConfig, hostConfig, networkingConfig), "name1", 5*time.Second)
 
 	q.Add(task1)
 	assert.Equal(t, len(q.Tasks), 1)

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	containertypes "github.com/docker/engine-api/types/container"
 	networktypes "github.com/docker/engine-api/types/network"
@@ -148,8 +149,9 @@ func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, 
 	if err != nil {
 		var retries int64
 		//  fails with image not found, then try to reschedule with image affinity
+		// ENGINEAPIFIXME: The first error can be removed once dockerclient is removed
 		bImageNotFoundError, _ := regexp.MatchString(`image \S* not found`, err.Error())
-		if bImageNotFoundError && !config.HaveNodeConstraint() {
+		if (bImageNotFoundError || client.IsErrImageNotFound(err)) && !config.HaveNodeConstraint() {
 			// Check if the image exists in the cluster
 			// If exists, retry with a image affinity
 			if c.Image(config.Image) != nil {

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -138,7 +138,7 @@ func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *docke
 }
 
 // CreateContainer aka schedule a brand new container into the cluster.
-func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (*cluster.Container, error) {
+func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, authConfig *types.AuthConfig) (*cluster.Container, error) {
 	container, err := c.createContainer(config, name, false, authConfig)
 
 	if err != nil {
@@ -162,7 +162,7 @@ func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, 
 	return container, err
 }
 
-func (c *Cluster) createContainer(config *cluster.ContainerConfig, name string, withImageAffinity bool, authConfig *dockerclient.AuthConfig) (*cluster.Container, error) {
+func (c *Cluster) createContainer(config *cluster.ContainerConfig, name string, withImageAffinity bool, authConfig *types.AuthConfig) (*cluster.Container, error) {
 	c.scheduler.Lock()
 
 	// Ensure the name is available

--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -45,10 +45,10 @@ func (w *Watchdog) removeDuplicateContainers(e *Engine) {
 
 		for _, containerInCluster := range w.cluster.Containers() {
 			if containerInCluster.Config.SwarmID() == container.Config.SwarmID() && containerInCluster.Engine.ID != container.Engine.ID {
-				log.Debugf("container %s was rescheduled on node %s, removing it", container.Id, containerInCluster.Engine.Name)
+				log.Debugf("container %s was rescheduled on node %s, removing it", container.ID, containerInCluster.Engine.Name)
 				// container already exists in the cluster, destroy it
 				if err := e.RemoveContainer(container, true, true); err != nil {
-					log.Errorf("Failed to remove duplicate container %s on node %s: %v", container.Id, containerInCluster.Engine.Name, err)
+					log.Errorf("Failed to remove duplicate container %s on node %s: %v", container.ID, containerInCluster.Engine.Name, err)
 				}
 			}
 		}
@@ -65,7 +65,7 @@ func (w *Watchdog) rescheduleContainers(e *Engine) {
 
 		// Skip containers which don't have an "on-node-failure" reschedule policy.
 		if !c.Config.HasReschedulePolicy("on-node-failure") {
-			log.Debugf("Skipping rescheduling of %s based on rescheduling policies", c.Id)
+			log.Debugf("Skipping rescheduling of %s based on rescheduling policies", c.ID)
 			continue
 		}
 
@@ -78,15 +78,15 @@ func (w *Watchdog) rescheduleContainers(e *Engine) {
 		newContainer, err := w.cluster.CreateContainer(c.Config, c.Info.Name, nil)
 
 		if err != nil {
-			log.Errorf("Failed to reschedule container %s: %v", c.Id, err)
+			log.Errorf("Failed to reschedule container %s: %v", c.ID, err)
 			// add the container back, so we can retry later
 			c.Engine.AddContainer(c)
 		} else {
-			log.Infof("Rescheduled container %s from %s to %s as %s", c.Id, c.Engine.Name, newContainer.Engine.Name, newContainer.Id)
+			log.Infof("Rescheduled container %s from %s to %s as %s", c.ID, c.Engine.Name, newContainer.Engine.Name, newContainer.ID)
 			if c.Info.State.Running {
-				log.Infof("Container %s was running, starting container %s", c.Id, newContainer.Id)
+				log.Infof("Container %s was running, starting container %s", c.ID, newContainer.ID)
 				if err := w.cluster.StartContainer(newContainer, nil); err != nil {
-					log.Errorf("Failed to start rescheduled container %s: %v", newContainer.Id, err)
+					log.Errorf("Failed to start rescheduled container %s: %v", newContainer.ID, err)
 				}
 			}
 		}

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -38,7 +38,7 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 				containers := []string{}
 				for _, container := range node.Containers {
 					if len(container.Names) > 0 {
-						containers = append(containers, container.Id, strings.TrimPrefix(container.Names[0], "/"))
+						containers = append(containers, container.ID, strings.TrimPrefix(container.Names[0], "/"))
 					}
 				}
 				if affinity.Match(containers...) {

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -3,9 +3,10 @@ package filter
 import (
 	"testing"
 
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,49 +67,49 @@ func TestConstrainteFilter(t *testing.T) {
 	assert.Equal(t, result, nodes)
 
 	// Set a constraint that cannot be fulfilled and expect an error back.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:does_not_exist==true"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:does_not_exist==true"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 
 	// Set a contraint that can only be filled by a single node.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name==node1"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name==node1"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
 
 	// This constraint can only be fulfilled by a subset of nodes.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:group==1"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:group==1"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 	assert.NotContains(t, result, nodes[2])
 
 	// Validate node pinning by id.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==node-2-id"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:node==node-2-id"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[2])
 
 	// Validate node pinning by name.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==node-1-name"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:node==node-1-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
 
 	// Make sure constraints are evaluated as logical ANDs.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name==node0", "constraint:group==1"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name==node0", "constraint:group==1"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Check matching
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region==us"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region==us"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region==us*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region==us*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region==*us*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region==*us*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 }
@@ -122,22 +123,22 @@ func TestConstraintNotExpr(t *testing.T) {
 	)
 
 	// Check not (!) expression
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name!=node0"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name!=node0"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 3)
 
 	// Check not does_not_exist. All should be found
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name!=does_not_exist"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name!=does_not_exist"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 4)
 
 	// Check name must not start with n
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name!=n*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name!=n*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 
 	// Check not with globber pattern
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region!=us*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region!=us*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 }
@@ -151,22 +152,22 @@ func TestConstraintRegExp(t *testing.T) {
 	)
 
 	// Check with regular expression /node\d/ matches node{0..2}
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name==/node\d/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name==/node\d/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 3)
 
 	// Check with regular expression /node\d/ matches node{0..2}
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name==/node[12]/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name==/node[12]/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 
 	// Check with regular expression ! and regexp /node[12]/ matches node[0] and node[3]
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name!=/node[12]/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name!=/node[12]/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 
 	// Validate node pinning by ! and regexp.
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node!=/node-[01]-id/"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:node!=/node-[01]-id/"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 }
@@ -187,19 +188,19 @@ func TestFilterRegExpCaseInsensitive(t *testing.T) {
 	}
 
 	// Case-sensitive, so not match
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name==/abcdef/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name==/abcdef/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)
 
 	// Match with case-insensitive
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name==/(?i)abcdef/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name==/(?i)abcdef/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[3])
 	assert.Equal(t, result[0].Labels["name"], "aBcDeF")
 
 	// Test ! filter combined with case insensitive
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name!=/(?i)abc*/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name!=/(?i)abc*/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 3)
 }
@@ -213,17 +214,17 @@ func TestFilterEquals(t *testing.T) {
 	)
 
 	// Check == comparison
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name==node0"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name==node0"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 
 	// Test == with glob
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region==us*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region==us*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 
 	// Validate node name with ==
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==node-1-name"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:node==node-1-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
@@ -237,11 +238,11 @@ func TestUnsupportedOperators(t *testing.T) {
 		err    error
 	)
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name=node0"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name=node0"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:name=!node0"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name=!node0"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)
 }
@@ -254,26 +255,26 @@ func TestFilterSoftConstraint(t *testing.T) {
 		err    error
 	)
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:node==~node-1-name"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:node==~node-1-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{`constraint:name!=~/(?i)abc*/`}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{`constraint:name!=~/(?i)abc*/`}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 4)
 
 	// Check not with globber pattern
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region!=~us*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region!=~us*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region!=~can*"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region!=~can*"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 4)
 
 	// Check matching
-	result, err = f.Filter(cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"constraint:region==~us~"}}), nodes, true)
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:region==~us~"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)
 }

--- a/scheduler/filter/dependency.go
+++ b/scheduler/filter/dependency.go
@@ -36,8 +36,8 @@ func (f *DependencyFilter) Filter(config *cluster.ContainerConfig, nodes []*node
 
 	// Check if --net points to a container.
 	net := []string{}
-	if strings.HasPrefix(config.HostConfig.NetworkMode, "container:") {
-		net = append(net, strings.TrimPrefix(config.HostConfig.NetworkMode, "container:"))
+	if strings.HasPrefix(string(config.HostConfig.NetworkMode), "container:") {
+		net = append(net, strings.TrimPrefix(string(config.HostConfig.NetworkMode), "container:"))
 	}
 
 	candidates := []*node.Node{}
@@ -65,7 +65,7 @@ func (f *DependencyFilter) GetFilters(config *cluster.ContainerConfig) ([]string
 	for _, link := range config.HostConfig.Links {
 		dependencies = append(dependencies, fmt.Sprintf("--link=%s", link))
 	}
-	if strings.HasPrefix(config.HostConfig.NetworkMode, "container:") {
+	if strings.HasPrefix(string(config.HostConfig.NetworkMode), "container:") {
 		dependencies = append(dependencies, fmt.Sprintf("--net=%s", config.HostConfig.NetworkMode))
 	}
 	return dependencies, nil

--- a/scheduler/filter/dependency_test.go
+++ b/scheduler/filter/dependency_test.go
@@ -3,9 +3,11 @@ package filter
 import (
 	"testing"
 
+	"github.com/docker/engine-api/types"
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +20,7 @@ func TestDependencyFilterSimple(t *testing.T) {
 				Name: "node-0-name",
 				Addr: "node-0",
 				Containers: []*cluster.Container{{
-					Container: dockerclient.Container{Id: "c0"},
+					Container: types.Container{ID: "c0"},
 					Config:    &cluster.ContainerConfig{},
 				}},
 			},
@@ -28,7 +30,7 @@ func TestDependencyFilterSimple(t *testing.T) {
 				Name: "node-1-name",
 				Addr: "node-1",
 				Containers: []*cluster.Container{{
-					Container: dockerclient.Container{Id: "c1"},
+					Container: types.Container{ID: "c1"},
 					Config:    &cluster.ContainerConfig{},
 				}},
 			},
@@ -38,7 +40,7 @@ func TestDependencyFilterSimple(t *testing.T) {
 				Name: "node-2-name",
 				Addr: "node-2",
 				Containers: []*cluster.Container{{
-					Container: dockerclient.Container{Id: "c2"},
+					Container: types.Container{ID: "c2"},
 					Config:    &cluster.ContainerConfig{},
 				}},
 			},
@@ -55,54 +57,54 @@ func TestDependencyFilterSimple(t *testing.T) {
 	assert.Equal(t, result, nodes)
 
 	// volumes-from.
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c0"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// volumes-from:rw
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c0:rw"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// volumes-from:ro
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c0:ro"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// link.
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		Links: []string{"c1:foobar"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
 
 	// net.
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
-		NetworkMode: "container:c2",
-	}}}
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
+		NetworkMode: containertypes.NetworkMode("container:c2"),
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[2])
 
 	// net not prefixed by "container:" should be ignored.
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
-		NetworkMode: "bridge",
-	}}}
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
+		NetworkMode: containertypes.NetworkMode("bridge"),
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Equal(t, result, nodes)
@@ -119,11 +121,11 @@ func TestDependencyFilterMulti(t *testing.T) {
 				Addr: "node-0",
 				Containers: []*cluster.Container{
 					{
-						Container: dockerclient.Container{Id: "c0"},
+						Container: types.Container{ID: "c0"},
 						Config:    &cluster.ContainerConfig{},
 					},
 					{
-						Container: dockerclient.Container{Id: "c1"},
+						Container: types.Container{ID: "c1"},
 						Config:    &cluster.ContainerConfig{},
 					},
 				},
@@ -136,7 +138,7 @@ func TestDependencyFilterMulti(t *testing.T) {
 				Addr: "node-1",
 				Containers: []*cluster.Container{
 					{
-						Container: dockerclient.Container{Id: "c2"},
+						Container: types.Container{ID: "c2"},
 						Config:    &cluster.ContainerConfig{},
 					},
 				},
@@ -155,36 +157,36 @@ func TestDependencyFilterMulti(t *testing.T) {
 	)
 
 	// Depend on c0 which is on nodes[0]
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c0"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Depend on c1 which is on nodes[0]
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c1"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Depend on c0 AND c1 which are both on nodes[0]
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c0", "c1"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Depend on c0 AND c2 which are on different nodes.
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{HostConfig: dockerclient.HostConfig{
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
 		VolumesFrom: []string{"c0", "c2"},
-	}}}
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.Error(t, err)
 }
@@ -200,11 +202,11 @@ func TestDependencyFilterChaining(t *testing.T) {
 				Addr: "node-0",
 				Containers: []*cluster.Container{
 					{
-						Container: dockerclient.Container{Id: "c0"},
+						Container: types.Container{ID: "c0"},
 						Config:    &cluster.ContainerConfig{},
 					},
 					{
-						Container: dockerclient.Container{Id: "c1"},
+						Container: types.Container{ID: "c1"},
 						Config:    &cluster.ContainerConfig{},
 					},
 				},
@@ -217,7 +219,7 @@ func TestDependencyFilterChaining(t *testing.T) {
 				Addr: "node-1",
 				Containers: []*cluster.Container{
 					{
-						Container: dockerclient.Container{Id: "c2"},
+						Container: types.Container{ID: "c2"},
 						Config:    &cluster.ContainerConfig{},
 					},
 				},
@@ -236,26 +238,22 @@ func TestDependencyFilterChaining(t *testing.T) {
 	)
 
 	// Different dependencies on c0 and c1
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{
-		HostConfig: dockerclient.HostConfig{
-			VolumesFrom: []string{"c0"},
-			Links:       []string{"c1"},
-			NetworkMode: "container:c1",
-		},
-	}}
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
+		VolumesFrom: []string{"c0"},
+		Links:       []string{"c1"},
+		NetworkMode: containertypes.NetworkMode("container:c1"),
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Different dependencies on c0 and c2
-	config = &cluster.ContainerConfig{dockerclient.ContainerConfig{
-		HostConfig: dockerclient.HostConfig{
-			VolumesFrom: []string{"c0"},
-			Links:       []string{"c2"},
-			NetworkMode: "container:c1",
-		},
-	}}
+	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
+		VolumesFrom: []string{"c0"},
+		Links:       []string{"c2"},
+		NetworkMode: containertypes.NetworkMode("container:c1"),
+	}, networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.Error(t, err)
 }

--- a/scheduler/filter/filters_test.go
+++ b/scheduler/filter/filters_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,14 +19,18 @@ func TestApplyFilters(t *testing.T) {
 				Name: "node-0-name",
 				Addr: "node-0",
 				Containers: []*cluster.Container{
-					{Container: dockerclient.Container{
-						Id:    "container-n0-0-id",
-						Names: []string{"/container-n0-0-name"},
-					}},
-					{Container: dockerclient.Container{
-						Id:    "container-n0-1-id",
-						Names: []string{"/container-n0-1-name"},
-					}},
+					{
+						Container: types.Container{
+							ID:    "container-n0-0-id",
+							Names: []string{"/container-n0-0-name"},
+						},
+					},
+					{
+						Container: types.Container{
+							ID:    "container-n0-1-id",
+							Names: []string{"/container-n0-1-name"},
+						},
+					},
 				},
 				Images: []*cluster.Image{{Image: types.Image{
 					ID:       "image-0-id",
@@ -39,14 +44,14 @@ func TestApplyFilters(t *testing.T) {
 				Addr: "node-1",
 				Containers: []*cluster.Container{
 					{
-						Container: dockerclient.Container{
-							Id:    "container-n1-0-id",
+						Container: types.Container{
+							ID:    "container-n1-0-id",
 							Names: []string{"/container-n1-0-name"},
 						},
 					},
 					{
-						Container: dockerclient.Container{
-							Id:    "container-n1-1-id",
+						Container: types.Container{
+							ID:    "container-n1-1-id",
 							Names: []string{"/container-n1-1-name"},
 						},
 					},
@@ -63,7 +68,7 @@ func TestApplyFilters(t *testing.T) {
 	)
 
 	//Tests for Soft affinity, it should be considered as last
-	config := cluster.BuildContainerConfig(dockerclient.ContainerConfig{Env: []string{"affinity:image==~image-0:tag3"}})
+	config := cluster.BuildContainerConfig(containertypes.Config{Env: []string{"affinity:image==~image-0:tag3"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{})
 	result, err = ApplyFilters(filters, config, nodes, true)
 	assert.Error(t, err)
 	assert.Len(t, result, 0)

--- a/scheduler/filter/port.go
+++ b/scheduler/filter/port.go
@@ -3,9 +3,9 @@ package filter
 import (
 	"fmt"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
-	"github.com/samalba/dockerclient"
 )
 
 // PortFilter guarantees that, when scheduling a container binding a public
@@ -32,7 +32,7 @@ func (p *PortFilter) filterHost(config *cluster.ContainerConfig, nodes []*node.N
 	for port := range config.ExposedPorts {
 		candidates := []*node.Node{}
 		for _, node := range nodes {
-			if !p.portAlreadyExposed(node, port) {
+			if !p.portAlreadyExposed(node, string(port)) {
 				candidates = append(candidates, node)
 			}
 		}
@@ -66,7 +66,7 @@ func (p *PortFilter) portAlreadyExposed(node *node.Node, requestedPort string) b
 	for _, c := range node.Containers {
 		if c.Info.HostConfig.NetworkMode == "host" {
 			for port := range c.Info.Config.ExposedPorts {
-				if port == requestedPort {
+				if string(port) == requestedPort {
 					return true
 				}
 			}
@@ -75,7 +75,7 @@ func (p *PortFilter) portAlreadyExposed(node *node.Node, requestedPort string) b
 	return false
 }
 
-func (p *PortFilter) portAlreadyInUse(node *node.Node, requested dockerclient.PortBinding) bool {
+func (p *PortFilter) portAlreadyInUse(node *node.Node, requested nat.PortBinding) bool {
 	for _, c := range node.Containers {
 		// HostConfig.PortBindings contains the requested ports.
 		// NetworkSettings.Ports contains the actual ports.
@@ -96,7 +96,7 @@ func (p *PortFilter) portAlreadyInUse(node *node.Node, requested dockerclient.Po
 	return false
 }
 
-func (p *PortFilter) compare(requested dockerclient.PortBinding, bindings map[string][]dockerclient.PortBinding) bool {
+func (p *PortFilter) compare(requested nat.PortBinding, bindings nat.PortMap) bool {
 	for _, binding := range bindings {
 		for _, b := range binding {
 			if b.HostPort == "" {
@@ -110,7 +110,7 @@ func (p *PortFilter) compare(requested dockerclient.PortBinding, bindings map[st
 				// port/protocol.  Verify if they are requesting the same
 				// binding IP, or if the other container is already binding on
 				// every interface.
-				if requested.HostIp == b.HostIp || bindsAllInterfaces(requested) || bindsAllInterfaces(b) {
+				if requested.HostIP == b.HostIP || bindsAllInterfaces(requested) || bindsAllInterfaces(b) {
 					return true
 				}
 			}
@@ -137,6 +137,6 @@ func (p *PortFilter) GetFilters(config *cluster.ContainerConfig) ([]string, erro
 	return allPortConstraints, nil
 }
 
-func bindsAllInterfaces(binding dockerclient.PortBinding) bool {
-	return binding.HostIp == "0.0.0.0" || binding.HostIp == ""
+func bindsAllInterfaces(binding nat.PortBinding) bool {
+	return binding.HostIP == "0.0.0.0" || binding.HostIP == ""
 }

--- a/scheduler/filter/port.go
+++ b/scheduler/filter/port.go
@@ -64,7 +64,7 @@ func (p *PortFilter) filterBridge(config *cluster.ContainerConfig, nodes []*node
 
 func (p *PortFilter) portAlreadyExposed(node *node.Node, requestedPort string) bool {
 	for _, c := range node.Containers {
-		if c.Info.HostConfig.NetworkMode == "host" {
+		if c.Info.HostConfig != nil && c.Info.HostConfig.NetworkMode == "host" {
 			for port := range c.Info.Config.ExposedPorts {
 				if string(port) == requestedPort {
 					return true
@@ -89,7 +89,7 @@ func (p *PortFilter) portAlreadyInUse(node *node.Node, requested nat.PortBinding
 		//    NetworkSettings.Port will be null and we have to check
 		//    HostConfig.PortBindings to find out the mapping.
 
-		if p.compare(requested, c.Info.HostConfig.PortBindings) || p.compare(requested, c.Info.NetworkSettings.Ports) {
+		if (c.Info.HostConfig != nil && p.compare(requested, c.Info.HostConfig.PortBindings)) || (c.Info.NetworkSettings != nil && p.compare(requested, c.Info.NetworkSettings.Ports)) {
 			return true
 		}
 	}

--- a/scheduler/node/node.go
+++ b/scheduler/node/node.go
@@ -56,7 +56,7 @@ func (n *Node) Container(IDOrName string) *cluster.Container {
 func (n *Node) AddContainer(container *cluster.Container) error {
 	if container.Config != nil {
 		memory := container.Config.Memory
-		cpus := container.Config.CpuShares
+		cpus := container.Config.CPUShares
 		if n.TotalMemory-memory < 0 || n.TotalCpus-cpus < 0 {
 			return errors.New("not enough resources")
 		}

--- a/scheduler/node/node.go
+++ b/scheduler/node/node.go
@@ -55,8 +55,8 @@ func (n *Node) Container(IDOrName string) *cluster.Container {
 // AddContainer injects a container into the internal state.
 func (n *Node) AddContainer(container *cluster.Container) error {
 	if container.Config != nil {
-		memory := container.Config.Memory
-		cpus := container.Config.CPUShares
+		memory := container.Config.HostConfig.Memory
+		cpus := container.Config.HostConfig.CPUShares
 		if n.TotalMemory-memory < 0 || n.TotalCpus-cpus < 0 {
 			return errors.New("not enough resources")
 		}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -3,11 +3,12 @@ package scheduler
 import (
 	"testing"
 
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/filter"
 	"github.com/docker/swarm/scheduler/node"
 	"github.com/docker/swarm/scheduler/strategy"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,11 +43,14 @@ func TestSelectNodesForContainer(t *testing.T) {
 			},
 		}
 
-		config = cluster.BuildContainerConfig(dockerclient.ContainerConfig{
-			Memory:    1024 * 1024 * 1024,
-			CpuShares: 2,
-			Env:       []string{"constraint:group==~1"},
-		})
+		config = cluster.BuildContainerConfig(containertypes.Config{
+			Env: []string{"constraint:group==~1"},
+		}, containertypes.HostConfig{
+			Resources: containertypes.Resources{
+				Memory:    1024 * 1024 * 1024,
+				CPUShares: 2,
+			},
+		}, networktypes.NetworkingConfig{})
 	)
 	candidates, err := s.SelectNodesForContainer(nodes, config)
 	assert.NoError(t, err)

--- a/scheduler/strategy/binpack_test.go
+++ b/scheduler/strategy/binpack_test.go
@@ -170,22 +170,22 @@ func TestPlaceContainerOvercommit(t *testing.T) {
 	config := createConfig(0, 0)
 
 	// Below limit should still work.
-	config.Memory = 90 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 90 * 1024 * 1024 * 1024
 	node := selectTopNode(t, s, config, nodes)
 	assert.Equal(t, node, nodes[0])
 
 	// At memory limit should still work.
-	config.Memory = 100 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 100 * 1024 * 1024 * 1024
 	node = selectTopNode(t, s, config, nodes)
 	assert.Equal(t, node, nodes[0])
 
 	// Up to 105% it should still work.
-	config.Memory = 105 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 105 * 1024 * 1024 * 1024
 	node = selectTopNode(t, s, config, nodes)
 	assert.Equal(t, node, nodes[0])
 
 	// Above it should return an error.
-	config.Memory = 106 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 106 * 1024 * 1024 * 1024
 	_, err = s.RankAndSort(config, nodes)
 	assert.Error(t, err)
 }

--- a/scheduler/strategy/binpack_test.go
+++ b/scheduler/strategy/binpack_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/engine-api/types"
+	containertypes "github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,14 +26,22 @@ func createNode(ID string, memory int64, cpus int64) *node.Node {
 }
 
 func createConfig(memory int64, cpus int64) *cluster.ContainerConfig {
-	return cluster.BuildContainerConfig(dockerclient.ContainerConfig{Memory: memory * 1024 * 1024 * 1024, CpuShares: cpus})
+	return cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{
+		Resources: containertypes.Resources{
+			Memory:    memory * 1024 * 1024 * 1024,
+			CPUShares: cpus,
+		},
+	}, networktypes.NetworkingConfig{})
 }
 
 func createContainer(ID string, config *cluster.ContainerConfig) *cluster.Container {
 	return &cluster.Container{
-		Container: dockerclient.Container{Id: ID},
+		Container: types.Container{ID: ID},
 		Config:    config,
-		Info:      dockerclient.ContainerInfo{Config: &config.ContainerConfig},
+		// FIXMEENGINEAPI - maybe Hostconfig and networkingconfig also need to be stored
+		Info: types.ContainerJSON{
+			Config: &config.Config,
+		},
 	}
 }
 

--- a/scheduler/strategy/spread_test.go
+++ b/scheduler/strategy/spread_test.go
@@ -164,22 +164,22 @@ func TestSpreadPlaceContainerOvercommit(t *testing.T) {
 	config := createConfig(0, 0)
 
 	// Below limit should still work.
-	config.Memory = 90 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 90 * 1024 * 1024 * 1024
 	node := selectTopNode(t, s, config, nodes)
 	assert.Equal(t, node, nodes[0])
 
 	// At memory limit should still work.
-	config.Memory = 100 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 100 * 1024 * 1024 * 1024
 	node = selectTopNode(t, s, config, nodes)
 	assert.Equal(t, node, nodes[0])
 
 	// Up to 105% it should still work.
-	config.Memory = 105 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 105 * 1024 * 1024 * 1024
 	node = selectTopNode(t, s, config, nodes)
 	assert.Equal(t, node, nodes[0])
 
 	// Above it should return an error.
-	config.Memory = 106 * 1024 * 1024 * 1024
+	config.HostConfig.Memory = 106 * 1024 * 1024 * 1024
 	_, err := s.RankAndSort(config, nodes)
 	assert.Error(t, err)
 }

--- a/scheduler/strategy/weighted_node.go
+++ b/scheduler/strategy/weighted_node.go
@@ -44,7 +44,7 @@ func weighNodes(config *cluster.ContainerConfig, nodes []*node.Node, healthiness
 		nodeCpus := node.TotalCpus
 
 		// Skip nodes that are smaller than the requested resources.
-		if nodeMemory < int64(config.Memory) || nodeCpus < config.CPUShares {
+		if nodeMemory < int64(config.HostConfig.Memory) || nodeCpus < config.HostConfig.CPUShares {
 			continue
 		}
 
@@ -53,11 +53,11 @@ func weighNodes(config *cluster.ContainerConfig, nodes []*node.Node, healthiness
 			memoryScore int64 = 100
 		)
 
-		if config.CPUShares > 0 {
-			cpuScore = (node.UsedCpus + config.CPUShares) * 100 / nodeCpus
+		if config.HostConfig.CPUShares > 0 {
+			cpuScore = (node.UsedCpus + config.HostConfig.CPUShares) * 100 / nodeCpus
 		}
-		if config.Memory > 0 {
-			memoryScore = (node.UsedMemory + config.Memory) * 100 / nodeMemory
+		if config.HostConfig.Memory > 0 {
+			memoryScore = (node.UsedMemory + config.HostConfig.Memory) * 100 / nodeMemory
 		}
 
 		if cpuScore <= 100 && memoryScore <= 100 {

--- a/scheduler/strategy/weighted_node.go
+++ b/scheduler/strategy/weighted_node.go
@@ -44,7 +44,7 @@ func weighNodes(config *cluster.ContainerConfig, nodes []*node.Node, healthiness
 		nodeCpus := node.TotalCpus
 
 		// Skip nodes that are smaller than the requested resources.
-		if nodeMemory < int64(config.Memory) || nodeCpus < config.CpuShares {
+		if nodeMemory < int64(config.Memory) || nodeCpus < config.CPUShares {
 			continue
 		}
 
@@ -53,8 +53,8 @@ func weighNodes(config *cluster.ContainerConfig, nodes []*node.Node, healthiness
 			memoryScore int64 = 100
 		)
 
-		if config.CpuShares > 0 {
-			cpuScore = (node.UsedCpus + config.CpuShares) * 100 / nodeCpus
+		if config.CPUShares > 0 {
+			cpuScore = (node.UsedCpus + config.CPUShares) * 100 / nodeCpus
 		}
 		if config.Memory > 0 {
 			memoryScore = (node.UsedMemory + config.Memory) * 100 / nodeMemory

--- a/test/integration/nodemanagement/nodehealth.bats
+++ b/test/integration/nodemanagement/nodehealth.bats
@@ -32,7 +32,7 @@ function teardown() {
 	# Try to schedule a container. It'd first select node-1 and fail
 	run docker_swarm run -m 10m busybox sh
 	[ "$status" -ne 0 ]
-	[[ "${lines[0]}" == *"Cannot connect to the docker engine endpoint"* ]]
+	[[ "${lines[0]}" == *"Cannot connect to the docker engine endpoint"* || "${lines[0]}" == *"Cannot connect to the Docker daemon"* ]]
 
 	# Try to run it again. It'd select node-0 and succeed
 	run docker_swarm run -m 10m busybox sh


### PR DESCRIPTION
**This is work in progress, PR is meant for review**

This is the first change that will truly affect the entire repo AND the users, and will need discussion as some old API conventions might have to be deprecated.

The important decision here is the change in `ContainerConfig` struct inside `config.go`. Initially, `ContainerConfig` looked like

```
 type ContainerConfig struct {
     dockerclient.ContainerConfig
 }
```
but now it looks like
```
 type ContainerConfig struct {
     container.Config
     container.HostConfig
     network.NetworkingConfig
 }
```
where `container` and `network` are packages in `engine-api/types`. This is keeping in line with the recent Docker API changes where `HostConfig` and `NetworkingConfig` was moved out of `ContainerConfig` (renamed as `Config`) to be independent.

### "This change is too big"
I'm afraid so, but there's no other way to do it, all of this change needs to happen at once. Three function calls have been moved over to use `engine-api`, namely `ContainerCreate`, `ContainerInspect`, and `ContainerList`, along with the relevant changes needed to make these work.

### "How do I review this?"
Fortunately, many changes can be classified as "plumbing", so the root changes are fairly small. Start with `cluster/config.go` and `cluster/container.go` to see how structs have changed. Then check out `cluster/engine.go` where all the real stuff is happening, and scan through the calls being made to ensure that it all makes sense. **Note:** We don't have an embedded `HostConfig` inside `Config` anymore, they're separate, so we don't have to copy data over each time.

Finally, please do pull this branch and test locally, to make sure that it actually works.

This PR is part of a series to implement #1879.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>