### PR TITLE
make Operating System ouput compatible in docker info

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -74,6 +74,11 @@
 			"Rev": "b65fd8e879545e8c9b859ea9b6b825ac50c79e46"
 		},
 		{
+			"ImportPath": "github.com/docker/docker/pkg/parsers/operatingsystem",
+			"Comment": "v1.4.1-10581-gb65fd8e",
+			"Rev": "b65fd8e879545e8c9b859ea9b6b825ac50c79e46"
+		},
+		{
 			"ImportPath": "github.com/docker/docker/pkg/random",
 			"Comment": "v1.4.1-10581-gb65fd8e",
 			"Rev": "b65fd8e879545e8c9b859ea9b6b825ac50c79e46"
@@ -222,6 +227,11 @@
 			"ImportPath": "github.com/hashicorp/serf/coordinate",
 			"Comment": "v0.7.0-1-g39c7c06",
 			"Rev": "39c7c06298b480560202bec00c2c77e974e88792"
+		},
+		{
+			"ImportPath": "github.com/mattn/go-shellwords",
+			"Comment": "v1.0.0-1-g525bede",
+			"Rev": "525bedee691b5a8df547cb5cf9f86b7fb1883e24"
 		},
 		{
 			"ImportPath": "github.com/mesos/mesos-go/auth",

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_freebsd.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_freebsd.go
@@ -1,0 +1,18 @@
+package operatingsystem
+
+import (
+	"errors"
+)
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	// TODO: Implement OS detection
+	return "", errors.New("Cannot detect OS version")
+}
+
+// IsContainerized returns true if we are running inside a container.
+// No-op on FreeBSD, always returns false.
+func IsContainerized() (bool, error) {
+	// TODO: Implement jail detection
+	return false, errors.New("Cannot detect if we are in container")
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -1,0 +1,77 @@
+// Package operatingsystem provides helper function to get the operating system
+// name for different platforms.
+package operatingsystem
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+)
+
+var (
+	// file to use to detect if the daemon is running in a container
+	proc1Cgroup = "/proc/1/cgroup"
+
+	// file to check to determine Operating System
+	etcOsRelease = "/etc/os-release"
+
+	// used by stateless systems like Clear Linux
+	altOsRelease = "/usr/lib/os-release"
+)
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	osReleaseFile, err := os.Open(etcOsRelease)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("Error opening %s: %v", etcOsRelease, err)
+		}
+		osReleaseFile, err = os.Open(altOsRelease)
+		if err != nil {
+			return "", fmt.Errorf("Error opening %s: %v", altOsRelease, err)
+		}
+	}
+	defer osReleaseFile.Close()
+
+	var prettyName string
+	scanner := bufio.NewScanner(osReleaseFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "PRETTY_NAME=") {
+			data := strings.SplitN(line, "=", 2)
+			prettyNames, err := shellwords.Parse(data[1])
+			if err != nil {
+				return "", fmt.Errorf("PRETTY_NAME is invalid: %s", err.Error())
+			}
+			if len(prettyNames) != 1 {
+				return "", fmt.Errorf("PRETTY_NAME needs to be enclosed by quotes if they have spaces: %s", data[1])
+			}
+			prettyName = prettyNames[0]
+		}
+	}
+	if prettyName != "" {
+		return prettyName, nil
+	}
+	// If not set, defaults to PRETTY_NAME="Linux"
+	// c.f. http://www.freedesktop.org/software/systemd/man/os-release.html
+	return "Linux", nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+func IsContainerized() (bool, error) {
+	b, err := ioutil.ReadFile(proc1Cgroup)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range bytes.Split(b, []byte{'\n'}) {
+		if len(line) > 0 && !bytes.HasSuffix(line, []byte{'/'}) && !bytes.HasSuffix(line, []byte("init.scope")) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
@@ -1,0 +1,247 @@
+// +build linux freebsd
+
+package operatingsystem
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetOperatingSystem(t *testing.T) {
+	var backup = etcOsRelease
+
+	invalids := []struct {
+		content       string
+		errorExpected string
+	}{
+		{
+			`PRETTY_NAME=Source Mage GNU/Linux
+PRETTY_NAME=Ubuntu 14.04.LTS`,
+			"PRETTY_NAME needs to be enclosed by quotes if they have spaces: Source Mage GNU/Linux",
+		},
+		{
+			`PRETTY_NAME="Ubuntu Linux
+PRETTY_NAME=Ubuntu 14.04.LTS`,
+			"PRETTY_NAME is invalid: invalid command line string",
+		},
+		{
+			`PRETTY_NAME=Ubuntu'
+PRETTY_NAME=Ubuntu 14.04.LTS`,
+			"PRETTY_NAME is invalid: invalid command line string",
+		},
+		{
+			`PRETTY_NAME'
+PRETTY_NAME=Ubuntu 14.04.LTS`,
+			"PRETTY_NAME needs to be enclosed by quotes if they have spaces: Ubuntu 14.04.LTS",
+		},
+	}
+
+	valids := []struct {
+		content  string
+		expected string
+	}{
+		{
+			`NAME="Ubuntu"
+PRETTY_NAME_AGAIN="Ubuntu 14.04.LTS"
+VERSION="14.04, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`,
+			"Linux",
+		},
+		{
+			`NAME="Ubuntu"
+VERSION="14.04, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`,
+			"Linux",
+		},
+		{
+			`NAME=Gentoo
+ID=gentoo
+PRETTY_NAME="Gentoo/Linux"
+ANSI_COLOR="1;32"
+HOME_URL="http://www.gentoo.org/"
+SUPPORT_URL="http://www.gentoo.org/main/en/support.xml"
+BUG_REPORT_URL="https://bugs.gentoo.org/"
+`,
+			"Gentoo/Linux",
+		},
+		{
+			`NAME="Ubuntu"
+VERSION="14.04, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`,
+			"Ubuntu 14.04 LTS",
+		},
+		{
+			`NAME="Ubuntu"
+VERSION="14.04, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME='Ubuntu 14.04 LTS'`,
+			"Ubuntu 14.04 LTS",
+		},
+		{
+			`PRETTY_NAME=Source
+NAME="Source Mage"`,
+			"Source",
+		},
+		{
+			`PRETTY_NAME=Source
+PRETTY_NAME="Source Mage"`,
+			"Source Mage",
+		},
+	}
+
+	dir := os.TempDir()
+	etcOsRelease = filepath.Join(dir, "etcOsRelease")
+
+	defer func() {
+		os.Remove(etcOsRelease)
+		etcOsRelease = backup
+	}()
+
+	for _, elt := range invalids {
+		if err := ioutil.WriteFile(etcOsRelease, []byte(elt.content), 0600); err != nil {
+			t.Fatalf("failed to write to %s: %v", etcOsRelease, err)
+		}
+		s, err := GetOperatingSystem()
+		if err == nil || err.Error() != elt.errorExpected {
+			t.Fatalf("Expected an error %q, got %q (err: %v)", elt.errorExpected, s, err)
+		}
+	}
+
+	for _, elt := range valids {
+		if err := ioutil.WriteFile(etcOsRelease, []byte(elt.content), 0600); err != nil {
+			t.Fatalf("failed to write to %s: %v", etcOsRelease, err)
+		}
+		s, err := GetOperatingSystem()
+		if err != nil || s != elt.expected {
+			t.Fatalf("Expected %q, got %q (err: %v)", elt.expected, s, err)
+		}
+	}
+}
+
+func TestIsContainerized(t *testing.T) {
+	var (
+		backup                                = proc1Cgroup
+		nonContainerizedProc1Cgroupsystemd226 = []byte(`9:memory:/init.scope
+8:net_cls,net_prio:/
+7:cpuset:/
+6:freezer:/
+5:devices:/init.scope
+4:blkio:/init.scope
+3:cpu,cpuacct:/init.scope
+2:perf_event:/
+1:name=systemd:/init.scope
+`)
+		nonContainerizedProc1Cgroup = []byte(`14:name=systemd:/
+13:hugetlb:/
+12:net_prio:/
+11:perf_event:/
+10:bfqio:/
+9:blkio:/
+8:net_cls:/
+7:freezer:/
+6:devices:/
+5:memory:/
+4:cpuacct:/
+3:cpu:/
+2:cpuset:/
+`)
+		containerizedProc1Cgroup = []byte(`9:perf_event:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+8:blkio:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+7:net_cls:/
+6:freezer:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+5:devices:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+4:memory:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+3:cpuacct:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+2:cpu:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+1:cpuset:/`)
+	)
+
+	dir := os.TempDir()
+	proc1Cgroup = filepath.Join(dir, "proc1Cgroup")
+
+	defer func() {
+		os.Remove(proc1Cgroup)
+		proc1Cgroup = backup
+	}()
+
+	if err := ioutil.WriteFile(proc1Cgroup, nonContainerizedProc1Cgroup, 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", proc1Cgroup, err)
+	}
+	inContainer, err := IsContainerized()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inContainer {
+		t.Fatal("Wrongly assuming containerized")
+	}
+
+	if err := ioutil.WriteFile(proc1Cgroup, nonContainerizedProc1Cgroupsystemd226, 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", proc1Cgroup, err)
+	}
+	inContainer, err = IsContainerized()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inContainer {
+		t.Fatal("Wrongly assuming containerized for systemd /init.scope cgroup layout")
+	}
+
+	if err := ioutil.WriteFile(proc1Cgroup, containerizedProc1Cgroup, 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", proc1Cgroup, err)
+	}
+	inContainer, err = IsContainerized()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inContainer {
+		t.Fatal("Wrongly assuming non-containerized")
+	}
+}
+
+func TestOsReleaseFallback(t *testing.T) {
+	var backup = etcOsRelease
+	var altBackup = altOsRelease
+	dir := os.TempDir()
+	etcOsRelease = filepath.Join(dir, "etcOsRelease")
+	altOsRelease = filepath.Join(dir, "altOsRelease")
+
+	defer func() {
+		os.Remove(dir)
+		etcOsRelease = backup
+		altOsRelease = altBackup
+	}()
+	content := `NAME=Gentoo
+ID=gentoo
+PRETTY_NAME="Gentoo/Linux"
+ANSI_COLOR="1;32"
+HOME_URL="http://www.gentoo.org/"
+SUPPORT_URL="http://www.gentoo.org/main/en/support.xml"
+BUG_REPORT_URL="https://bugs.gentoo.org/"
+`
+	if err := ioutil.WriteFile(altOsRelease, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", etcOsRelease, err)
+	}
+	s, err := GetOperatingSystem()
+	if err != nil || s != "Gentoo/Linux" {
+		t.Fatalf("Expected %q, got %q (err: %v)", "Gentoo/Linux", s, err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -1,0 +1,49 @@
+package operatingsystem
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// See https://code.google.com/p/go/source/browse/src/pkg/mime/type_windows.go?r=d14520ac25bf6940785aabb71f5be453a286f58c
+// for a similar sample
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+
+	var h syscall.Handle
+
+	// Default return value
+	ret := "Unknown Operating System"
+
+	if err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE,
+		syscall.StringToUTF16Ptr(`SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\`),
+		0,
+		syscall.KEY_READ,
+		&h); err != nil {
+		return ret, err
+	}
+	defer syscall.RegCloseKey(h)
+
+	var buf [1 << 10]uint16
+	var typ uint32
+	n := uint32(len(buf) * 2) // api expects array of bytes, not uint16
+
+	if err := syscall.RegQueryValueEx(h,
+		syscall.StringToUTF16Ptr("ProductName"),
+		nil,
+		&typ,
+		(*byte)(unsafe.Pointer(&buf[0])),
+		&n); err != nil {
+		return ret, err
+	}
+	ret = syscall.UTF16ToString(buf[:])
+
+	return ret, nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+// No-op on Windows, always returns false.
+func IsContainerized() (bool, error) {
+	return false, nil
+}

--- a/Godeps/_workspace/src/github.com/mattn/go-shellwords/README.md
+++ b/Godeps/_workspace/src/github.com/mattn/go-shellwords/README.md
@@ -1,0 +1,47 @@
+# go-shellwords
+
+[![Coverage Status](https://coveralls.io/repos/mattn/go-shellwords/badge.png?branch=master)](https://coveralls.io/r/mattn/go-shellwords?branch=master)
+[![Build Status](https://travis-ci.org/mattn/go-shellwords.svg?branch=master)](https://travis-ci.org/mattn/go-shellwords)
+
+Parse line as shell words.
+
+## Usage
+
+```go
+args, err := shellwords.Parse("./foo --bar=baz")
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+os.Setenv("FOO", "bar")
+p := shellwords.NewParser()
+p.ParseEnv = true
+args, err := p.Parse("./foo $FOO")
+// args should be ["./foo", "bar"]
+```
+
+```go
+p := shellwords.NewParser()
+p.ParseBacktick = true
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+# Thanks
+
+This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).
+
+# License
+
+under the MIT License: http://mattn.mit-license.org/2014
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/Godeps/_workspace/src/github.com/mattn/go-shellwords/shellwords.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,134 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
+var envRe = regexp.MustCompile(`\$({[a-zA-Z0-9_]+}|[a-zA-Z0-9_]+)`)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+func replaceEnv(s string) string {
+	return envRe.ReplaceAllStringFunc(s, func(s string) string {
+		s = s[1:]
+		if s[0] == '{' {
+			s = s[1 : len(s)-1]
+		}
+		return os.Getenv(s)
+	})
+}
+
+type Parser struct {
+	ParseEnv      bool
+	ParseBacktick bool
+}
+
+func NewParser() *Parser {
+	return &Parser{ParseEnv, ParseBacktick}
+}
+
+func (p *Parser) Parse(line string) ([]string, error) {
+	line = strings.TrimSpace(line)
+
+	args := []string{}
+	buf := ""
+	var escaped, doubleQuoted, singleQuoted, backQuote bool
+	backtick := ""
+
+	for _, r := range line {
+		if escaped {
+			buf += string(r)
+			escaped = false
+			continue
+		}
+
+		if r == '\\' {
+			if singleQuoted {
+				buf += string(r)
+			} else {
+				escaped = true
+			}
+			continue
+		}
+
+		if isSpace(r) {
+			if singleQuoted || doubleQuoted || backQuote {
+				buf += string(r)
+				backtick += string(r)
+			} else if buf != "" {
+				if p.ParseEnv {
+					buf = replaceEnv(buf)
+				}
+				args = append(args, buf)
+				buf = ""
+			}
+			continue
+		}
+
+		switch r {
+		case '`':
+			if !singleQuoted && !doubleQuoted {
+				if p.ParseBacktick {
+					if backQuote {
+						out, err := shellRun(backtick)
+						if err != nil {
+							return nil, err
+						}
+						buf = out
+					}
+					backtick = ""
+					backQuote = !backQuote
+					continue
+				}
+				backtick = ""
+				backQuote = !backQuote
+			}
+		case '"':
+			if !singleQuoted {
+				doubleQuoted = !doubleQuoted
+				continue
+			}
+		case '\'':
+			if !doubleQuoted {
+				singleQuoted = !singleQuoted
+				continue
+			}
+		}
+
+		buf += string(r)
+		if backQuote {
+			backtick += string(r)
+		}
+	}
+
+	if buf != "" {
+		if p.ParseEnv {
+			buf = replaceEnv(buf)
+		}
+		args = append(args, buf)
+	}
+
+	if escaped || singleQuoted || doubleQuoted || backQuote {
+		return nil, errors.New("invalid command line string")
+	}
+
+	return args, nil
+}
+
+func Parse(line string) ([]string, error) {
+	return NewParser().Parse(line)
+}

--- a/Godeps/_workspace/src/github.com/mattn/go-shellwords/shellwords_test.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-shellwords/shellwords_test.go
@@ -1,0 +1,132 @@
+package shellwords
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+var testcases = []struct {
+	line     string
+	expected []string
+}{
+	{`var --bar=baz`, []string{`var`, `--bar=baz`}},
+	{`var --bar="baz"`, []string{`var`, `--bar=baz`}},
+	{`var "--bar=baz"`, []string{`var`, `--bar=baz`}},
+	{`var "--bar='baz'"`, []string{`var`, `--bar='baz'`}},
+	{"var --bar=`baz`", []string{`var`, "--bar=`baz`"}},
+	{`var "--bar=\"baz'"`, []string{`var`, `--bar="baz'`}},
+	{`var "--bar=\'baz\'"`, []string{`var`, `--bar='baz'`}},
+	{`var --bar='\'`, []string{`var`, `--bar=\`}},
+	{`var "--bar baz"`, []string{`var`, `--bar baz`}},
+	{`var --"bar baz"`, []string{`var`, `--bar baz`}},
+	{`var  --"bar baz"`, []string{`var`, `--bar baz`}},
+}
+
+func TestSimple(t *testing.T) {
+	for _, testcase := range testcases {
+		args, err := Parse(testcase.line)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if !reflect.DeepEqual(args, testcase.expected) {
+			t.Fatalf("Expected %v, but %v:", testcase.expected, args)
+		}
+	}
+}
+
+func TestError(t *testing.T) {
+	_, err := Parse("foo '")
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+	_, err = Parse(`foo "`)
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+
+	_, err = Parse("foo `")
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+}
+
+func TestBacktick(t *testing.T) {
+	goversion, err := shellRun("go version")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	parser := NewParser()
+	parser.ParseBacktick = true
+	args, err := parser.Parse("echo `go version`")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", goversion}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}
+
+func TestBacktickError(t *testing.T) {
+	parser := NewParser()
+	parser.ParseBacktick = true
+	_, err := parser.Parse("echo `go Version`")
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+}
+
+func TestEnv(t *testing.T) {
+	os.Setenv("FOO", "bar")
+
+	parser := NewParser()
+	parser.ParseEnv = true
+	args, err := parser.Parse("echo $FOO")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", "bar"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}
+
+func TestNoEnv(t *testing.T) {
+	parser := NewParser()
+	parser.ParseEnv = true
+	args, err := parser.Parse("echo $BAR")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", ""}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}
+
+func TestDupEnv(t *testing.T) {
+	os.Setenv("FOO", "bar")
+	os.Setenv("FOO_BAR", "baz")
+
+	parser := NewParser()
+	parser.ParseEnv = true
+	args, err := parser.Parse("echo $$FOO$")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", "$bar$"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+
+	args, err = parser.Parse("echo $${FOO_BAR}$")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected = []string{"echo", "$baz$"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}

--- a/Godeps/_workspace/src/github.com/mattn/go-shellwords/util_posix.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-shellwords/util_posix.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("SHELL")
+	b, err := exec.Command(shell, "-c", line).Output()
+	if err != nil {
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/Godeps/_workspace/src/github.com/mattn/go-shellwords/util_windows.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-shellwords/util_windows.go
@@ -1,0 +1,17 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("COMSPEC")
+	b, err := exec.Command(shell, "/c", line).Output()
+	if err != nil {
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -16,6 +16,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	versionpkg "github.com/docker/docker/pkg/version"
 	apitypes "github.com/docker/engine-api/types"
 	containertypes "github.com/docker/engine-api/types/container"
@@ -47,7 +48,6 @@ func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 		BridgeNfIP6tables: true,
 		OomKillDisable:    true,
 		ServerVersion:     "swarm/" + version.VERSION,
-		OperatingSystem:   runtime.GOOS,
 		Architecture:      runtime.GOARCH,
 		NCPU:              c.cluster.TotalCpus(),
 		MemTotal:          c.cluster.TotalMemory(),
@@ -72,6 +72,14 @@ func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		info.SystemStatus = status
 	}
+
+	operatingSystem := "<unknown>"
+	if s, err := operatingsystem.GetOperatingSystem(); err != nil {
+		log.Warnf("Could not get operating system name: %v", err)
+	} else {
+		operatingSystem = s
+	}
+	info.OperatingSystem = operatingSystem
 
 	kernelVersion := "<unknown>"
 	if kv, err := kernel.GetKernelVersion(); err != nil {


### PR DESCRIPTION
In docker info and docker_swarm info, there are some incompatibilities.
This pr did:
1. make Operating System output same as Docker Daemon
2. Add new dependencies:
```
github.com/mattn/go-shellwords
github.com/docker/docker/pkg/parsers/operatingsystem
```

Fixes #2096 

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>