### PR TITLE
Moving start container to engine-api

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1199,7 +1199,12 @@ func (e *Engine) cleanupContainers() {
 
 // StartContainer starts a container
 func (e *Engine) StartContainer(id string, hostConfig *dockerclient.HostConfig) error {
-	err := e.client.StartContainer(id, hostConfig)
+	var err error
+	if hostConfig != nil {
+		err = e.client.StartContainer(id, hostConfig)
+	} else {
+		err = e.apiClient.ContainerStart(context.TODO(), id)
+	}
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err


### PR DESCRIPTION
If `HostConfig` is passed on `/start`, dockerclient is still used.

(related to #1879)

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>