### PR TITLE
Change "master" to "manager"

### DIFF
--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -245,7 +245,7 @@ nodes using the Swarm API, which is nearly the same as the standard Docker API.
 In this example, you use SSL to connect to `manager0` and `consul0` host again.
 Then, you address commands to the Swarm manager.
 
-1. Get information about the master and nodes in the cluster:
+1. Get information about the manager and nodes in the cluster:
 
         $ docker -H :4000 info
 
@@ -273,11 +273,11 @@ replica.
 
         $ docker ps
 
-3. Shut down the primary master, replacing `<id_name>` with the container's id or name (for example, "8862717fe6d3" or "trusting_lamarr").
+3. Shut down the primary manager, replacing `<id_name>` with the container's id or name (for example, "8862717fe6d3" or "trusting_lamarr").
 
         docker rm -f <id_name>
 
-4. Start the Swarm master. For example:
+4. Start the Swarm manager. For example:
 
         $ docker run -d -p 4000:4000 swarm manage -H :4000 --replication --advertise 172.30.0.161:4000 consul://172.30.0.161:237
 
@@ -290,11 +290,11 @@ replica.
         time="2016-02-02T02:12:32Z" level=info msg="Leader Election: Cluster leadership lost"
         time="2016-02-02T02:12:32Z" level=info msg="New leader elected: 172.30.0.160:4000"
 
-6. To get information about the master and nodes in the cluster, enter:
+6. To get information about the manager and nodes in the cluster, enter:
 
         $ docker -H :4000 info
 
-You can connect to the `master1` node and run the `info` and `logs` commands.
+You can connect to the `manager1` node and run the `info` and `logs` commands.
 They will display corresponding entries for the change in leadership.
 
 ## Additional Resources

--- a/docs/provision-with-machine.md
+++ b/docs/provision-with-machine.md
@@ -100,8 +100,8 @@ refers to this token as the `SWARM_CLUSTER_TOKEN`.
 
 All Swarm nodes in a cluster must have Engine installed. With Machine and the
 `SWARM_CLUSTER_TOKEN` you can provision a host with Engine and configure it as a
-Swarm node with one Machine command. To create a Swarm master node on a new VM
-called `swarm-master`, you do the following:
+Swarm node with one Machine command. To create a Swarm manager node on a new VM
+called `swarm-manager`, you do the following:
 
 ```
 docker-machine create \
@@ -109,7 +109,7 @@ docker-machine create \
     --swarm \
     --swarm-master \
     --swarm-discovery token://SWARM_CLUSTER_TOKEN \
-    swarm-master
+    swarm-manager
 ```
 
 Then, provision an additional node. You must supply the
@@ -148,17 +148,17 @@ connect to Swarm nodes.
 docker-machine env --swarm HOST_NODE_NAME
 export DOCKER_TLS_VERIFY="1"
 export DOCKER_HOST="tcp://192.168.99.101:3376"
-export DOCKER_CERT_PATH="/Users/mary/.docker/machine/machines/swarm-master"
-export DOCKER_MACHINE_NAME="swarm-master"
+export DOCKER_CERT_PATH="/Users/mary/.docker/machine/machines/swarm-manager"
+export DOCKER_MACHINE_NAME="swarm-manager"
 # Run this command to configure your shell:
 # eval $(docker-machine env --swarm HOST_NODE_NAME)
 ```
 
-To set your SHELL connect to a Swarm node called `swarm-master`, you would do
+To set your SHELL connect to a Swarm node called `swarm-manager`, you would do
 this:
 
 ```
-eval "$(docker-machine env --swarm swarm-master)"
+eval "$(docker-machine env --swarm swarm-manager)"
 ```
 
 Now, you can use the Docker CLI to query and interact with your cluster.
@@ -171,7 +171,7 @@ Role: primary
 Strategy: spread
 Filters: health, port, dependency, affinity, constraint
 Nodes: 1
- swarm-master: 192.168.99.101:2376
+ swarm-manager: 192.168.99.101:2376
   └ Status: Healthy
   └ Containers: 2
   └ Reserved CPUs: 0 / 1
@@ -179,7 +179,7 @@ Nodes: 1
   └ Labels: executiondriver=native-0.2, kernelversion=4.1.13-boot2docker, operatingsystem=Boot2Docker 1.9.1 (TCL 6.4.1); master : cef800b - Fri Nov 20 19:33:59 UTC 2015, provider=virtualbox, storagedriver=aufs
 CPUs: 1
 Total Memory: 1.021 GiB
-Name: swarm-master
+Name: swarm-manager
 ```
 
 ## Related information

--- a/docs/scheduler/filter.md
+++ b/docs/scheduler/filter.md
@@ -98,8 +98,8 @@ $ docker daemon --label storage=disk
 $ swarm join --advertise=192.168.0.43:2375 token://XXXXXXXXXXXXXXXXXX
 ```
 
-Once the nodes are joined to a cluster, the Swarm master pulls their respective
-tags.  Moving forward, the master takes the tags into account when scheduling
+Once the nodes are joined to a cluster, the Swarm manager pulls their respective
+tags.  Moving forward, the manager takes the tags into account when scheduling
 new containers.
 
 Continuing the previous example, assuming your cluster with `node-1` and
@@ -116,7 +116,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 f8b693db9cd6        mysql:latest        "mysqld"            Less than a second ago   running             192.168.0.42:49178->3306/tcp    node-1      db
 ```
 
-In this example, the master selected all nodes that met the `storage=ssd`
+In this example, the manager selected all nodes that met the `storage=ssd`
 constraint and applied resource management on top of them.   Only `node-1` was
 selected because it's the only host running flash.
 
@@ -164,7 +164,7 @@ Successfully built cd70495a1514
 
 $ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-dockerswarm/swarm   master              8c2c56438951        2 days ago          795.7 MB
+dockerswarm/swarm   manager             8c2c56438951        2 days ago          795.7 MB
 ouruser/sinatra     v2                  cd70495a1514        35 seconds ago      318.7 MB
 ubuntu              14.04               a5a467fddcb8        11 days ago         187.9 MB
 ```

--- a/docs/swarm_at_scale/03-create-cluster.md
+++ b/docs/swarm_at_scale/03-create-cluster.md
@@ -140,7 +140,7 @@ the Consul container, you launch a Swarm manager container.
     The command is acting on the Swarm port, so it returns information about the
     entire cluster. You have a manager and no nodes.
 
-9. While still on the `master` node, join each node one-by-one to the cluster.
+9. While still on the `manager` node, join each node one-by-one to the cluster.
 
     You can run these commands to join each node from the `manager` node command
     line. The `-H` flag with the `docker` command specifies a node IP address


### PR DESCRIPTION
The Docker Swarm documentation states that:

"Some documentation still refers to a primary manager as a “master”, but
that term has been superseded."

This change attempts to remove remaining references to "master" in order
to keep documentation consistent.