### PR TITLE
remove engine details in POST /volumes/create API

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -45,7 +45,7 @@ type Cluster interface {
 	RemoveNetwork(network *Network) error
 
 	// Create a volume
-	CreateVolume(request *types.VolumeCreateRequest) (*Volume, error)
+	CreateVolume(request *types.VolumeCreateRequest) (*types.Volume, error)
 
 	// Return all volumes
 	Volumes() Volumes

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -945,17 +945,16 @@ func (e *Engine) CreateNetwork(name string, request *types.NetworkCreate) (*type
 }
 
 // CreateVolume creates a volume in the engine
-func (e *Engine) CreateVolume(request *types.VolumeCreateRequest) (*Volume, error) {
+func (e *Engine) CreateVolume(request *types.VolumeCreateRequest) (*types.Volume, error) {
 	volume, err := e.apiClient.VolumeCreate(context.Background(), *request)
-
-	e.RefreshVolumes()
 	e.CheckConnectionErr(err)
-
 	if err != nil {
 		return nil, err
 	}
-	return &Volume{Volume: volume, Engine: e}, nil
 
+	e.RefreshVolumes()
+
+	return &volume, err
 }
 
 // encodeAuthToBase64 serializes the auth configuration as JSON base64 payload

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -301,7 +301,7 @@ func (c *Cluster) refreshNetworks() {
 }
 
 // CreateVolume creates a volume in the cluster
-func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*cluster.Volume, error) {
+func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*types.Volume, error) {
 	return nil, errNotSupported
 }
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -493,10 +493,10 @@ func (c *Cluster) CreateNetwork(name string, request *types.NetworkCreate) (resp
 }
 
 // CreateVolume creates a volume in the cluster
-func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*cluster.Volume, error) {
+func (c *Cluster) CreateVolume(request *types.VolumeCreateRequest) (*types.Volume, error) {
 	var (
 		wg     sync.WaitGroup
-		volume *cluster.Volume
+		volume *types.Volume
 		err    error
 		parts  = strings.SplitN(request.Name, "/", 2)
 		node   = ""


### PR DESCRIPTION
This PR did:
remove engine details in POST /volumes/create API

Fixed #2260 

Signed-off-by: allencloud <allen.sun@daocloud.io>