### PR TITLE
Refactoring code around image ref generation

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -320,3 +320,17 @@ func int64ValueOrZero(r *http.Request, k string) int64 {
 func tagHasDigest(tag string) bool {
 	return strings.Contains(tag, ":")
 }
+
+// TODO(nishanttotla): There might be a better way to pass a ref string than construct it here
+// getImageRef returns a string containing the registry reference given a repo and tag
+func getImageRef(repo, tag string) string {
+	ref := repo
+	if tag != "" {
+		if tagHasDigest(tag) {
+			ref += "@" + tag
+		} else {
+			ref += ":" + tag
+		}
+	}
+	return ref
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -63,7 +63,7 @@ type Cluster interface {
 	// `callback` can be called multiple time
 	// `where` is where it is being imported
 	// `status` is the current status, like "", "in progress" or "imported"
-	Import(source string, repository string, tag string, imageReader io.Reader, callback func(where, status string, err error))
+	Import(source string, ref string, tag string, imageReader io.Reader, callback func(where, status string, err error))
 
 	// Load images
 	// `callback` can be called multiple time
@@ -98,5 +98,5 @@ type Cluster interface {
 	BuildImage(io.Reader, *types.ImageBuildOptions, io.Writer) error
 
 	// Tag an image
-	TagImage(IDOrName string, repo string, tag string, force bool) error
+	TagImage(IDOrName string, ref string, force bool) error
 }

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1045,7 +1045,7 @@ func (e *Engine) Load(reader io.Reader) error {
 }
 
 // Import image
-func (e *Engine) Import(source string, repository string, tag string, imageReader io.Reader) error {
+func (e *Engine) Import(source string, ref string, tag string, imageReader io.Reader) error {
 	importSrc := types.ImageImportSource{
 		Source:     imageReader,
 		SourceName: source,
@@ -1053,17 +1053,7 @@ func (e *Engine) Import(source string, repository string, tag string, imageReade
 	opts := types.ImageImportOptions{
 		Tag: tag,
 	}
-	// TODO(nishanttotla): There might be a better way to pass a ref string than construct it here
 
-	// generate ref string
-	ref := repository
-	if tag != "" {
-		if strings.Contains(tag, ":") {
-			ref += "@" + tag
-		} else {
-			ref += ":" + tag
-		}
-	}
 	_, err := e.apiClient.ImageImport(context.Background(), importSrc, ref, opts)
 	e.CheckConnectionErr(err)
 	if err != nil {
@@ -1281,22 +1271,12 @@ func (e *Engine) BuildImage(buildContext io.Reader, buildImage *types.ImageBuild
 }
 
 // TagImage tags an image
-func (e *Engine) TagImage(IDOrName string, repo string, tag string, force bool) error {
+func (e *Engine) TagImage(IDOrName string, ref string, force bool) error {
 	// send tag request to docker engine
 	opts := types.ImageTagOptions{
 		Force: force,
 	}
-	// TODO(nishanttotla): There might be a better way to pass a ref string than construct it here
 
-	// generate ref string
-	ref := repo
-	if tag != "" {
-		if strings.Contains(tag, ":") {
-			ref += "@" + tag
-		} else {
-			ref += ":" + tag
-		}
-	}
 	err := e.apiClient.ImageTag(context.Background(), IDOrName, ref, opts)
 	e.CheckConnectionErr(err)
 	if err != nil {

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -375,7 +375,7 @@ func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string
 }
 
 // Import image
-func (c *Cluster) Import(source string, repository string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
+func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
 
 }
 
@@ -675,6 +675,6 @@ func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuil
 }
 
 // TagImage tags an image
-func (c *Cluster) TagImage(IDOrName string, repo string, tag string, force bool) error {
+func (c *Cluster) TagImage(IDOrName string, ref string, force bool) error {
 	return errNotSupported
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -663,7 +663,7 @@ func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string
 }
 
 // Import image
-func (c *Cluster) Import(source string, repository string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
+func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
 	var wg sync.WaitGroup
 	c.RLock()
 	pipeWriters := []*io.PipeWriter{}
@@ -679,7 +679,7 @@ func (c *Cluster) Import(source string, repository string, tag string, imageRead
 			defer reader.Close()
 
 			// call engine import
-			err := engine.Import(source, repository, tag, reader)
+			err := engine.Import(source, ref, tag, reader)
 			if callback != nil {
 				if err != nil {
 					callback(engine.Name, "", err)
@@ -932,7 +932,7 @@ func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuil
 }
 
 // TagImage tags an image
-func (c *Cluster) TagImage(IDOrName string, repo string, tag string, force bool) error {
+func (c *Cluster) TagImage(IDOrName string, ref string, force bool) error {
 	c.RLock()
 	defer c.RUnlock()
 
@@ -943,7 +943,7 @@ func (c *Cluster) TagImage(IDOrName string, repo string, tag string, force bool)
 		for _, image := range e.Images() {
 			if image.Match(IDOrName, true) {
 				found = true
-				err := image.Engine.TagImage(IDOrName, repo, tag, force)
+				err := image.Engine.TagImage(IDOrName, ref, force)
 				if err != nil {
 					errs = append(errs, fmt.Sprintf("%s: %s", image.Engine.Name, err.Error()))
 					continue

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -265,6 +265,6 @@ func TestTagImage(t *testing.T) {
 
 	// tag image
 	apiClient.On("ImageTag", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("types.ImageTagOptions")).Return(nil).Once()
-	assert.Nil(t, c.TagImage("busybox", "test_busybox", "latest", false))
-	assert.NotNil(t, c.TagImage("busybox_not_exists", "test_busybox", "latest", false))
+	assert.Nil(t, c.TagImage("busybox", "test_busybox:latest", false))
+	assert.NotNil(t, c.TagImage("busybox_not_exists", "test_busybox:latest", false))
 }


### PR DESCRIPTION
Follow up to #2272.

Moving code for generating image refs from repo and tag to one place.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>