### PR TITLE
make /images/json compatible with docker engine

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -232,7 +232,7 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		image.RepoTags = result
 
 		// de-duplicate RepoDigests
-		result = []string{}
+		result = nil
 		seen = map[string]bool{}
 		for _, val := range image.RepoDigests {
 			if _, ok := seen[val]; !ok {
@@ -240,6 +240,7 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 				seen[val] = true
 			}
 		}
+
 		image.RepoDigests = result
 
 		images = append(images, image)


### PR DESCRIPTION
fixed #2294 

In API `/images/json`, when no data in field **RepoDigests**, Swarm returns a field with `[]`, while docker engine returns `null`.

This PR made Swarm's response compatible with docker's returning **null**.

Signed-off-by: allencloud allen.sun@daocloud.io
