### PR TITLE
volume rm integration test needs wait to avoid race

### DIFF
--- a/test/integration/api/volume.bats
+++ b/test/integration/api/volume.bats
@@ -73,20 +73,25 @@ function teardown() {
 	start_docker_with_busybox 2
 	swarm_manage
 
+	# check for failure when removing a nonexistant volume
 	run docker_swarm volume rm test_volume
 	[ "$status" -ne 0 ]
 
+	# run a container that exits imediately but stays around and
+	# connected to the volume. Wait for it to finish.
 	docker_swarm run -d --name=test_container -v=/tmp busybox true
-	
+	docker_swarm wait test_container
+
 	run docker_swarm volume ls -q
 	volume=${output}
 	[ "${#lines[@]}" -eq 1 ]
 
+	# check that removing an attached volume is an error
 	run docker_swarm volume rm $volume
 	[ "$status" -ne 0 ]
 
 	docker_swarm rm test_container
-	
+
 	run docker_swarm volume rm $volume
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 1 ]


### PR DESCRIPTION
my opinion on #2110

I see the volume rm failure locally. I don't see it if we make sure to wait (however small the length of that wait is). 

Added some comments as well.

I added some `docker ps` into the test, and we can see that it does appear as running.

```
# time="2016-04-13T10:57:43Z" level=debug msg="HTTP request received" method=POST uri="/v1.24/containers/create?name=test_container"
# ec4cfdfca4b8da6f693f707a47bab250fa586eb934455b216c7031d88c8c2a72
# time="2016-04-13T10:57:43Z" level=debug msg="HTTP request received" method=POST uri="/v1.24/containers/ec4cfdfca4b8da6f693f707a47bab250fa586eb934455b216c7031d88c8c2a72/start"
# time="2016-04-13T10:57:44Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/volumes"
# time="2016-04-13T10:57:44Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/containers/json"
# CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                  PORTS               NAMES
# ec4cfdfca4b8        busybox             "true"              1 seconds ago       Up Less than a second                       node-0/test_container
# time="2016-04-13T10:57:44Z" level=debug msg="HTTP request received" method=DELETE uri="/v1.24/volumes/node-0/531dff2eca79ab2974ce58854f713f1f604267564812035b0eda8a556e8c7957"
# time="2016-04-13T10:57:44Z" level=error msg="HTTP error: node-0: Error response from daemon: Unable to remove volume, volume still in use: remove 531dff2eca79ab2974ce58854f713f1f604267564812035b0eda8a556e8c7957: volume is in use - [ec4cfdfca4b8da6f693f707a47bab250fa586eb934455b216c7031d88c8c2a72]" status=500
# time="2016-04-13T10:57:44Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/containers/json"
# CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                  PORTS               NAMES
# ec4cfdfca4b8        busybox             "true"              1 seconds ago       Up Less than a second                       node-0/test_container
# time="2016-04-13T10:57:44Z" level=debug msg="HTTP request received" method=DELETE uri="/v1.24/containers/test_container"
```