### PR TITLE
use --cpu-shares instead of -c in integration test

### DIFF
--- a/test/integration/resource_management.bats
+++ b/test/integration/resource_management.bats
@@ -61,7 +61,7 @@ function teardown() {
 	start_docker_with_busybox 2
 	swarm_manage
 
-	run docker_swarm run -c 10240 busybox sh
+	run docker_swarm run --cpu-shares 10240 busybox sh
 	[ "$status" -ne 0 ]
 	[[ "${output}" == *"no resources available to schedule container"* ]]
 
@@ -73,7 +73,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Nodes: 2"* ]]
 
-	docker_swarm run --name container_test -c 1 busybox sh
+	docker_swarm run --name container_test --cpu-shares 1 busybox sh
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Reserved CPUs: 1"* ]]
@@ -90,13 +90,13 @@ function teardown() {
 	start_docker_with_busybox 2
 	swarm_manage --strategy spread ${HOSTS[0]},${HOSTS[1]}
 
-	docker_swarm run --name container_test1 -c 1 busybox sh
+	docker_swarm run --name container_test1 --cpu-shares 1 busybox sh
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Reserved CPUs: 1"* ]]
 	[[ "${output}" == *"Reserved CPUs: 0"* ]]
 
-	docker_swarm run --name container_test2 -c 1 busybox sh
+	docker_swarm run --name container_test2 --cpu-shares 1 busybox sh
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Reserved CPUs: 1"* ]]
@@ -107,13 +107,13 @@ function teardown() {
 	start_docker_with_busybox 2
 	swarm_manage --strategy binpack ${HOSTS[0]},${HOSTS[1]}
 
-	docker_swarm run --name container_test1 -c 1 busybox sh
+	docker_swarm run --name container_test1 --cpu-shares 1 busybox sh
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Reserved CPUs: 1"* ]]
 	[[ "${output}" == *"Reserved CPUs: 0"* ]]
 
-	docker_swarm run --name container_test2 -c 1 busybox sh
+	docker_swarm run --name container_test2 --cpu-shares 1 busybox sh
 	run docker_swarm info
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Reserved CPUs: 2"* ]]


### PR DESCRIPTION
Running integration test locally ran into such case:
```
# Warning: '-c' is deprecated, it will be replaced by '--cpu-shares' soon. See usage.
```

This pr did:
1. use --cpu-shares instead of -c in integration test

While --cpu-shares is always usable in each version of docker daemon.

In `docker version` of docker 1.11.0, no `-c` in `docker run` usage:
```
root@10-11-1-156:~# docker run --help
Usage:	docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
Run a command in a new container
  -a, --attach=[]                 Attach to STDIN, STDOUT or STDERR
  --add-host=[]                   Add a custom host-to-IP mapping (host:ip)
  --blkio-weight                  Block IO (relative weight), between 10 and 1000
  --blkio-weight-device=[]        Block IO weight (relative device weight)
  --cpu-shares                    CPU shares (relative weight)
```

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>