### PR TITLE
show container status of each node in docker info

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -865,7 +865,24 @@ func (c *Cluster) Info() [][2]string {
 		info = append(info, [2]string{" " + engineName, engine.Addr})
 		info = append(info, [2]string{"  └ ID", engine.ID})
 		info = append(info, [2]string{"  └ Status", engine.Status()})
-		info = append(info, [2]string{"  └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
+
+		// if engine's status is healthy, show container details of the node
+		if engine.IsHealthy() {
+			var paused, running, stopped int = 0, 0, 0
+			for _, c := range engine.Containers() {
+				if c.Info.State.Paused {
+					paused++
+				} else if c.Info.State.Running {
+					running++
+				} else {
+					stopped++
+				}
+			}
+			info = append(info, [2]string{"  └ Containers", fmt.Sprintf("%d (%d Running, %d Paused, %d Stopped)", len(engine.Containers()), running, paused, stopped)})
+		} else {
+			info = append(info, [2]string{"  └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
+		}
+
 		info = append(info, [2]string{"  └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})
 		info = append(info, [2]string{"  └ Reserved Memory", fmt.Sprintf("%s / %s", units.BytesSize(float64(engine.UsedMemory())), units.BytesSize(float64(engine.TotalMemory())))})
 		labels := make([]string, 0, len(engine.Labels))

--- a/test/integration/api/info.bats
+++ b/test/integration/api/info.bats
@@ -31,15 +31,18 @@ function teardown() {
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Running: 1"* ]]
+	[[ "${output}" == *"Containers: 1 (1 Running, 0 Paused, 0 Stopped)"* ]]
 
 	docker_swarm pause test
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Paused: 1"* ]]
+	[[ "${output}" == *"Containers: 1 (0 Running, 1 Paused, 0 Stopped)"* ]]
 
 	docker_swarm unpause test
 	docker_swarm kill test
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Stopped: 1"* ]]
+	[[ "${output}" == *"Containers: 1 (0 Running, 0 Paused, 1 Stopped)"* ]]
 }


### PR DESCRIPTION
1.Show container status of each node in `docker info`
2. add integration test cases in info.bats

Details:
If engine's status is not healthy, skip it.
```
...
Nodes: 1
 ubuntu: 10.1.0.108:2376
  └ Status: Healthy
  └ Containers: 1 (1 Running, 0 Paused, 0 Stopped)
  └ Reserved CPUs: 0 / 1
  └ Reserved Memory: 0 B / 2.052 GiB
  └ Labels: executiondriver=, kernelversion=3.19.0-25-generic, operatingsystem=Ubuntu 14.04.3 LTS, storagedriver=aufs
  └ Error: (none)
  └ UpdatedAt: 2016-04-25T06:58:36Z
  └ ServerVersion: 1.11.0
...
```
Fixed #2141

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>