### PR TITLE
update min docker engine's version swarm supports

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -37,7 +37,7 @@ const (
 	thresholdTime = 2 * time.Second
 
 	// Minimum docker engine version supported by swarm.
-	minSupportedVersion = version.Version("1.6.0")
+	minSupportedVersion = version.Version("1.8.0")
 )
 
 type engineState int
@@ -432,13 +432,9 @@ func (e *Engine) CheckConnectionErr(err error) {
 
 // Update API Version in apiClient
 func (e *Engine) updateClientVersionFromServer(serverVersion string) {
-	// v will be >= 1.6, since this is checked earlier
+	// v will be >= 1.8, since this is checked earlier
 	v := version.Version(serverVersion)
 	switch {
-	case v.LessThan(version.Version("1.7")):
-		e.apiClient.UpdateClientVersion("1.18")
-	case v.LessThan(version.Version("1.8")):
-		e.apiClient.UpdateClientVersion("1.19")
 	case v.LessThan(version.Version("1.9")):
 		e.apiClient.UpdateClientVersion("1.20")
 	case v.LessThan(version.Version("1.10")):

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -45,7 +45,7 @@ var (
 	}
 
 	mockVersion = types.Version{
-		Version: "1.6.2",
+		Version: "1.8.2",
 	}
 
 	engOpts = &EngineOpts{

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -40,7 +40,7 @@ var (
 	}
 
 	mockVersion = types.Version{
-		Version: "1.6.2",
+		Version: "1.8.2",
 	}
 
 	engOpts = &cluster.EngineOpts{


### PR DESCRIPTION
This PR updated min docker engine's version swarm supports

Since 
* engine-api does not support API /events in docker 1.7.x
* engine-api does not support API /info in docker 1.6.x.

So the minimum docker version Swarm supports is 1.8.0. And we can revert the minSupportedVersion until engine-api supports lower engine version.

Fixed #2330 

It is really surprised me that the minimum engine version swarm supports is 1.8.0. And maybe some work needs to be done in engine-api to enhance this.