### PR TITLE
use travis build matrix for different GOOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: go
 go:
   - 1.5.3
 
+env:
+  - BUILD_GOOS=darwin
+  - BUILD_GOOS=windows
+  - BUILD_GOOS=linux
+
 # let us have speedy Docker-based Travis workers
 sudo: false
 
@@ -21,7 +26,5 @@ script:
   - fgt golint ./...
   # Lint shell files and make sure they are not space indented.
   - fgt find test/ -type f \( -name "*.sh" -or -name "*.bash" -or -name "*.bats" \) -exec grep -Hn -e "^ " {} \;
-  - GOOS=darwin go build
-  - GOOS=windows go build
-  - GOOS=linux go build
-  - go test -v -race ./...
+  - GOOS=${BUILD_GOOS} go build
+  - if [[ ${BUILD_GOOS} == 'linux' ]] ; then GOOS=${BUILD_GOOS} go test -v -race ./... ; else true ; fi


### PR DESCRIPTION
- run individual builds based on GOOS
- only run the tests on the linux build

I got travis set up personally, and decided to take a look at how travis worked.  I thought this was an interesting result, but setting GOOS required a trick. I also figured we could avoid running the tests on the non-linuxs builds. 

I'm not sure effect this has on the badge for the github checks. 
