### PR TITLE
Allow tasks to continue running in Mesos even after swarm manager crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
 	git \
 	&& CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD` -X github.com/docker/swarm/version.BUILDTIME \"`date -u`\""  \
-	&& apk del .build-deps
+    && apk del .build-deps \
+    && apk update && apk add curl
 
 ENV SWARM_HOST :2375
 EXPOSE 2375

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
 	git \
 	&& CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT `git rev-parse --short HEAD` -X github.com/docker/swarm/version.BUILDTIME \"`date -u`\""  \
-    && apk del .build-deps \
-    && apk update && apk add curl
+	&& apk del .build-deps \
+	&& apk update && apk add curl
 
 ENV SWARM_HOST :2375
 EXPOSE 2375

--- a/cli/help.go
+++ b/cli/help.go
@@ -46,7 +46,8 @@ Options:
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.createretry=0\tcontainer create retry count after initial failure"}}
                                     {{printf "\t * mesos.address=\taddress to bind on [$SWARM_MESOS_ADDRESS]"}}
-                                    {{printf "\t * mesos.failovertimeout=0\tmesos will keep any started tasks running for this number of seconds after a swarm manager crash event [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
+                                    {{printf "\t * mesos.frameworkid=\tspecify a framework id, allows restarting with the same id in case of a manager crash, if not set mesos assigns a random id [$SWARM_MESOS_FRAMEWORKID]"}}
+                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks running for this number of seconds after a swarm manager crash, recover by restarting with the same framwrodk id [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
                                     {{printf "\t * mesos.checkpointfailover=false\tcheckpointing allows a restarted slave to reconnect with old executors and recover status updates, at the cost of disk I/O [$SWARM_MESOS_CHECKPOINT_FAILOVER]"}}
                                     {{printf "\t * mesos.port=\tport to bind on [$SWARM_MESOS_PORT]"}}
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}

--- a/cli/help.go
+++ b/cli/help.go
@@ -46,6 +46,7 @@ Options:
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.createretry=0\tcontainer create retry count after initial failure"}}
                                     {{printf "\t * mesos.address=\taddress to bind on [$SWARM_MESOS_ADDRESS]"}}
+                                    {{printf "\t * mesos.failovertimeout=0\tmesos will keep any started tasks running for this number of seconds after a swarm manager crash event [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
                                     {{printf "\t * mesos.checkpointfailover=false\tcheckpointing allows a restarted slave to reconnect with old executors and recover status updates, at the cost of disk I/O [$SWARM_MESOS_CHECKPOINT_FAILOVER]"}}
                                     {{printf "\t * mesos.port=\tport to bind on [$SWARM_MESOS_PORT]"}}
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -91,13 +91,13 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 
 	// Build a framework ID from params, many swarm services can share an ID allowing for HA
 	// If not defined, mesos will assign a random id
-	var frameworkId *mesosproto.FrameworkID 
+	var frameworkID *mesosproto.FrameworkID 
 	if frameworkUID, ok := options.String("mesos.frameworkid", "SWARM_MESOS_FRAMEWORKID"); ok {
-		frameworkId = &mesosproto.FrameworkID{Value: &frameworkUID}
+		frameworkID = &mesosproto.FrameworkID{Value: &frameworkUID}
 	} 
 
 	driverConfig := mesosscheduler.DriverConfig{
-		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user, Id: frameworkId},
+		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user, Id: frameworkID},
 		Master:           cluster.master,
 		HostnameOverride: hostname,
 	}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -121,6 +121,10 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 		driverConfig.BindingAddress = bindingAddress
 	}
 
+	if failoverTimeout, ok := options.Float("mesos.failovertimeout", "SWARM_MESOS_FAILOVER_TIMEOUT"); ok {
+		driverConfig.Framework.FailoverTimeout = &failoverTimeout
+	}
+	
 	if checkpointFailover, ok := options.Bool("mesos.checkpointfailover", "SWARM_MESOS_CHECKPOINT_FAILOVER"); ok {
 		driverConfig.Framework.Checkpoint = &checkpointFailover
 	}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -89,8 +89,15 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 	// Do not check error here, so mesos-go can still try.
 	hostname, _ := os.Hostname()
 
+	// Build a framework ID from params, many swarm services can share an ID allowing for HA
+	// If not defined, mesos will assign a random id
+	var frameworkId *mesosproto.FrameworkID 
+	if frameworkUID, ok := options.String("mesos.frameworkid", "SWARM_MESOS_FRAMEWORKID"); ok {
+		frameworkId = &mesosproto.FrameworkID{Value: &frameworkUID}
+	} 
+
 	driverConfig := mesosscheduler.DriverConfig{
-		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user},
+		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user, Id: frameworkId},
 		Master:           cluster.master,
 		HostnameOverride: hostname,
 	}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -91,10 +91,10 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 
 	// Build a framework ID from params, many swarm services can share an ID allowing for HA
 	// If not defined, mesos will assign a random id
-	var frameworkID *mesosproto.FrameworkID 
+	var frameworkID *mesosproto.FrameworkID
 	if frameworkUID, ok := options.String("mesos.frameworkid", "SWARM_MESOS_FRAMEWORKID"); ok {
 		frameworkID = &mesosproto.FrameworkID{Value: &frameworkUID}
-	} 
+	}
 
 	driverConfig := mesosscheduler.DriverConfig{
 		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user, Id: frameworkID},

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -124,7 +124,7 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 	if failoverTimeout, ok := options.Float("mesos.failovertimeout", "SWARM_MESOS_FAILOVER_TIMEOUT"); ok {
 		driverConfig.Framework.FailoverTimeout = &failoverTimeout
 	}
-	
+
 	if checkpointFailover, ok := options.Bool("mesos.checkpointfailover", "SWARM_MESOS_CHECKPOINT_FAILOVER"); ok {
 		driverConfig.Framework.Checkpoint = &checkpointFailover
 	}


### PR DESCRIPTION
By default, when a framework fails, Mesos will terminate any tasks started by a framework This parameter allows the tasks to continue running for this number of seconds after the swarm manager dies. (default 0)

If Swarm manages to reconnect with the same mesos task ID it had before then tasks will be reassigned to it.

Signed-off-by: Guillermo Rodriguez <grodriguez@cmcrc.com>