### PR TITLE
make 2xx response status code compatible with docker engine

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -690,7 +690,7 @@ func postImagesCreate(c *context, w http.ResponseWriter, r *http.Request) {
 // POST /images/load
 func postImagesLoad(c *context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusOK)
 
 	// call cluster to load image on every node
 	wf := NewWriteFlusher(w)
@@ -1139,6 +1139,7 @@ func postTagImage(c *context, w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
+	w.WriteHeader(http.StatusCreated)
 }
 
 // Proxy a request to a random node
@@ -1273,6 +1274,7 @@ func postRenameContainer(c *context, w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
+	w.WriteHeader(http.StatusNoContent)
 
 }
 


### PR DESCRIPTION
make 2xx response status code compatible with docker
1. POST /images/load    from 201 to 200
2. POST /images/{name:.*}/tag from 200 to 201
3. POST /containers/{name:.*}/rename from 200 to 204

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>