### PR TITLE
fixes #2033 - adding a -i flag to the docs for the docker run hello-world

### DIFF
--- a/docs/install-w-machine.md
+++ b/docs/install-w-machine.md
@@ -162,7 +162,7 @@ Here, you connect to the cluster and review information about the Swarm manager 
 
 4. Run a container on the Swarm.
 
-        $ docker run hello-world
+        $ docker run -i hello-world
         Hello from Docker.
         .
         .


### PR DESCRIPTION
fixes #2033 - adding a -i flag to the docs for the docker run hello-world command in the install-w-machine.md file

