### PR TITLE
return an error when assertion fails in hijack

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -244,14 +244,17 @@ func hijack(tlsConfig *tls.Config, addr string, w http.ResponseWriter, r *http.R
 	if err != nil {
 		return err
 	}
+
 	hj, ok := w.(http.Hijacker)
 	if !ok {
-		return err
+		return errors.New("Docker server does not support hijacking")
 	}
+
 	nc, _, err := hj.Hijack()
 	if err != nil {
 		return err
 	}
+
 	defer nc.Close()
 	defer d.Close()
 


### PR DESCRIPTION
1.return an New error when assertion fails in hijack, in the original code err is nil, so return nil may be not enough.
2. add some blank lines.

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>