### PR TITLE
Remove /containers/ps from the api router

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -324,7 +324,6 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(volumes)
 }
 
-// GET /containers/ps
 // GET /containers/json
 func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {

--- a/api/primary.go
+++ b/api/primary.go
@@ -39,7 +39,6 @@ var routes = map[string]map[string]handler{
 		"/images/{name:.*}/get":           proxyImageGet,
 		"/images/{name:.*}/history":       proxyImage,
 		"/images/{name:.*}/json":          proxyImage,
-		"/containers/ps":                  getContainersJSON,
 		"/containers/json":                getContainersJSON,
 		"/containers/{name:.*}/archive":   proxyContainer,
 		"/containers/{name:.*}/export":    proxyContainer,


### PR DESCRIPTION
Docker itself have removed this api since 1.9.0, so it should same
for swarm to remove this old api.

Signed-off-by: Kai Qiang Wu(Kennan) <wkqwu@cn.ibm.com>