### PR TITLE
hide error in info when empty

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -871,10 +871,9 @@ func (c *Cluster) Info() [][2]string {
 		sort.Strings(labels)
 		info = append(info, [2]string{"  └ Labels", fmt.Sprintf("%s", strings.Join(labels, ", "))})
 		errMsg := engine.ErrMsg()
-		if len(errMsg) == 0 {
-			errMsg = "(none)"
+		if len(errMsg) != 0 {
+			info = append(info, [2]string{"  └ Error", errMsg})
 		}
-		info = append(info, [2]string{"  └ Error", errMsg})
 		info = append(info, [2]string{"  └ UpdatedAt", engine.UpdatedAt().UTC().Format(time.RFC3339)})
 		info = append(info, [2]string{"  └ ServerVersion", engine.Version})
 	}


### PR DESCRIPTION
When Swarm manages many nodes, The `Nodes` field shows so much information that it is not so easy for us to read.

When 100 Nodes managed by Swarm works very well, we will get 100 `└ Error: (none)` which is useless. We can totally hide this error when empty, and just show error when there is indeed an error. 

This PR hides `└ Error: (none)` when error is empty, like below:
```
Nodes: 1
 ubuntu: 10.1.0.108:2376
  └ ID: RDEJ:ZCV6:CJH5:UCNB:P5RR:66LB:JZSO:YACX:TBL3:PYMV:2F77:KBUA
  └ Status: Healthy
  └ Containers: 0
  └ Reserved CPUs: 0 / 1
  └ Reserved Memory: 0 B / 2.052 GiB
  └ Labels: executiondriver=, kernelversion=3.19.0-25-generic, operatingsystem=Ubuntu 14.04.3 LTS, storagedriver=aufs
  └ UpdatedAt: 2016-05-07T04:25:53Z
  └ ServerVersion: 1.11.0
```
Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>