### PR TITLE
fix issue #2162 add removeDuplicateContainers behaviour for every node when it's added.

### DIFF
--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -20,7 +20,7 @@ func (w *Watchdog) Handle(e *Event) error {
 	}
 
 	switch e.Status {
-	case "engine_reconnect":
+	case "engine_connect", "engine_reconnect":
 		go w.removeDuplicateContainers(e.Engine)
 	case "engine_disconnect":
 		go w.rescheduleContainers(e.Engine)


### PR DESCRIPTION
fix issue #2162 
Swarm will delete node key when this key is expired after some time. So if we do removeDuplicateContainers job every time when a node add in , it will solve this problem.And if this node's docker engine id changed, this **engine_connected** event will also behave well to remove duplicate containers and you can also do some other job at **engine_connected** event.