### PR TITLE
fix set reschedule policy docs

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -90,7 +90,7 @@ func BuildContainerConfig(c container.Config, h container.HostConfig, n network.
 		json.Unmarshal([]byte(labels), &constraints)
 	}
 
-	// parse reschedule policy from labels (ex. docker run --label 'com.docker.swarm.reschedule-policies=on-node-failure')
+	// parse reschedule policy from labels (ex. docker run --label 'com.docker.swarm.reschedule-policies=["on-node-failure"]')
 	if labels, ok := c.Labels[SwarmLabelNamespace+".reschedule-policies"]; ok {
 		json.Unmarshal([]byte(labels), &reschedulePolicies)
 	}

--- a/docs/scheduler/rescheduling.md
+++ b/docs/scheduler/rescheduling.md
@@ -19,7 +19,7 @@ running on fail.
 
 You set the reschedule policy when you start a container. You can do this with
 the `reschedule` environment variable  or the
-`com.docker.swarm.reschedule-policy` label. If you don't specify a policy, the
+`com.docker.swarm.reschedule-policies` label. If you don't specify a policy, the
 default rescheduling policy is `off` which means that Swarm does not restart a
 container when a node fails.
 
@@ -29,10 +29,10 @@ To set the `on-node-failure` policy with a `reschedule` environment variable:
 $ docker run -d -e reschedule:on-node-failure redis
 ```
 
-To set the same policy with a `com.docker.swarm.reschedule-policy` label:
+To set the same policy with a `com.docker.swarm.reschedule-policies` label:
 
 ```bash
-$ docker run -d -l 'com.docker.swarm.reschedule-policy=["on-node-failure"]' redis
+$ docker run -d -l 'com.docker.swarm.reschedule-policies=["on-node-failure"]' redis
 ```
 
 ## Review reschedule logs


### PR DESCRIPTION
Swarm can't detect `com.docker.swarm.reschedule-policy` label, and it should be `com.docker.swarm.reschedule-policies`.

Thanks.

Signed-off-by: realityone <realityone@me.com>