### PR TITLE
fix bug that http server should return when handler is nil

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -28,6 +28,7 @@ func (d *dispatcher) SetHandler(handler http.Handler) {
 func (d *dispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if d.handler == nil {
 		httpError(w, "No dispatcher defined", http.StatusInternalServerError)
+		return
 	}
 	d.handler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
fix bug that http server should return when handler is nil to avoid potential panic

Signed-off-by: Sun Hongliang <allen.sun@daocloud.io>