### PR TITLE
remove a running container by force in volume.bats

### DIFF
--- a/test/integration/api/volume.bats
+++ b/test/integration/api/volume.bats
@@ -85,7 +85,7 @@ function teardown() {
 	run docker_swarm volume rm $volume
 	[ "$status" -ne 0 ]
 
-	docker_swarm rm test_container
+	docker_swarm rm -f test_container
 	
 	run docker_swarm volume rm $volume
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
In volume.bats, it tries to remove a running container, 
then docker engine will response an error like : 
https://jenkins.dockerproject.org/job/Swarm-PRs%20(engine%20master)/2433/console
```
time="2016-04-11T16:03:27Z" level=error msg="HTTP error: 409 Conflict: You cannot remove a running container 48177d682859056488e0a0cbff1f7728b98bfbf552f4387423e7edff065cda5e. Stop the container before attempting removal or use -f\n" status=500
```

So this pr added a flag `-f` to remove running container forcefully.

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>