### PR TITLE
fix unit test command in CONTRIBUTION.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ For complete documentation on how to use Swarm, refer to the Swarm section of [d
 To run unit tests:
 
 ```sh
-go test -race ./...
+go test -v -race `go list ./... | grep -v /vendor/`
 ```
 
 To run integration tests:


### PR DESCRIPTION
This PR fixed the unit test command in CONTRIBUTION.md.
It could help hacker follow the instructions in CONTRIBUTION.md without confuse.

Fixed #2221 

Signed-off-by: allencloud <allen.sun@daocloud.io>