### PR TITLE
remove binpacking (not binpack) out of strategy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Docker Swarm Roadmap
 ####Scheduler
 Swarm comes with a builtin scheduler. It currently provides basic functionalities, such as
 scheduling containers based on constraints or affinity (co-scheduling of containers), persistent
-storage and multiple scheduling strategies like binpacking or random.
+storage and multiple scheduling strategies like binpack or random.
 
 We plan to add more features to the builtin scheduler such as rebalancing (in case of host failure)
 and global scheduling (schedule containers on every node)

--- a/scheduler/strategy/binpack_test.go
+++ b/scheduler/strategy/binpack_test.go
@@ -162,8 +162,7 @@ func TestPlaceContainerHuge(t *testing.T) {
 }
 
 func TestPlaceContainerOvercommit(t *testing.T) {
-	s, err := New("binpacking")
-	assert.NoError(t, err)
+	s := &BinpackPlacementStrategy{}
 
 	nodes := []*node.Node{createNode("node-1", 100, 1)}
 

--- a/scheduler/strategy/strategy.go
+++ b/scheduler/strategy/strategy.go
@@ -44,10 +44,6 @@ func init() {
 
 // New creates a new PlacementStrategy for the given strategy name.
 func New(name string) (PlacementStrategy, error) {
-	if name == "binpacking" { //TODO: remove this compat
-		name = "binpack"
-	}
-
 	for _, strategy := range strategies {
 		if strategy.Name() == name {
 			log.WithField("name", name).Debugf("Initializing strategy")


### PR DESCRIPTION
As in swarm 0.2.0, strategy `binpacking` is treated as a legacy strategy which has the same usage of `binpack`.

And Swarm is close to version 1.2.0, maybe we can remove `binpacking` out of strategy.

1. Changed binpacking in ROAD.md into binpack
2. remove binpacking in strategy.go
3. remove binpacking in binpack_test.go