### PR TITLE
classify whether constraint error or affinity error

### DIFF
--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -69,7 +69,7 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 			}
 		}
 		if len(candidates) == 0 {
-			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", affinity.key, OPERATORS[affinity.operator], affinity.value)
+			return nil, fmt.Errorf("unable to find a node that satisfies the affinity %s%s%s", affinity.key, OPERATORS[affinity.operator], affinity.value)
 		}
 		nodes = candidates
 	}

--- a/scheduler/filter/constraint.go
+++ b/scheduler/filter/constraint.go
@@ -45,7 +45,7 @@ func (f *ConstraintFilter) Filter(config *cluster.ContainerConfig, nodes []*node
 			}
 		}
 		if len(candidates) == 0 {
-			return nil, fmt.Errorf("unable to find a node that satisfies %s%s%s", constraint.key, OPERATORS[constraint.operator], constraint.value)
+			return nil, fmt.Errorf("unable to find a node that satisfies the constraint %s%s%s", constraint.key, OPERATORS[constraint.operator], constraint.value)
 		}
 		nodes = candidates
 	}

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -209,7 +209,7 @@ function teardown() {
 	run docker_swarm run -d --name test_container -e constraint:node==node-1 busyboxabcde sleep 1000
 
 	# check error message
-	[[ "${output}" != *"unable to find a node that satisfies"* ]]
+	[[ "${output}" != *"unable to find a node that satisfies the constraint"* ]]
 	[[ "${output}" == *"not found"* ]]
 }
 


### PR DESCRIPTION
When constraint or affinity fails, 
make corresponding error more specific.
Since it is confusing when constraint and affinity are both label specific, and both fail.

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>