### PR TITLE
Update stats test to stop connection

### DIFF
--- a/test/integration/api/stats.bats
+++ b/test/integration/api/stats.bats
@@ -18,9 +18,8 @@ function teardown() {
 	# make sure container is up
 	[ -n $(docker_swarm ps -q --filter=name=test_container --filter=status=running) ]
 
-	# storage the stats output in TEMP_FILE
-	# it will stop automatically when manager stop
-	docker_swarm stats test_container > $TEMP_FILE &
+	# save the stats output in TEMP_FILE
+	docker_swarm stats --no-stream test_container > $TEMP_FILE &
 
 	# retry until TEMP_FILE is not empty
 	retry 5 1 eval "[ -s $TEMP_FILE ]"

--- a/test/integration/mesos/api/stats.bats
+++ b/test/integration/mesos/api/stats.bats
@@ -21,9 +21,8 @@ function teardown() {
 	# make sure container is up
 	[ -n $(docker_swarm ps -q --filter=name=test_container --filter=status=running) ]
 
-	# storage the stats output in TEMP_FILE
-	# it will stop automatically when manager stop
-	docker_swarm stats test_container > $TEMP_FILE &
+	# save the stats output in TEMP_FILE
+	docker_swarm stats --no-stream test_container > $TEMP_FILE &
 
 	# retry until TEMP_FILE is not empty
 	retry 5 1 eval "[ -s $TEMP_FILE ]"


### PR DESCRIPTION
On master branch, `api/stats` and `mesos/api/stats` do not clean up docker so next tests cannot start properly and it cause timeout. It may be related to Engine's re-architecture. 

Fix #2146.
 
Signed-off-by: Dong Chen <dongluo.chen@docker.com>