### PR TITLE
Add scheduler detail log for node

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -220,6 +220,7 @@ func (c *Cluster) createContainer(config *cluster.ContainerConfig, name string, 
 
 	c.scheduler.Unlock()
 
+	log.WithFields(log.Fields{"NodeName": n.Name, "NodeID": n.ID}).Debugf("Scheduling container %s to ", name)
 	container, err := engine.Create(config, name, true, authConfig)
 
 	c.scheduler.Lock()


### PR DESCRIPTION
 This PR add scheduler detail log for node select. It's important info for user when a container occurs some problem, we can easily find which node to login and find what happend.