### PR TITLE
Moving Image handling to engine-api

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -185,7 +185,7 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	accepteds := filters.Get("node")
 	// this struct helps grouping images
 	// but still keeps their Engine infos as an array.
-	groupImages := make(map[string]dockerclient.Image)
+	groupImages := make(map[string]apitypes.Image)
 	opts := cluster.ImageFilterOptions{
 		All:        boolValue(r, "all"),
 		NameFilter: r.FormValue("filter"),
@@ -206,16 +206,16 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		// grouping images by Id, and concat their RepoTags
-		if entry, existed := groupImages[image.Id]; existed {
+		if entry, existed := groupImages[image.ID]; existed {
 			entry.RepoTags = append(entry.RepoTags, image.RepoTags...)
 			entry.RepoDigests = append(entry.RepoDigests, image.RepoDigests...)
-			groupImages[image.Id] = entry
+			groupImages[image.ID] = entry
 		} else {
-			groupImages[image.Id] = image.Image
+			groupImages[image.ID] = image.Image
 		}
 	}
 
-	images := []dockerclient.Image{}
+	images := []apitypes.Image{}
 
 	for _, image := range groupImages {
 		// de-duplicate RepoTags

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -187,9 +187,11 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	// but still keeps their Engine infos as an array.
 	groupImages := make(map[string]apitypes.Image)
 	opts := cluster.ImageFilterOptions{
-		All:        boolValue(r, "all"),
-		NameFilter: r.FormValue("filter"),
-		Filters:    filters,
+		apitypes.ImageListOptions{
+			All:       boolValue(r, "all"),
+			MatchName: r.FormValue("filter"),
+			Filters:   filters,
+		},
 	}
 	for _, image := range c.cluster.Images().Filter(opts) {
 		if len(accepteds) != 0 {

--- a/api/sorter.go
+++ b/api/sorter.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"github.com/docker/engine-api/types"
 	"github.com/docker/swarm/cluster"
-	"github.com/samalba/dockerclient"
 )
 
 // ContainerSorter implements the Sort interface to sort Docker containers.
@@ -27,7 +27,7 @@ func (s ContainerSorter) Less(i, j int) bool {
 
 // ImageSorter implements the Sort interface to sort Docker Images.
 // It is not guaranteed to be a stable sort.
-type ImageSorter []dockerclient.Image
+type ImageSorter []types.Image
 
 // Len returns the number of images to be sorted.
 func (s ImageSorter) Len() int {

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -536,7 +536,8 @@ func (e *Engine) RemoveVolume(name string) error {
 
 // RefreshImages refreshes the list of images on the engine.
 func (e *Engine) RefreshImages() error {
-	images, err := e.client.ListImages(true)
+	imgLstOpts := types.ImageListOptions{All: true}
+	images, err := e.apiClient.ImageList(context.TODO(), imgLstOpts)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
@@ -544,7 +545,7 @@ func (e *Engine) RefreshImages() error {
 	e.Lock()
 	e.images = nil
 	for _, image := range images {
-		e.images = append(e.images, &Image{Image: *image, Engine: e})
+		e.images = append(e.images, &Image{Image: image, Engine: e})
 	}
 	e.Unlock()
 	return nil

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -165,7 +165,7 @@ func TestEngineCpusMemory(t *testing.T) {
 		mock.AnythingOfType("Args"),
 	).Return(types.VolumesListResponse{}, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
@@ -195,7 +195,7 @@ func TestEngineSpecs(t *testing.T) {
 		mock.AnythingOfType("Args"),
 	).Return(types.VolumesListResponse{}, nil)
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil)
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
@@ -233,7 +233,7 @@ func TestEngineState(t *testing.T) {
 
 	// The client will return one container at first, then a second one will appear.
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
 	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
@@ -287,7 +287,7 @@ func TestCreateContainer(t *testing.T) {
 	).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 
 	assert.NoError(t, engine.ConnectWithClient(client, apiClient))
 	assert.True(t, engine.isConnected())
@@ -302,7 +302,7 @@ func TestCreateContainer(t *testing.T) {
 	var auth *dockerclient.AuthConfig
 	client.On("CreateContainer", &mockConfig, name, auth).Return(id, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf(`{"id":[%q]}`, id)).Return([]dockerclient.Container{{Id: id}}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 	client.On("InspectContainer", id).Return(&dockerclient.ContainerInfo{Config: &config.ContainerConfig}, nil).Once()
 	container, err := engine.Create(config, name, false, auth)
 	assert.Nil(t, err)
@@ -325,7 +325,7 @@ func TestCreateContainer(t *testing.T) {
 	client.On("CreateContainer", &mockConfig, name, auth).Return("", dockerclient.ErrImageNotFound).Once()
 	client.On("CreateContainer", &mockConfig, name, auth).Return(id, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf(`{"id":[%q]}`, id)).Return([]dockerclient.Container{{Id: id}}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 	client.On("InspectContainer", id).Return(&dockerclient.ContainerInfo{Config: &config.ContainerConfig}, nil).Once()
 	container, err = engine.Create(config, name, true, auth)
 	assert.Nil(t, err)
@@ -337,9 +337,9 @@ func TestImages(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	engine.setState(stateHealthy)
 	engine.images = []*Image{
-		{dockerclient.Image{Id: "a"}, engine},
-		{dockerclient.Image{Id: "b"}, engine},
-		{dockerclient.Image{Id: "c"}, engine},
+		{types.Image{ID: "a"}, engine},
+		{types.Image{ID: "b"}, engine},
+		{types.Image{ID: "c"}, engine},
 	}
 
 	result := engine.Images()
@@ -392,7 +392,7 @@ func TestUsedCpus(t *testing.T) {
 					mock.AnythingOfType("Args"),
 				).Return(types.VolumesListResponse{}, nil)
 				client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
-				client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
+				apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil).Once()
 				client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "test"}}, nil).Once()
 				client.On("InspectContainer", "test").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: cpuShares}}, nil).Once()
 
@@ -429,7 +429,7 @@ func TestContainerRemovedDuringRefresh(t *testing.T) {
 	apiClient.On("VolumeList", mock.Anything,
 		mock.AnythingOfType("Args"),
 	).Return(types.VolumesListResponse{}, nil)
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{container1, container2}, nil)
 	client.On("InspectContainer", "c1").Return(info1, errors.New("Not found"))
@@ -466,7 +466,7 @@ func TestDisconnect(t *testing.T) {
 
 	// The client will return one container at first, then a second one will appear.
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{{Id: "one"}}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil).Once()
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 	client.On("InspectContainer", "one").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
 	client.On("ListContainers", true, false, fmt.Sprintf("{%q:[%q]}", "id", "two")).Return([]dockerclient.Container{{Id: "two"}}, nil).Once()
 	client.On("InspectContainer", "two").Return(&dockerclient.ContainerInfo{Config: &dockerclient.ContainerConfig{CpuShares: 100}}, nil).Once()
@@ -494,6 +494,7 @@ func TestRemoveImage(t *testing.T) {
 	dIs := []types.ImageDelete{{Deleted: imageName}}
 
 	apiClient := engineapimock.NewMockClient()
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 	apiClient.On("ImageRemove", context.TODO(),
 		mock.AnythingOfType("ImageRemoveOptions")).Return(dIs, nil)
 	engine.apiClient = apiClient

--- a/cluster/image.go
+++ b/cluster/image.go
@@ -3,13 +3,13 @@ package cluster
 import (
 	"strings"
 
+	"github.com/docker/engine-api/types"
 	dockerfilters "github.com/docker/engine-api/types/filters"
-	"github.com/samalba/dockerclient"
 )
 
 // Image is exported
 type Image struct {
-	dockerclient.Image
+	types.Image
 
 	Engine *Engine
 }
@@ -39,12 +39,12 @@ func (image *Image) Match(IDOrName string, matchTag bool) bool {
 	size := len(IDOrName)
 
 	// TODO: prefix match can cause false positives with image names
-	if image.Id == IDOrName || (size > 2 && strings.HasPrefix(image.Id, IDOrName)) {
+	if image.ID == IDOrName || (size > 2 && strings.HasPrefix(image.ID, IDOrName)) {
 		return true
 	}
 
 	// trim sha256: and retry
-	if parts := strings.SplitN(image.Id, ":", 2); len(parts) == 2 {
+	if parts := strings.SplitN(image.ID, ":", 2); len(parts) == 2 {
 		if parts[1] == IDOrName || (size > 2 && strings.HasPrefix(parts[1], IDOrName)) {
 			return true
 		}
@@ -80,6 +80,7 @@ func (image *Image) Match(IDOrName string, matchTag bool) bool {
 
 // ImageFilterOptions is the set of filtering options supported by
 // Images.Filter()
+// FIXMEENGINEAPI: should either embed or be replaced by types.ImageListOptions
 type ImageFilterOptions struct {
 	All        bool
 	NameFilter string

--- a/cluster/image.go
+++ b/cluster/image.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/types"
-	dockerfilters "github.com/docker/engine-api/types/filters"
 )
 
 // Image is exported
@@ -80,11 +79,8 @@ func (image *Image) Match(IDOrName string, matchTag bool) bool {
 
 // ImageFilterOptions is the set of filtering options supported by
 // Images.Filter()
-// FIXMEENGINEAPI: should either embed or be replaced by types.ImageListOptions
 type ImageFilterOptions struct {
-	All        bool
-	NameFilter string
-	Filters    dockerfilters.Args
+	types.ImageListOptions
 }
 
 // Images is a collection of Image objects that can be filtered
@@ -108,12 +104,12 @@ func (images Images) Filter(opts ImageFilterOptions) Images {
 	}
 
 	includeRepoFilter := func(image *Image) bool {
-		if opts.NameFilter == "" {
+		if opts.MatchName == "" {
 			return true
 		}
 		for _, repoTag := range image.RepoTags {
 			repoName, _ := ParseRepositoryTag(repoTag)
-			if repoTag == opts.NameFilter || repoName == opts.NameFilter {
+			if repoTag == opts.MatchName || repoName == opts.MatchName {
 				return true
 			}
 		}

--- a/cluster/image_test.go
+++ b/cluster/image_test.go
@@ -3,15 +3,15 @@ package cluster
 import (
 	"testing"
 
+	"github.com/docker/engine-api/types"
 	dockerfilters "github.com/docker/engine-api/types/filters"
-	"github.com/samalba/dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMatch(t *testing.T) {
 	img := Image{}
 
-	img.Id = "378954456789"
+	img.ID = "378954456789"
 	img.RepoTags = []string{"name:latest"}
 	img.RepoDigests = []string{"name@sha256:a973f1415c489a934bf56dd653079d36b4ec717760215645726439de9705911d"}
 
@@ -42,7 +42,7 @@ func TestMatch(t *testing.T) {
 func TestMatchPrivateRepo(t *testing.T) {
 	img := Image{}
 
-	img.Id = "378954456789"
+	img.ID = "378954456789"
 	img.RepoTags = []string{"private.registry.com:5000/name:latest"}
 
 	assert.True(t, img.Match("private.registry.com:5000/name:latest", true))
@@ -58,33 +58,33 @@ func TestMatchPrivateRepo(t *testing.T) {
 func TestImagesFilterWithLabelFilter(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	images := Images{
-		{dockerclient.Image{Id: "a"}, engine},
-		{dockerclient.Image{
-			Id:     "b",
+		{types.Image{ID: "a"}, engine},
+		{types.Image{
+			ID:     "b",
 			Labels: map[string]string{"com.example.project": "bar"},
 		}, engine},
-		{dockerclient.Image{Id: "c"}, engine},
+		{types.Image{ID: "c"}, engine},
 	}
 
 	filters := dockerfilters.NewArgs()
 	filters.Add("label", "com.example.project=bar")
 	result := images.Filter(ImageFilterOptions{All: true, Filters: filters})
 	assert.Equal(t, len(result), 1)
-	assert.Equal(t, result[0].Id, "b")
+	assert.Equal(t, result[0].ID, "b")
 }
 
 func TestImagesFilterWithNameFilter(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	images := Images{
 		{
-			dockerclient.Image{
-				Id:       "a",
+			types.Image{
+				ID:       "a",
 				RepoTags: []string{"example:latest", "example:2"},
 			},
 			engine,
 		},
 		{
-			dockerclient.Image{Id: "b", RepoTags: []string{"example:1"}},
+			types.Image{ID: "b", RepoTags: []string{"example:1"}},
 			engine,
 		},
 	}
@@ -94,25 +94,25 @@ func TestImagesFilterWithNameFilter(t *testing.T) {
 		NameFilter: "example:2",
 	})
 	assert.Equal(t, len(result), 1)
-	assert.Equal(t, result[0].Id, "a")
+	assert.Equal(t, result[0].ID, "a")
 }
 
 func TestImagesFilterWithNameFilterWithTag(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	images := Images{
 		{
-			dockerclient.Image{
-				Id:       "a",
+			types.Image{
+				ID:       "a",
 				RepoTags: []string{"example:latest", "example:2"},
 			},
 			engine,
 		},
 		{
-			dockerclient.Image{Id: "b", RepoTags: []string{"example:1"}},
+			types.Image{ID: "b", RepoTags: []string{"example:1"}},
 			engine,
 		},
 		{
-			dockerclient.Image{Id: "c", RepoTags: []string{"foo:latest"}},
+			types.Image{ID: "c", RepoTags: []string{"foo:latest"}},
 			engine,
 		},
 	}

--- a/cluster/image_test.go
+++ b/cluster/image_test.go
@@ -68,12 +68,12 @@ func TestImagesFilterWithLabelFilter(t *testing.T) {
 
 	filters := dockerfilters.NewArgs()
 	filters.Add("label", "com.example.project=bar")
-	result := images.Filter(ImageFilterOptions{All: true, Filters: filters})
+	result := images.Filter(ImageFilterOptions{types.ImageListOptions{All: true, Filters: filters}})
 	assert.Equal(t, len(result), 1)
 	assert.Equal(t, result[0].ID, "b")
 }
 
-func TestImagesFilterWithNameFilter(t *testing.T) {
+func TestImagesFilterWithMatchName(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	images := Images{
 		{
@@ -89,15 +89,12 @@ func TestImagesFilterWithNameFilter(t *testing.T) {
 		},
 	}
 
-	result := images.Filter(ImageFilterOptions{
-		All:        true,
-		NameFilter: "example:2",
-	})
+	result := images.Filter(ImageFilterOptions{types.ImageListOptions{All: true, MatchName: "example:2"}})
 	assert.Equal(t, len(result), 1)
 	assert.Equal(t, result[0].ID, "a")
 }
 
-func TestImagesFilterWithNameFilterWithTag(t *testing.T) {
+func TestImagesFilterWithMatchNameWithTag(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	images := Images{
 		{
@@ -117,10 +114,7 @@ func TestImagesFilterWithNameFilterWithTag(t *testing.T) {
 		},
 	}
 
-	result := images.Filter(ImageFilterOptions{
-		All:        true,
-		NameFilter: "example",
-	})
+	result := images.Filter(ImageFilterOptions{types.ImageListOptions{All: true, MatchName: "example"}})
 	assert.Equal(t, len(result), 2)
 }
 

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -143,7 +143,7 @@ func TestImportImage(t *testing.T) {
 	apiClient.On("VolumeList", mock.Anything, mock.Anything).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -196,7 +196,7 @@ func TestLoadImage(t *testing.T) {
 	apiClient.On("VolumeList", mock.Anything, mock.Anything).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
-	client.On("ListImages", mock.Anything).Return([]*dockerclient.Image{}, nil)
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return([]types.Image{}, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)
@@ -227,10 +227,10 @@ func TestTagImage(t *testing.T) {
 	c := &Cluster{
 		engines: make(map[string]*cluster.Engine),
 	}
-	images := []*dockerclient.Image{}
+	images := []types.Image{}
 
-	image1 := &dockerclient.Image{
-		Id:       "1234567890",
+	image1 := types.Image{
+		ID:       "1234567890",
 		RepoTags: []string{"busybox:latest"},
 	}
 	images = append(images, image1)
@@ -252,7 +252,7 @@ func TestTagImage(t *testing.T) {
 	apiClient.On("VolumeList", mock.Anything, mock.Anything).Return(types.VolumesListResponse{}, nil)
 	client.On("StartMonitorEvents", mock.Anything, mock.Anything, mock.Anything).Return()
 	client.On("ListContainers", true, false, "").Return([]dockerclient.Container{}, nil).Once()
-	client.On("ListImages", mock.Anything).Return(images, nil)
+	apiClient.On("ImageList", mock.Anything, mock.AnythingOfType("ImageListOptions")).Return(images, nil)
 
 	// connect client
 	engine.ConnectWithClient(client, apiClient)

--- a/scheduler/filter/affinity.go
+++ b/scheduler/filter/affinity.go
@@ -47,7 +47,7 @@ func (f *AffinityFilter) Filter(config *cluster.ContainerConfig, nodes []*node.N
 			case "image":
 				images := []string{}
 				for _, image := range node.Images {
-					images = append(images, image.Id)
+					images = append(images, image.ID)
 					images = append(images, image.RepoTags...)
 					for _, tag := range image.RepoTags {
 						repo, _ := cluster.ParseRepositoryTag(tag)

--- a/scheduler/filter/affinity_test.go
+++ b/scheduler/filter/affinity_test.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"testing"
 
+	"github.com/docker/engine-api/types"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
 	"github.com/samalba/dockerclient"
@@ -27,8 +28,8 @@ func TestAffinityFilter(t *testing.T) {
 						Names: []string{"/container-n0-1-name"},
 					}},
 				},
-				Images: []*cluster.Image{{Image: dockerclient.Image{
-					Id:       "image-0-id",
+				Images: []*cluster.Image{{Image: types.Image{
+					ID:       "image-0-id",
 					RepoTags: []string{"image-0:tag1", "image-0:tag2"},
 				}}},
 			},
@@ -46,8 +47,8 @@ func TestAffinityFilter(t *testing.T) {
 						Names: []string{"/container-n1-1-name"},
 					}},
 				},
-				Images: []*cluster.Image{{Image: dockerclient.Image{
-					Id:       "image-1-id",
+				Images: []*cluster.Image{{Image: types.Image{
+					ID:       "image-1-id",
 					RepoTags: []string{"image-1:tag1", "image-0:tag3", "image-1:tag2"},
 				}}},
 			},
@@ -215,8 +216,8 @@ func TestAffinityFilterLabels(t *testing.T) {
 						Names: []string{"/container-n0-name"},
 					}},
 				},
-				Images: []*cluster.Image{{Image: dockerclient.Image{
-					Id:       "image-0-id",
+				Images: []*cluster.Image{{Image: types.Image{
+					ID:       "image-0-id",
 					RepoTags: []string{"image-0:tag0"},
 				}}},
 			},
@@ -230,8 +231,8 @@ func TestAffinityFilterLabels(t *testing.T) {
 						Names: []string{"/container-n1-name"},
 					}},
 				},
-				Images: []*cluster.Image{{Image: dockerclient.Image{
-					Id:       "image-1-id",
+				Images: []*cluster.Image{{Image: types.Image{
+					ID:       "image-1-id",
 					RepoTags: []string{"image-1:tag1"},
 				}}},
 			},

--- a/scheduler/filter/filters_test.go
+++ b/scheduler/filter/filters_test.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"testing"
 
+	"github.com/docker/engine-api/types"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
 	"github.com/samalba/dockerclient"
@@ -26,8 +27,8 @@ func TestApplyFilters(t *testing.T) {
 						Names: []string{"/container-n0-1-name"},
 					}},
 				},
-				Images: []*cluster.Image{{Image: dockerclient.Image{
-					Id:       "image-0-id",
+				Images: []*cluster.Image{{Image: types.Image{
+					ID:       "image-0-id",
 					RepoTags: []string{"image-0:tag1", "image-0:tag2"},
 				}}},
 				HealthIndicator: 100,
@@ -50,8 +51,8 @@ func TestApplyFilters(t *testing.T) {
 						},
 					},
 				},
-				Images: []*cluster.Image{{Image: dockerclient.Image{
-					Id:       "image-1-id",
+				Images: []*cluster.Image{{Image: types.Image{
+					ID:       "image-1-id",
 					RepoTags: []string{"image-1:tag1", "image-0:tag3", "image-1:tag2"},
 				}}},
 				HealthIndicator: 0,


### PR DESCRIPTION
This change moves over all image handling to `engine-api`. It's self-contained, and relatively small.

It's part of implementing the proposal #1879.