### PR TITLE
Remove type unnecessary type conversion

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -49,7 +49,7 @@ func getInfo(c *context, w http.ResponseWriter, r *http.Request) {
 		ServerVersion:     "swarm/" + version.VERSION,
 		OperatingSystem:   runtime.GOOS,
 		Architecture:      runtime.GOARCH,
-		NCPU:              c.cluster.TotalCpus(),
+		NCPU:              int(c.cluster.TotalCpus()),
 		MemTotal:          c.cluster.TotalMemory(),
 		HTTPProxy:         os.Getenv("http_proxy"),
 		HTTPSProxy:        os.Getenv("https_proxy"),

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -79,7 +79,7 @@ type Cluster interface {
 	TotalMemory() int64
 
 	// Return the number of CPUs in the cluster
-	TotalCpus() int
+	TotalCpus() int64
 
 	// Register an event handler for cluster-wide events.
 	RegisterEventHandler(h EventHandler) error

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -108,7 +108,7 @@ type Engine struct {
 	IP      string
 	Addr    string
 	Name    string
-	Cpus    int
+	Cpus    int64
 	Memory  int64
 	Labels  map[string]string
 	Version string
@@ -492,7 +492,7 @@ func (e *Engine) updateSpecs() error {
 		return fmt.Errorf(message)
 	}
 	e.Name = info.Name
-	e.Cpus = info.NCPU
+	e.Cpus = int64(info.NCPU)
 	e.Memory = info.MemTotal
 	e.Labels = map[string]string{
 		"storagedriver":   info.Driver,
@@ -738,7 +738,7 @@ func (e *Engine) updateContainer(c types.Container, containers map[string]*Conta
 		}
 		container.Config = BuildContainerConfig(*info.Config, *info.HostConfig, networkingConfig)
 		// FIXME remove "duplicate" line and move this to cluster/config.go
-		container.Config.HostConfig.CPUShares = container.Config.HostConfig.CPUShares * int64(e.Cpus) / 1024.0
+		container.Config.HostConfig.CPUShares = container.Config.HostConfig.CPUShares * e.Cpus / 1024.0
 
 		// Save the entire inspect back into the container.
 		container.Info = info
@@ -857,8 +857,8 @@ func (e *Engine) TotalMemory() int64 {
 }
 
 // TotalCpus returns the total cpus + overcommit
-func (e *Engine) TotalCpus() int {
-	return e.Cpus + (e.Cpus * int(e.overcommitRatio) / 100)
+func (e *Engine) TotalCpus() int64 {
+	return e.Cpus + (e.Cpus * e.overcommitRatio / 100)
 }
 
 // Create a new container

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -224,7 +224,7 @@ func TestEngineSpecs(t *testing.T) {
 	assert.True(t, engine.isConnected())
 	assert.True(t, engine.IsHealthy())
 
-	assert.Equal(t, engine.Cpus, mockInfo.NCPU)
+	assert.Equal(t, engine.Cpus, int64(mockInfo.NCPU))
 	assert.Equal(t, engine.Memory, mockInfo.MemTotal)
 	assert.Equal(t, engine.Labels["storagedriver"], mockInfo.Driver)
 	assert.Equal(t, engine.Labels["executiondriver"], mockInfo.ExecutionDriver)
@@ -396,17 +396,17 @@ func TestTotalMemory(t *testing.T) {
 func TestTotalCpus(t *testing.T) {
 	engine := NewEngine("test", 0.05, engOpts)
 	engine.Cpus = 2
-	assert.Equal(t, engine.TotalCpus(), 2+2*5/100)
+	assert.Equal(t, engine.TotalCpus(), int64(2+2*5/100))
 
 	engine = NewEngine("test", 0, engOpts)
 	engine.Cpus = 2
-	assert.Equal(t, engine.TotalCpus(), 2)
+	assert.Equal(t, engine.TotalCpus(), int64(2))
 }
 
 func TestUsedCpus(t *testing.T) {
 	var (
 		containerNcpu = []int64{1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47}
-		hostNcpu      = []int{1, 2, 4, 8, 10, 12, 16, 20, 32, 36, 40, 48}
+		hostNcpu      = []int64{1, 2, 4, 8, 10, 12, 16, 20, 32, 36, 40, 48}
 	)
 
 	engine := NewEngine("test", 0, engOpts)
@@ -416,8 +416,8 @@ func TestUsedCpus(t *testing.T) {
 
 	for _, hn := range hostNcpu {
 		for _, cn := range containerNcpu {
-			if int(cn) <= hn {
-				mockInfo.NCPU = hn
+			if cn <= hn {
+				mockInfo.NCPU = int(hn)
 				cpuShares := int64(math.Ceil(float64(cn*1024) / float64(mockInfo.NCPU)))
 
 				apiClient.On("Info", mock.Anything).Return(mockInfo, nil).Once()
@@ -435,7 +435,7 @@ func TestUsedCpus(t *testing.T) {
 
 				engine.ConnectWithClient(client, apiClient)
 
-				assert.Equal(t, engine.Cpus, mockInfo.NCPU)
+				assert.Equal(t, engine.Cpus, int64(mockInfo.NCPU))
 				assert.Equal(t, engine.UsedCpus(), cn)
 			}
 		}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -449,12 +449,12 @@ func (c *Cluster) TotalMemory() int64 {
 }
 
 // TotalCpus returns the total memory of the cluster
-func (c *Cluster) TotalCpus() int {
+func (c *Cluster) TotalCpus() int64 {
 	c.RLock()
 	defer c.RUnlock()
-	var totalCpus int
+	var totalCpus int64
 	for _, s := range c.agents {
-		totalCpus += int(sumScalarResourceValue(s.offers, "cpus"))
+		totalCpus += int64(sumScalarResourceValue(s.offers, "cpus"))
 	}
 	return totalCpus
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -838,8 +838,8 @@ func (c *Cluster) TotalMemory() int64 {
 }
 
 // TotalCpus return the total memory of the cluster
-func (c *Cluster) TotalCpus() int {
-	var totalCpus int
+func (c *Cluster) TotalCpus() int64 {
+	var totalCpus int64
 	for _, engine := range c.engines {
 		totalCpus += engine.TotalCpus()
 	}

--- a/scheduler/node/node.go
+++ b/scheduler/node/node.go
@@ -37,7 +37,7 @@ func NewNode(e *cluster.Engine) *Node {
 		UsedMemory:      e.UsedMemory(),
 		UsedCpus:        e.UsedCpus(),
 		TotalMemory:     e.TotalMemory(),
-		TotalCpus:       int64(e.TotalCpus()),
+		TotalCpus:       e.TotalCpus(),
 		HealthIndicator: e.HealthIndicator(),
 	}
 }


### PR DESCRIPTION
This undoes some of the type conversions that were needed to implement #1938 while waiting for #1983 to finish.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>