### PR TITLE
validate swarm.overcommit and add integration test for cluster options

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -82,12 +82,19 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, discovery
 	}
 
 	if val, ok := options.Float("swarm.overcommit", ""); ok {
-		cluster.overcommitRatio = val
+		if val <= float64(-1) {
+			log.Fatalf("swarm.overcommit should be larger than -1, %f is invalid", val)
+		} else if val < float64(0) {
+			log.Warn("-1 < swarm.overcommit < 0 will make swarm take less resource than docker engine offers")
+			cluster.overcommitRatio = val
+		} else {
+			cluster.overcommitRatio = val
+		}
 	}
 
 	if val, ok := options.Int("swarm.createretry", ""); ok {
 		if val < 0 {
-			log.Fatalf("swarm.createretry=%d is invalid", val)
+			log.Fatalf("swarm.createretry can not be negative, %d is invalid", val)
 		}
 		cluster.createRetry = val
 	}

--- a/test/integration/nodemanagement/cluster_options.bats
+++ b/test/integration/nodemanagement/cluster_options.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load ../helpers
+
+@test "cluster options" {
+	# cluster option swarm.overcommit
+	run swarm manage --cluster-opt swarm.overcommit=-2 nodes://192.168.56.22:4444
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"swarm.overcommit should be larger than -1, -2.000000 is invalid"* ]]
+
+	# cluster option swarm.createretry
+	run swarm manage --cluster-opt swarm.createretry=-1 nodes://192.168.56.22:4444
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"swarm.createretry can not be negative, -1 is invalid"* ]]
+}


### PR DESCRIPTION
1. validate cluster option swarm.overcommit not to be negative
2. add a test file testing cluster options

if we set swarm.overcommit=-2, below is part of `docker info` result:
```
Nodes: 1
 ubuntu: 192.168.59.103:2376
  └ Status: Healthy
  └ Containers: 1
  └ Reserved CPUs: 0 / -1
  └ Reserved Memory: 0 B / -2.098e+09 B 
```

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>