### PR TITLE
when HTTPClientAndScheme returns a nil client, handle it

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -95,6 +95,10 @@ func proxyAsync(engine *cluster.Engine, w http.ResponseWriter, r *http.Request, 
 
 	client, scheme := engine.HTTPClientAndScheme()
 
+	if client == nil {
+		return fmt.Errorf("Failed to connect to engine (name: %s, ID: %s) ", engine.Name, engine.ID)
+	}
+
 	r.URL.Scheme = scheme
 	r.URL.Host = engine.Addr
 


### PR DESCRIPTION
when HTTPClientAndScheme returns a nil client, return an error

fixed #2098 

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>