### PR TITLE
make port 0 invalid in checkAddrFormat

### DIFF
--- a/cli/join.go
+++ b/cli/join.go
@@ -18,7 +18,7 @@ func checkAddrFormat(addr string) bool {
 		return false
 	}
 	portNum, err := strconv.Atoi(port)
-	return err == nil && portNum >= 0 && portNum <= 65535
+	return err == nil && portNum > 0 && portNum <= 65535
 }
 
 func join(c *cli.Context) {

--- a/cli/join_test.go
+++ b/cli/join_test.go
@@ -25,6 +25,7 @@ func TestCheckAddrFormat(t *testing.T) {
 	assert.True(t, checkAddrFormat("hostname:1111"))
 	assert.True(t, checkAddrFormat("host-name_42:1111"))
 	assert.False(t, checkAddrFormat("1.1.1.1:-1"))
+	assert.False(t, checkAddrFormat("1.1.1.1:0"))
 	assert.True(t, checkAddrFormat("1.1.1.1:65535"))
 	assert.False(t, checkAddrFormat("1.1.1.1:65536"))
 	assert.False(t, checkAddrFormat("1.1.1.1: 4000"))

--- a/test/integration/cli_join.bats
+++ b/test/integration/cli_join.bats
@@ -15,6 +15,14 @@ DISCOVERY="consul://127.0.0.1:5555/test"
 	[ "$status" -ne 0 ]
 	[[ "${output}" == *"--advertise should be of the form ip:port or hostname:port"* ]]
 
+	run swarm join --heartbeat=1s --ttl=10s --delay=1s --advertise=127.0.0.1:0 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--advertise should be of the form ip:port or hostname:port"* ]]
+
+	run swarm join --heartbeat=1s --ttl=10s --delay=1s --advertise=127.0.0.1:65536 "$DISCOVERY"
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"--advertise should be of the form ip:port or hostname:port"* ]]
+
 	# --delay
 	run swarm join --heartbeat=1s --ttl=10s --delay=asdf --advertise=127.0.0.1:2376 "$DISCOVERY"
 	[ "$status" -ne 0 ]


### PR DESCRIPTION
1. make port 0 invalid in checkAddrFormat
2. add a test case in join_test.go
3. add some integration test in cli_join.bats

It is meaningless to register an address with port 0.
While listening on port 0 will dynamically listen a free port of unused.
Then meaningless to connect a port of 0 for swarm manager.

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>