### PR TITLE
Fix the bug that start container mess the host config

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -797,7 +797,7 @@ func postContainersStart(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body.Close()
 
-	if len(buf) <= 2 {
+	if len(buf) <= 2 || (len(buf) == 4 && string(buf) == "null") {
 		hostConfig = nil
 	} else {
 		if err := json.Unmarshal(buf, hostConfig); err != nil {

--- a/test/integration/api/start.bats
+++ b/test/integration/api/start.bats
@@ -48,3 +48,27 @@ function teardown() {
 	run docker_swarm inspect test_container
 	[[ "${output}" == *'"PublishAllPorts": true'* ]]
 }
+
+@test "docker start with null hostConfig" {
+	start_docker_with_busybox 2
+	swarm_manage
+
+	# create with PublishAllPorts true
+	docker_swarm create --name test_container -P busybox sleep 1000
+
+	# make sure created container exists
+	# new created container has no status
+	run docker_swarm ps -l
+	[ "${#lines[@]}" -eq 2 ]
+	[[ "${lines[1]}" ==  *"test_container"* ]]
+
+	# start with null hostConfig
+	curl -s -H "Content-Type: application/json" -X POST -d 'null' ${SWARM_HOSTS[0]}/v1.23/containers/test_container/start
+
+	# Verify
+	[ -n $(docker_swarm ps -q --filter=name=test_container --filter=status=running) ]
+
+	# Inspect HostConfig of container, should have PublishAllPorts set to true
+	run docker_swarm inspect test_container
+	[[ "${output}" == *'"PublishAllPorts": true'* ]]
+}


### PR DESCRIPTION
When use samalba/dockerclient to start a container on Swarm cluster, if the hostConfig is null pointer, Swarm master will receive the request body with "null", then the json Unmarshal will parse the request body to default value .This will override the original hostConfig from container creation. It will cause some unpredictable behaviour. The behaviour of Docker Engine is to process "null" as same as the empty request body.  So, Swarm should pass the hostConfig as nil rather than the default struct of HostConfig.

How to reproduce the problem with samalba/dockerclient
```
// Start the container
err := client.StartContainer("nginx", nil)
```

Signed-off-by: Xianlu <xianlu.cxl@alibaba-inc.com>