### PR TITLE
Update API docs to add relationship of swarm with docker api and clarify from missing endpoint

### DIFF
--- a/docs/api/status-code-comparison-to-docker.md
+++ b/docs/api/status-code-comparison-to-docker.md
@@ -2,7 +2,7 @@
 +++
 title = "API response codes"
 description = "Swarm API response codes"
-keywords = ["docker, swarm, response, code,  api"]
+keywords = ["docker, swarm, response, code, api"]
 [menu.main]
 parent="workw_swarm"
 weight=99

--- a/docs/api/swarm-and-docker-api-versions.md
+++ b/docs/api/swarm-and-docker-api-versions.md
@@ -1,0 +1,32 @@
+<!--[metadata]>
++++
+title = "Relation of Swarm and API version"
+description = "relation of Swarm and API version"
+keywords = ["docker, swarm, api, version"]
+[menu.main]
+parent="workw_swarm"
+weight=99
++++
+<![end-metadata]-->
+
+## Swarm version and Docker API version
+Every release of Swarm supports a corresponding Docker API version. The
+relationship of Swarm version and Docker API version is like the following
+table.
+
+|Swarm version|Docker API version|
+| :-: | :-: |
+|`1.2.3`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.2.2`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.2.1`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.2.0`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.1.3`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.1.2`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.1.1`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.1.0`|[1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md)|
+|`1.0.1`|[1.21](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.21.md)|
+|`1.0.0`|[1.21](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.21.md)|
+|`0.4.0`|1.16|
+|`0.3.0`|1.16|
+|`0.2.0`|1.16|
+|`0.1.0`|1.16|

--- a/docs/api/swarm-api.md
+++ b/docs/api/swarm-api.md
@@ -3,7 +3,7 @@
 aliases = ["/api/swarm-api/", "/swarm/api/"]
 title = "Docker Swarm API"
 description = "Swarm API"
-keywords = ["docker, swarm, clustering,  api"]
+keywords = ["docker, swarm, clustering, api"]
 [menu.main]
 parent="workw_swarm"
 weight=99
@@ -19,13 +19,13 @@ Remote API.
 
 ## Missing endpoints
 
-Some endpoints have not yet been implemented and will return a 404 error.
-
-```
-POST "/images/create" : "docker import" flow not implement
-```
+As of Swarm version 1.1.0 or higher, Swarm supports the API version 1.22 or 
+lower. There are no missing endpoints for Swarm in API version 1.22.
 
 ## Endpoints which behave differently
+
+Though the newest version has no missing api endpoint, there are still some which
+behave differently between Swarm and Docker Engine. 
 
 <table>
     <tr>
@@ -33,6 +33,81 @@ POST "/images/create" : "docker import" flow not implement
         <th>Differences</th>
     </tr>
     <tr>
+        <td>
+            <code>GET "/version"</code>
+        </td>
+        <td>
+            Field <code>Version</code> replaces Docker server version with Swarm version
+        </td>
+    </tr>
+        <td>
+            <code>GET "/info"</code>
+        </td>
+        <td>
+            Field <code>ServerVersion</code> replaces Docker server version with Swarm version<br/>
+            New field <code>SystemStatus</code> added with <code>Role</code>,<code>Strategy</code>,<code>Filters</code>,<code>Nodes</code>:<br />
+<pre>
+  "SystemStatus": [
+    [
+      "Role",
+      "primary"
+    ],
+    [
+      "Strategy",
+      "spread"
+    ],
+    [
+      "Filters",
+      "health, port, dependency, affinity, constraint"
+    ],
+    [
+      "Nodes",
+      "1"
+    ],
+    [
+      " ubuntu",
+      "10.1.0.108:2376"
+    ],
+    [
+      "  └ ID",
+      "RDEJ:ZCV6:CJH5:UCNB:P5RR:66LB:JZSO:YACX:TBL3:PYMV:2F77:KBUA"
+    ],
+    [
+      "  └ Status",
+      "Healthy"
+    ],
+    [
+      "  └ Containers",
+      "10"
+    ],
+    [
+      "  └ Reserved CPUs",
+      "1 / 1"
+    ],
+    [
+      "  └ Reserved Memory",
+      "8 GiB / 2.052 GiB"
+    ],
+    [
+      "  └ Labels",
+      "executiondriver=, kernelversion=3.19.0-25-generic, operatingsystem=Ubuntu 14.04.3 LTS, storagedriver=aufs"
+    ],
+    [
+      "  └ Error",
+      "(none)"
+    ],
+    [
+      "  └ UpdatedAt",
+      "2016-05-07T03:44:25Z"
+    ],
+    [
+      "  └ ServerVersion",
+      "1.11.0"
+    ]
+  ],
+</pre>
+        </td>
+    </tr>
         <td>
             <code>GET "/containers/{name:.*}/json"</code>
         </td>
@@ -96,6 +171,33 @@ POST "/images/create" : "docker import" flow not implement
             <code>CpuShares</code> in <code>HostConfig</code> sets the number of CPU cores allocated to the container.
         </td>
     </tr>
+    <tr>
+        <td>
+            <code>GET "/volumes"</code>
+        </td>
+        <td>
+            Volume name adds a prefix of Node Name:
+<pre>
+"Volumes": [
+    {
+      "Name": "ubuntu/tardis",
+      ...
+    },
+]
+</pre>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>GET "/networks"</code>
+        </td>
+        <td>
+            Network name adds a prefix of Node Name:
+<pre>
+"Name": "ubuntu/bridge",
+</pre>
+        </td>
+    </tr>
 </table>
 
 ## Registry Authentication
@@ -141,16 +243,13 @@ You can now authenticate to the registry, and run private images on Swarm:
 $ docker run --rm -it yourprivateimage:latest
 ```
 
-
 Be aware that tokens are short-lived and will expire quickly.
-
 
 ### Authenticate using username and password
 
 > **Note:** this authentication method stores your credentials unencrypted
 > on the filesystem. Refer to [Authenticate using registry tokens](#authenticate-using-registry-tokens)
 > for a more secure approach.
-
 
 First, calculate the header
 
@@ -175,8 +274,6 @@ You can now authenticate to the registry, and run private images on Swarm:
 ```bash
 $ docker run --rm -it yourprivateimage:latest
 ```
-
-
 
 ## Docker Swarm documentation index
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -222,4 +222,4 @@ github.com/docker/docker/pkg/discovery</a>.
 - [Docker Swarm overview](index.md)
 - [Scheduler strategies](scheduler/strategy.md)
 - [Scheduler filters](scheduler/filter.md)
-- [Swarm API](swarm-api.md)
+- [Swarm API](api/swarm-api.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,4 +26,4 @@ weight=-75
 * [Swarm and container networks](networking.md)
 * [Advanced Scheduling](scheduler/index.md)
 * [Provision a Swarm cluster with Docker Machine](provision-with-machine.md)
-* [Docker Swarm API](swarm-api.md)
+* [Docker Swarm API](api/swarm-api.md)

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -133,4 +133,4 @@ from `node-0`.
 - [Docker Swarm overview](index.md)
 - [Scheduler strategies](scheduler/strategy.md)
 - [Scheduler filters](scheduler/filter.md)
-- [Swarm API](swarm-api.md)
+- [Swarm API](api/swarm-api.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -63,7 +63,7 @@ documents.
 
 ## Swarm API
 
-The [Docker Swarm API](swarm-api.md) is compatible with
+The [Docker Swarm API](api/swarm-api.md) is compatible with
 the [Docker remote
 API](http://docs.docker.com/reference/api/docker_remote_api/), and extends it
 with some new endpoints.

--- a/docs/scheduler/filter.md
+++ b/docs/scheduler/filter.md
@@ -525,4 +525,4 @@ without a container that satisfies `redis*`
 - [Docker Swarm overview](../index.md)
 - [Discovery options](../discovery.md)
 - [Scheduler strategies](strategy.md)
-- [Swarm API](../swarm-api.md)
+- [Swarm API](../api/swarm-api.md)

--- a/docs/scheduler/strategy.md
+++ b/docs/scheduler/strategy.md
@@ -125,4 +125,4 @@ strategy prefers the node with most containers.
 - [Docker Swarm overview](../index.md)
 - [Discovery options](../discovery.md)
 - [Scheduler filters](filter.md)
-- [Swarm API](../swarm-api.md)
+- [Swarm API](../api/swarm-api.md)


### PR DESCRIPTION
This pr did 3 things:
1. add relationship of Swarm version and Docker API version supported;
2. clarify missing endpoint in swarm corresponding API version
3. add endpoints behaved differently.

Signed-off-by: Sun Hongliang allen.sun@daocloud.io
