### PR TITLE
close http response body to avoid potential memory leak

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -988,14 +988,16 @@ func (e *Engine) Pull(image string, authConfig *types.AuthConfig) error {
 	if err != nil {
 		return err
 	}
-	pullResponse, err := e.apiClient.ImagePull(context.Background(), pullOpts, nil)
+	pullResponseBody, err := e.apiClient.ImagePull(context.Background(), pullOpts, nil)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err
 	}
 
+	defer pullResponseBody.Close()
+
 	// wait until the image download is finished
-	dec := json.NewDecoder(pullResponse)
+	dec := json.NewDecoder(pullResponseBody)
 	m := map[string]interface{}{}
 	for {
 		if err := dec.Decode(&m); err != nil {
@@ -1023,8 +1025,11 @@ func (e *Engine) Load(reader io.Reader) error {
 		return err
 	}
 
+	defer loadResponse.Body.Close()
+
 	// wait until the image load is finished
 	dec := json.NewDecoder(loadResponse.Body)
+
 	m := map[string]interface{}{}
 	for {
 		if err := dec.Decode(&m); err != nil {


### PR DESCRIPTION
It is an amazing thing for Swarm to use engine-api to contact with docker daemon. However in engine-api, after `Do a request`, sometimes it makes sure that response body is closed via `ensureReaderClosed `:
```
err = json.NewDecoder(resp.body).Decode(&dels)
ensureReaderClosed(resp)
```
In some cases, engine api returns an `io.ReadCloser`  like below:
```
	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
	if err != nil {
		return nil, err
	}
	return resp.body, nil
```
In the case above, Swarm should close the resp.body.

This PR did:
1. change `pullResponse` into `pullResponseBody` to make it more readable, as this is a type of `io.ReadCloser` or `http.Response.Body`
2. close http response body to avoid potential memory leak
 
Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>