### PR TITLE
Moving to official consul image

### DIFF
--- a/test/integration/discovery/consul.bats
+++ b/test/integration/discovery/consul.bats
@@ -12,7 +12,7 @@ DISCOVERY="consul://${STORE_HOST}/test"
 CONTAINER_NAME=swarm_consul
 
 function start_store() {
-	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$CONTAINER_NAME -h $CONTAINER_NAME -p $STORE_HOST:8500 -d progrium/consul -server -bootstrap-expect 1 -config-file=/config/consul.json
+	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$CONTAINER_NAME -h $CONTAINER_NAME -p $STORE_HOST:8500 -d consul -server -bootstrap-expect 1 -config-file=/config/consul.json
 }
 
 function stop_store() {
@@ -93,7 +93,7 @@ function teardown() {
 	# is resilient to it.
 
 	# At this point, the store is not yet started.
-	
+
 	# Start 2 engines and join the cluster. They should keep retrying
 	start_docker 2
 	swarm_join "$DISCOVERY"

--- a/test/integration/replication.bats
+++ b/test/integration/replication.bats
@@ -21,14 +21,14 @@ NODE_2_URL="consul://${STORE_HOST_2}/test"
 NODE_3_URL="consul://${STORE_HOST_3}/test"
 
 function start_store_cluster() {
-	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$NODE_1 -h $NODE_1 -p $STORE_HOST_1:8500 -d progrium/consul -server -bootstrap-expect 3 -config-file=/config/consul.json
+	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$NODE_1 -h $NODE_1 -p $STORE_HOST_1:8500 -d consul -server -bootstrap-expect 3 -config-file=/config/consul.json
 
 	# Grab node_1 address required for other nodes to join the cluster
 	JOIN_ENDPOINT=$(docker_host inspect -f '{{.NetworkSettings.IPAddress}}' $NODE_1)
 
-	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$NODE_2 -h $NODE_2 -p $STORE_HOST_2:8500 -d progrium/consul -server -join $JOIN_ENDPOINT -config-file=/config/consul.json
+	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$NODE_2 -h $NODE_2 -p $STORE_HOST_2:8500 -d consul -server -join $JOIN_ENDPOINT -config-file=/config/consul.json
 
-	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$NODE_3 -h $NODE_3 -p $STORE_HOST_3:8500 -d progrium/consul -server -join $JOIN_ENDPOINT -config-file=/config/consul.json
+	docker_host run -v $(pwd)/discovery/consul/config:/config --name=$NODE_3 -h $NODE_3 -p $STORE_HOST_3:8500 -d consul -server -join $JOIN_ENDPOINT -config-file=/config/consul.json
 
 	# Wait for the cluster to be available.
 	sleep 2


### PR DESCRIPTION
There's now an official consul image: https://hub.docker.com/_/consul/

Let's see if our integration tests work with that.

Signed-off-by: Nishant Totla nishanttotla@gmail.com
