### PR TITLE
Fix bug: stop/restart/kill an inexisting container returns 500 rather than 404

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -894,6 +894,7 @@ func proxyContainerAndForceRefresh(c *context, w http.ResponseWriter, r *http.Re
 	if err != nil {
 		if container == nil {
 			httpError(w, err.Error(), http.StatusNotFound)
+			return
 		}
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Fix bug: stop/restart/kill an inexisting container returns 500 rather than 404