### PR TITLE
[DOCS] Typo in scheduler/filter.md

### DIFF
--- a/docs/scheduler/filter.md
+++ b/docs/scheduler/filter.md
@@ -196,7 +196,7 @@ there will be no limit on container number.
 When creating a container, you can use three types of container filters:
 
 * [`affinity`](#use-an-affinity-filter)
-* [`dependency`](#use-a-depedency-filter)
+* [`dependency`](#use-a-dependency-filter)
 * [`port`](#use-a-port-filter)
 
 ### Use an affinity filter


### PR DESCRIPTION
Link to the correct id #use-a-dependency-filter