### PR TITLE
install-manual: fix sec. swarm manager connect

### DIFF
--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -221,7 +221,7 @@ After creating the discovery backend, you can create the Swarm managers. In this
 
       Replacing `<manager1_ip>` with the IP address from the previous command, for example:
 
-        $ docker run -d swarm manage -H :4000 --replication --advertise <manager1_ip>:4000 consul://172.30.0.161:8500
+        $ docker run -d -p 4000:4000 swarm manage -H :4000 --replication --advertise <manager1_ip>:4000 consul://172.30.0.161:8500
 
 5. Enter `docker ps`to verify that a Swarm container is running.
 


### PR DESCRIPTION
Apparently, without -p 4000:4000 the secondary swarm manager would be inaccessible, basically rendering it useless.

Signed-off-by: Kir Kolyshkin <kir@openvz.org>