### PR TITLE
Updating apiClient version based on engine version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -91,58 +91,58 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport/cancellable",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/blkiodev",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/container",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/filters",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/network",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/registry",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/strslice",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/time",
-			"Comment": "v0.3.1-16-g6ca9064",
-			"Rev": "6ca9064650fd3d66ea1722c24e475ec0138feb11"
+			"Comment": "v0.3.1-34-g5b9e86c",
+			"Rev": "5b9e86c11862e755be8871b64aada2a65ded4b8b"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",

--- a/Godeps/_workspace/src/github.com/docker/engine-api/client/client.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/client/client.go
@@ -114,6 +114,12 @@ func (cli *Client) ClientVersion() string {
 	return cli.version
 }
 
+// UpdateClientVersion updates the version string associated with this
+// instance of the Client.
+func (cli *Client) UpdateClientVersion(v string) {
+	cli.version = v
+}
+
 // ParseHost verifies that the given host strings is valid.
 func ParseHost(host string) (string, string, string, error) {
 	protoAddrParts := strings.SplitN(host, "://", 2)

--- a/Godeps/_workspace/src/github.com/docker/engine-api/client/container_list.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/client/container_list.go
@@ -35,7 +35,8 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 	}
 
 	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filter)
+
 		if err != nil {
 			return nil, err
 		}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/client/hijack.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/client/hijack.go
@@ -68,11 +68,11 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	defer clientconn.Close()
 
 	// Server hijacks the connection, error 'connection closed' expected
-	clientconn.Do(req)
+	_, err = clientconn.Do(req)
 
 	rwc, br := clientconn.Hijack()
 
-	return types.HijackedResponse{Conn: rwc, Reader: br}, nil
+	return types.HijackedResponse{Conn: rwc, Reader: br}, err
 }
 
 func tlsDial(network, addr string, config *tls.Config) (net.Conn, error) {

--- a/Godeps/_workspace/src/github.com/docker/engine-api/client/interface.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/client/interface.go
@@ -68,6 +68,7 @@ type APIClient interface {
 	NetworkRemove(ctx context.Context, networkID string) error
 	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
 	ServerVersion(ctx context.Context) (types.Version, error)
+	UpdateClientVersion(v string)
 	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)

--- a/Godeps/_workspace/src/github.com/docker/engine-api/client/request.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/client/request.go
@@ -56,12 +56,14 @@ func (cli *Client) delete(ctx context.Context, path string, query url.Values, he
 }
 
 func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
-	body, err := encodeData(obj)
-	if err != nil {
-		return nil, err
-	}
+	var body io.Reader
 
-	if body != nil {
+	if obj != nil {
+		var err error
+		body, err = encodeData(obj)
+		if err != nil {
+			return nil, err
+		}
 		if headers == nil {
 			headers = make(map[string][]string)
 		}

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/client.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/client.go
@@ -103,7 +103,7 @@ func (h *HijackedResponse) Close() {
 	h.Conn.Close()
 }
 
-// CloseWriter is an interface that implement structs
+// CloseWriter is an interface that implements structs
 // that close input streams to prevent from writing.
 type CloseWriter interface {
 	CloseWrite() error

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/container/host_config.go
@@ -236,10 +236,11 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount     int64  `json:"CpuCount"`   // CPU count
-	CPUPercent   int64  `json:"CpuPercent"` // CPU percent
-	MaximumIOps  uint64 // Maximum IOps for the container system drive
-	MaximumIOBps uint64 // Maximum IO in bytes per second for the container system drive
+	CPUCount                int64  `json:"CpuCount"`   // CPU count
+	CPUPercent              int64  `json:"CpuPercent"` // CPU percent
+	IOMaximumIOps           uint64 // Maximum IOps for the container system drive
+	IOMaximumBandwidth      uint64 // Maximum IO in bytes per second for the container system drive
+	NetworkMaximumBandwidth uint64 // Maximum bandwidth of the network endpoint in bytes per second
 }
 
 // UpdateConfig holds the mutable attributes of a Container.

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/filters/parse.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/filters/parse.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -62,6 +63,26 @@ func ToParam(a Args) (string, error) {
 	}
 
 	buf, err := json.Marshal(a.fields)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func ToParamWithVersion(version string, a Args) (string, error) {
+	// this way we don't URL encode {}, just empty space
+	if a.Len() == 0 {
+		return "", nil
+	}
+
+	// for daemons older than v1.10, filter must be of the form map[string][]string
+	buf := []byte{}
+	err := errors.New("")
+	if version != "" && compareTo(version, "1.22") == -1 {
+		buf, err = json.Marshal(convertArgsToSlice(a.fields))
+	} else {
+		buf, err = json.Marshal(a.fields)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -254,4 +275,49 @@ func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
 		m[k] = values
 	}
 	return m
+}
+
+func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
+	m := map[string][]string{}
+	for k, v := range f {
+		values := []string{}
+		for kk, _ := range v {
+			if v[kk] {
+				values = append(values, kk)
+			}
+		}
+		m[k] = values
+	}
+	return m
+}
+
+// compareTo compares two version strings
+// returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise
+func compareTo(v1, v2 string) int {
+	var (
+		currTab  = strings.Split(v1, ".")
+		otherTab = strings.Split(v2, ".")
+	)
+
+	max := len(currTab)
+	if len(otherTab) > max {
+		max = len(otherTab)
+	}
+	for i := 0; i < max; i++ {
+		var currInt, otherInt int
+
+		if len(currTab) > i {
+			currInt, _ = strconv.Atoi(currTab[i])
+		}
+		if len(otherTab) > i {
+			otherInt, _ = strconv.Atoi(otherTab[i])
+		}
+		if currInt > otherInt {
+			return 1
+		}
+		if otherInt > currInt {
+			return -1
+		}
+	}
+	return 0
 }

--- a/Godeps/_workspace/src/github.com/docker/engine-api/types/stats.go
+++ b/Godeps/_workspace/src/github.com/docker/engine-api/types/stats.go
@@ -8,7 +8,7 @@ import "time"
 type ThrottlingData struct {
 	// Number of periods with throttling active
 	Periods uint64 `json:"periods"`
-	// Number of periods when the container hit its throttling limit.
+	// Number of periods when the container hits its throttling limit.
 	ThrottledPeriods uint64 `json:"throttled_periods"`
 	// Aggregate time the container was throttled for in nanoseconds.
 	ThrottledTime uint64 `json:"throttled_time"`

--- a/api/mockclient/mock.go
+++ b/api/mockclient/mock.go
@@ -347,6 +347,10 @@ func (client *MockClient) ServerVersion(ctx context.Context) (types.Version, err
 	return args.Get(0).(types.Version), args.Error(1)
 }
 
+// UpdateClientVersion updates the client version
+func (client *MockClient) UpdateClientVersion(v string) {
+}
+
 // VolumeCreate creates a volume in the docker host
 func (client *MockClient) VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error) {
 	args := client.Mock.Called(ctx, options)

--- a/api/nopclient/nop.go
+++ b/api/nopclient/nop.go
@@ -297,6 +297,10 @@ func (client *NopClient) ServerVersion(ctx context.Context) (types.Version, erro
 	return types.Version{}, errNoEngine
 }
 
+// UpdateClientVersion updates the client version
+func (client *NopClient) UpdateClientVersion(v string) {
+}
+
 // VolumeCreate creates a volume in the docker host
 func (client *NopClient) VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error) {
 	return types.Volume{}, errNoEngine

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -414,6 +414,26 @@ func (e *Engine) CheckConnectionErr(err error) {
 	// other errors may be ambiguous.
 }
 
+// Update API Version in apiClient
+func (e *Engine) updateClientVersionFromServer(serverVersion string) {
+	// v will be >= 1.6, since this is checked earlier
+	v := version.Version(serverVersion)
+	switch {
+	case v.LessThan(version.Version("1.7")):
+		e.apiClient.UpdateClientVersion("1.18")
+	case v.LessThan(version.Version("1.8")):
+		e.apiClient.UpdateClientVersion("1.19")
+	case v.LessThan(version.Version("1.9")):
+		e.apiClient.UpdateClientVersion("1.20")
+	case v.LessThan(version.Version("1.10")):
+		e.apiClient.UpdateClientVersion("1.21")
+	case v.LessThan(version.Version("1.11")):
+		e.apiClient.UpdateClientVersion("1.22")
+	default:
+		e.apiClient.UpdateClientVersion("1.23")
+	}
+}
+
 // Gather engine specs (CPU, memory, constraints, ...).
 func (e *Engine) updateSpecs() error {
 	info, err := e.apiClient.Info(context.TODO())
@@ -441,8 +461,10 @@ func (e *Engine) updateSpecs() error {
 		e.CheckConnectionErr(err)
 		return err
 	}
-	// update version
+	// update server version
 	e.Version = v.Version
+	// update client version. engine-api handles backward compatibility where needed
+	e.updateClientVersionFromServer(v.Version)
 
 	e.Lock()
 	defer e.Unlock()


### PR DESCRIPTION
Adding some changes needed by #1983 (https://github.com/docker/engine-api/pull/174 and https://github.com/docker/engine-api/pull/185). This will allow containers to be started correctly on different engine versions using `engine-api`.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>