### PR TITLE
add NodeID in docker info

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -863,6 +863,7 @@ func (c *Cluster) Info() [][2]string {
 			engineName = engine.Name
 		}
 		info = append(info, [2]string{" " + engineName, engine.Addr})
+		info = append(info, [2]string{"  └ ID", engine.ID})
 		info = append(info, [2]string{"  └ Status", engine.Status()})
 		info = append(info, [2]string{"  └ Containers", fmt.Sprintf("%d", len(engine.Containers()))})
 		info = append(info, [2]string{"  └ Reserved CPUs", fmt.Sprintf("%d / %d", engine.UsedCpus(), engine.TotalCpus())})


### PR DESCRIPTION
add NodeID in docker info

the `docker info` displays like below:
```
Nodes: 1
 ubuntu: 10.1.0.108:2376
  └ ID: RDEJ:ZCV6:CJH5:UCNB:P5RR:66LB:JZSO:YACX:TBL3:PYMV:2F77:KBUA
  └ Status: Healthy
  └ Containers: 1
  └ Reserved CPUs: 0 / 1
  └ Reserved Memory: 0 B / 2.052 GiB
  └ Labels: executiondriver=, kernelversion=3.19.0-25-generic, operatingsystem=Ubuntu 14.04.3 LTS, storagedriver=aufs
  └ Error: (none)
  └ UpdatedAt: 2016-04-26T14:31:23Z
  └ ServerVersion: 1.11.0
```

fixed #2168 , #2104 

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>