### PR TITLE
support daemon events for swarm

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1152,6 +1152,13 @@ func (e *Engine) handler(msg events.Message) error {
 		default:
 			e.refreshContainer(msg.ID, false)
 		}
+	case "daemon":
+		// docker 1.12 started to support daemon events
+		// https://github.com/docker/docker/pull/22590
+		switch msg.Action {
+		case "reload":
+			e.updateSpecs()
+		}
 	case "":
 		// docker < 1.10
 		switch msg.Status {


### PR DESCRIPTION
fixed #2285 

Since docker 1.12.0 supports docker daemon events **RELOAD**.
Once docker daemon reloads configuration such as labels, if swarm can change engine's info at the first time via events policy, then when swarm schedules container more accurate instead of waiting swarm itself change engine's state in a `refreshLoop`.

Signed-off-by: allencloud <allen.sun@daocloud.io>