### PR TITLE
Fix network Uniq method concurrent map writes problem

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -30,7 +30,12 @@ func (networks Networks) Uniq() Networks {
 				tmp[network.ID].Containers[id] = endpoint
 			}
 		} else {
-			tmp[network.ID] = network
+			netCopy := *network
+			netCopy.Containers = make(map[string]types.EndpointResource)
+			for key, value := range network.Containers {
+				netCopy.Containers[key] = value
+			}
+			tmp[network.ID] = &netCopy
 		}
 	}
 	uniq := Networks{}


### PR DESCRIPTION
This PR copy networks struct in Uniq method in network module. When concurrent write network's containers attribute, it will cause some error like this.


> time="2016-05-27T18:12:16+08:00"
>level=info msg="Creating container test2_web_5 with config &{Hostname: Domainname: User: AttachStdin:false AttachStdout:false AttachStderr:false ExposedPorts:map[80/tcp:{}] Tty:false OpenStdin:false StdinOnce:false Env:[WORDPRESS_AUTH_SALT=changeme WORDPRESS_LOGGED_IN_KEY=changeme WORDPRESS_AUTH_KEY=changeme WORDPRESS_SECURE_AUTH_SALT=changeme WORDPRESS_NONCE_KEY=changeme WORDPRESS_LOGGED_IN_SALT=changeme WORDPRESS_NONCE_SALT=changeme WORDPRESS_SECURE_AUTH_KEY=changeme com.docker.compose.service:web com.docker.compose.version:1.7.1 aliyun.scale:3] StopSignal: VolumeDriver: Memory:0 MemorySwap:0 CpuShares:0 Cpuset: PortSpecs:[] HostConfig:{Binds:[] ContainerIDFile: LxcConf:[] Memory:0 MemoryReservation:0 MemorySwap:0 KernelMemory:0 CpuShares:0 CpuPeriod:0 CpusetCpus: CpusetMems: CpuQuota:0 BlkioWeight:0 OomKillDisable:false MemorySwappiness:0 Privileged:false PortBindings:map[80/tcp:[{HostIp: HostPort:}]] Links:[test2_db_1:db_1 test2_db_1:mysql test2_db_1:test2_db_1] PublishAllPorts:false Dns:[] DNSOptions:[] DnsSearch:[] ExtraHosts:[] VolumesFrom:[] Devices:[] NetworkMode:default IpcMode: PidMode: UTSMode: CapAdd:[] CapDrop:[] GroupAdd:[] RestartPolicy:{Name:always MaximumRetryCount:0} SecurityOpt:[] ReadonlyRootfs:false Ulimits:[] LogConfig:{Type: Config:map[]} CgroupParent: ConsoleSize:[0 0] VolumeDriver: OomScoreAdj:0 Tmpfs:map[] ShmSize:0 BlkioWeightDevice:[] BlkioDeviceReadBps:[] BlkioDeviceWriteBps:[] BlkioDeviceReadIOps:[] BlkioDeviceWriteIOps:[]} NetworkingConfig:<nil>}"
fatal error: concurrent map writes
goroutine 23291 [running]:
runtime.throw(0x10d8240, 0x15)
/usr/local/go/src/runtime/panic.go:530 +0x90 fp=0xc820b24fd0 sp=0xc820b24fb8
runtime.mapassign1(0xbbaa80, 0xc820c8fe00, 0xc820b25100, 0xc820b25210)
/usr/local/go/src/runtime/hashmap.go:445 +0xb1 fp=0xc820b25078 sp=0xc820b24fd0
github.com/docker/swarm/cluster.Networks.Uniq(0xc8203ebd00, 0x3, 0x4, 0x0, 0x0, 0x0)
/Users/go/src/github.com/docker/swarm/cluster/network.go:30 +0x2ce fp=0xc820b253f8 sp=0xc820b25078
github.com/docker/swarm/cluster.Networks.Get(0xc820b792c0, 0xf, 0x18, 0xc8203ebb80, 0x12, 0x0)
/Users/go/src/github.com/docker/swarm/cluster/network.go:133 +0x354 fp=0xc820b25550 `

Signed-off-by: Xianlu <xianlu.cxl@alibaba-inc.com>