### PR TITLE
change the way of producing engine label

### DIFF
--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -118,7 +118,7 @@ func TestEngineFailureCount(t *testing.T) {
 	assert.True(t, engine.failureCount == 0)
 }
 
-func TestHealthINdicator(t *testing.T) {
+func TestHealthIndicator(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.True(t, engine.state == statePending)
 	assert.True(t, engine.HealthIndicator() == 0)
@@ -222,13 +222,20 @@ func TestEngineSpecs(t *testing.T) {
 	assert.True(t, engine.isConnected())
 	assert.True(t, engine.IsHealthy())
 
-	assert.Equal(t, engine.Cpus, int64(mockInfo.NCPU))
-	assert.Equal(t, engine.Memory, mockInfo.MemTotal)
-	assert.Equal(t, engine.Labels["storagedriver"], mockInfo.Driver)
-	assert.Equal(t, engine.Labels["executiondriver"], mockInfo.ExecutionDriver)
-	assert.Equal(t, engine.Labels["kernelversion"], mockInfo.KernelVersion)
-	assert.Equal(t, engine.Labels["operatingsystem"], mockInfo.OperatingSystem)
+	mockInfo2 := mockInfo
+	mockInfo2.Labels = []string{"foo=bar", "executiondriver=newdriver", "node=node1"}
+
+	assert.Equal(t, engine.Cpus, int64(mockInfo2.NCPU))
+	assert.Equal(t, engine.Memory, mockInfo2.MemTotal)
+	assert.Equal(t, engine.Labels["storagedriver"], mockInfo2.Driver)
+
+	assert.Equal(t, engine.Labels["executiondriver"], mockInfo2.ExecutionDriver)
+
+	assert.Equal(t, engine.Labels["kernelversion"], mockInfo2.KernelVersion)
+	assert.Equal(t, engine.Labels["operatingsystem"], mockInfo2.OperatingSystem)
 	assert.Equal(t, engine.Labels["foo"], "bar")
+
+	assert.NotEqual(t, engine.Labels["node"], "node1")
 
 	client.Mock.AssertExpectations(t)
 	apiClient.Mock.AssertExpectations(t)


### PR DESCRIPTION
Swarm has its way to construct engine labels. However docker daemon changes a little in its api.
For instance:
docker 1.10.3 has a field `ExecutionDriver` in `info` api:
https://github.com/docker/docker/blob/v1.10.3/daemon/info.go#L88
while, docker 1.11.0 has no field `ExecutionDriver` in `info` api:
https://github.com/docker/docker/blob/v1.11.0/daemon/info.go#L70-L107
As a result, swarm should change a little in that case.

And this PR did:
1. validate label if it is empty;
2. fix a typo when judging whether it is a label with key `node`
3. when user-provided engine labels have overlap with swarm specific labels, send a warn log and override the latter ones 
4. fix a typo in engine_test.go
5. add several unit tests in engine_test.go

This pr will make the `continuous-integration/travis-ci/pr` show a lot of Warning logs. 
Maybe need optimized?

Fixed #2201 

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>