### PR TITLE
Printing engine version in Info

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -98,13 +98,14 @@ type EngineOpts struct {
 type Engine struct {
 	sync.RWMutex
 
-	ID     string
-	IP     string
-	Addr   string
-	Name   string
-	Cpus   int
-	Memory int64
-	Labels map[string]string
+	ID      string
+	IP      string
+	Addr    string
+	Name    string
+	Cpus    int
+	Memory  int64
+	Labels  map[string]string
+	Version string
 
 	stopCh          chan struct{}
 	refreshDelayer  *delayer
@@ -438,6 +439,8 @@ func (e *Engine) updateSpecs() error {
 		e.CheckConnectionErr(err)
 		return err
 	}
+	// update version
+	e.Version = v.Version
 
 	e.Lock()
 	defer e.Unlock()

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -865,6 +865,7 @@ func (c *Cluster) Info() [][2]string {
 		}
 		info = append(info, [2]string{"  └ Error", errMsg})
 		info = append(info, [2]string{"  └ UpdatedAt", engine.UpdatedAt().UTC().Format(time.RFC3339)})
+		info = append(info, [2]string{"  └ ServerVersion", engine.Version})
 	}
 
 	return info


### PR DESCRIPTION
Minor change to add a `Version` field to `Engine` struct. This might be needed later to pass additional context to the `engine-api` client. It's also nice to print the current version in cluster Info.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>