### PR TITLE
Remove unneeded Container() interface

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -339,7 +339,7 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		before *cluster.Container
 	)
 	if value := r.FormValue("before"); value != "" {
-		before = c.cluster.Container(value)
+		before = c.cluster.Containers().Get(value)
 		if before == nil {
 			httpError(w, fmt.Sprintf("No such container %s", value), http.StatusNotFound)
 			return
@@ -486,7 +486,7 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 // GET /containers/{name:.*}/json
 func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
-	container := c.cluster.Container(name)
+	container := c.cluster.Containers().Get(name)
 	if container == nil {
 		httpError(w, fmt.Sprintf("No such container %s", name), http.StatusNotFound)
 		return
@@ -606,7 +606,7 @@ func deleteContainers(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	force := boolValue(r, "force")
 	volumes := boolValue(r, "v")
-	container := c.cluster.Container(name)
+	container := c.cluster.Containers().Get(name)
 	if container == nil {
 		httpError(w, fmt.Sprintf("Container %s not found", name), http.StatusNotFound)
 		return
@@ -793,7 +793,7 @@ func getEvents(c *context, w http.ResponseWriter, r *http.Request) {
 // POST /containers/{name:.*}/start
 func postContainersStart(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
-	container := c.cluster.Container(name)
+	container := c.cluster.Containers().Get(name)
 	if container == nil {
 		httpError(w, fmt.Sprintf("No such container %s", name), http.StatusNotFound)
 		return
@@ -837,7 +837,7 @@ func postExecStart(c *context, w http.ResponseWriter, r *http.Request) {
 // POST /containers/{name:.*}/exec
 func postContainersExec(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
-	container := c.cluster.Container(name)
+	container := c.cluster.Containers().Get(name)
 	if container == nil {
 		httpError(w, fmt.Sprintf("No such container %s", name), http.StatusNotFound)
 		return
@@ -996,7 +996,7 @@ func proxyNetworkDisconnect(c *context, w http.ResponseWriter, r *http.Request) 
 		}
 		engine = randomEngine
 	} else {
-		container := c.cluster.Container(disconnect.Container)
+		container := c.cluster.Containers().Get(disconnect.Container)
 		if container == nil {
 			httpError(w, fmt.Sprintf("No such container: %s", disconnect.Container), http.StatusNotFound)
 			return
@@ -1041,7 +1041,7 @@ func proxyNetworkConnect(c *context, w http.ResponseWriter, r *http.Request) {
 		httpError(w, fmt.Sprintf("Container is not specified"), http.StatusNotFound)
 		return
 	}
-	container := c.cluster.Container(connect.Container)
+	container := c.cluster.Containers().Get(connect.Container)
 	if container == nil {
 		httpError(w, fmt.Sprintf("No such container: %s", connect.Container), http.StatusNotFound)
 		return

--- a/api/utils.go
+++ b/api/utils.go
@@ -57,7 +57,7 @@ func sendErrorJSONMessage(w io.Writer, errorCode int, errorMessage string) {
 
 func getContainerFromVars(c *context, vars map[string]string) (string, *cluster.Container, error) {
 	if name, ok := vars["name"]; ok {
-		if container := c.cluster.Container(name); container != nil {
+		if container := c.cluster.Containers().Get(name); container != nil {
 			if !container.Engine.IsHealthy() {
 				return name, container, fmt.Errorf("Container %s running on unhealthy node %s", name, container.Engine.Name)
 			}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -30,11 +30,6 @@ type Cluster interface {
 	// Start a container
 	StartContainer(container *Container, hostConfig *dockerclient.HostConfig) error
 
-	// Return container the matching `IDOrName`
-	// TODO: remove this method from the interface as we can use
-	// cluster.Containers().Get(IDOrName)
-	Container(IDOrName string) *Container
-
 	// Return all networks
 	Networks() Networks
 

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -346,19 +346,6 @@ func (c *Cluster) Containers() cluster.Containers {
 	return out
 }
 
-// Container returns the container with IdOrName in the cluster
-func (c *Cluster) Container(IDOrName string) *cluster.Container {
-	// Abort immediately if the name is empty.
-	if len(IDOrName) == 0 {
-		return nil
-	}
-
-	c.RLock()
-	defer c.RUnlock()
-
-	return formatContainer(cluster.Containers(c.Containers()).Get(IDOrName))
-}
-
 // RemoveImage removes an image from the cluster
 func (c *Cluster) RemoveImage(image *cluster.Image) ([]types.ImageDelete, error) {
 	return nil, errNotSupported

--- a/cluster/mesos/cluster_test.go
+++ b/cluster/mesos/cluster_test.go
@@ -75,21 +75,21 @@ func TestContainerLookup(t *testing.T) {
 	assert.Equal(t, len(c.Containers()), 2)
 
 	// Invalid lookup
-	assert.Nil(t, c.Container("invalid-id"))
-	assert.Nil(t, c.Container(""))
+	assert.Nil(t, c.Containers().Get("invalid-id"))
+	assert.Nil(t, c.Containers().Get(""))
 	// Container ID lookup.
-	assert.NotNil(t, c.Container("container1-id"))
+	assert.NotNil(t, c.Containers().Get("container1-id"))
 	// Container ID prefix lookup.
-	assert.NotNil(t, c.Container("container1-"))
-	assert.Nil(t, c.Container("container"))
+	assert.NotNil(t, c.Containers().Get("container1-"))
+	assert.Nil(t, c.Containers().Get("container"))
 	// Container name lookup.
-	assert.NotNil(t, c.Container("container1-name1"))
-	assert.NotNil(t, c.Container("container1-name2"))
+	assert.NotNil(t, c.Containers().Get("container1-name1"))
+	assert.NotNil(t, c.Containers().Get("container1-name2"))
 	// Container engine/name matching.
-	assert.NotNil(t, c.Container("test-engine/container1-name1"))
-	assert.NotNil(t, c.Container("test-engine/container1-name2"))
+	assert.NotNil(t, c.Containers().Get("test-engine/container1-name1"))
+	assert.NotNil(t, c.Containers().Get("test-engine/container1-name2"))
 	// Match name before ID prefix
-	cc := c.Container("con")
+	cc := c.Containers().Get("con")
 	assert.NotNil(t, cc)
 	assert.Equal(t, cc.ID, "container2-id")
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -131,7 +131,7 @@ func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 func (c *Cluster) generateUniqueID() string {
 	for {
 		id := stringid.GenerateRandomID()
-		if c.Container(id) == nil {
+		if c.Containers().Get(id) == nil {
 			return id
 		}
 	}
@@ -752,15 +752,6 @@ func (c *Cluster) checkNameUniqueness(name string) bool {
 	}
 
 	return true
-}
-
-// Container returns the container with IDOrName in the cluster
-func (c *Cluster) Container(IDOrName string) *cluster.Container {
-	// Abort immediately if the name is empty.
-	if len(IDOrName) == 0 {
-		return nil
-	}
-	return c.Containers().Get(IDOrName)
 }
 
 // Networks returns all the networks in the cluster.

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -98,26 +98,26 @@ func TestContainerLookup(t *testing.T) {
 	assert.Equal(t, len(c.Containers()), 2)
 
 	// Invalid lookup
-	assert.Nil(t, c.Container("invalid-id"))
-	assert.Nil(t, c.Container(""))
+	assert.Nil(t, c.Containers().Get("invalid-id"))
+	assert.Nil(t, c.Containers().Get(""))
 	// Container ID lookup.
-	assert.NotNil(t, c.Container("container1-id"))
+	assert.NotNil(t, c.Containers().Get("container1-id"))
 	// Container ID prefix lookup.
-	assert.NotNil(t, c.Container("container1-"))
-	assert.Nil(t, c.Container("container"))
+	assert.NotNil(t, c.Containers().Get("container1-"))
+	assert.Nil(t, c.Containers().Get("container"))
 	// Container name lookup.
-	assert.NotNil(t, c.Container("container1-name1"))
-	assert.NotNil(t, c.Container("container1-name2"))
+	assert.NotNil(t, c.Containers().Get("container1-name1"))
+	assert.NotNil(t, c.Containers().Get("container1-name2"))
 	// Container engine/name matching.
-	assert.NotNil(t, c.Container("test-engine/container1-name1"))
-	assert.NotNil(t, c.Container("test-engine/container1-name2"))
+	assert.NotNil(t, c.Containers().Get("test-engine/container1-name1"))
+	assert.NotNil(t, c.Containers().Get("test-engine/container1-name2"))
 	// Swarm ID lookup.
-	assert.NotNil(t, c.Container("swarm1-id"))
+	assert.NotNil(t, c.Containers().Get("swarm1-id"))
 	// Swarm ID prefix lookup.
-	assert.NotNil(t, c.Container("swarm1-"))
-	assert.Nil(t, c.Container("swarm"))
+	assert.NotNil(t, c.Containers().Get("swarm1-"))
+	assert.Nil(t, c.Containers().Get("swarm"))
 	// Match name before ID prefix
-	cc := c.Container("con")
+	cc := c.Containers().Get("con")
 	assert.NotNil(t, cc)
 	assert.Equal(t, cc.ID, "container2-id")
 }


### PR DESCRIPTION
It's wired that `Container()` interface is duplicated with `Containers().Get()`, this will fix that.

Signed-off-by: Harry Zhang <harryz@hyper.sh>

