### PR TITLE
remove Mutex in struct scheduler

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"errors"
 	"strings"
-	"sync"
 
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/filter"
@@ -17,8 +16,6 @@ var (
 
 // Scheduler is exported
 type Scheduler struct {
-	sync.Mutex
-
 	strategy strategy.PlacementStrategy
 	filters  []filter.Filter
 }


### PR DESCRIPTION
I found that struct Scheduler in /swarm/scheduler/scheduler.go is like below:
```
type Scheduler struct {
	sync.Mutex

	strategy strategy.PlacementStrategy
	filters  []filter.Filter
}
```

However, I found that in struct `Scheduler` field `sync.Mutex` is useless. Since a mutual exclusion lock is used to avoid resource race, while when initialization of scheduler is finished, no write operation will happen on Scheduler.

This PR did:
* 1. remove `sync.Mutex` in struct scheduler;
* 2. remove `c.scheduler.Lock()` and `c.scheduler.Unlock()` in swarm/cluster.go and mesos/cluster.go

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>