### PR TITLE
add InspectContainer and CreateContainerExec in engine.go and called in handler.go

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -555,10 +555,6 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 // GET /containers/{name:.*}/json
 func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
-	sizeQuery := ""
-	if boolValue(r, "size") {
-		sizeQuery = "?size=1"
-	}
 	container := c.cluster.Container(name)
 	if container == nil {
 		httpError(w, fmt.Sprintf("No such container %s", name), http.StatusNotFound)
@@ -570,51 +566,28 @@ func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, scheme, err := container.Engine.HTTPClientAndScheme()
-	if err != nil {
-		httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	resp, err := client.Get(scheme + "://" + container.Engine.Addr + "/containers/" + container.ID + "/json" + sizeQuery)
-	container.Engine.CheckConnectionErr(err)
-	if err != nil {
-		httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// cleanup
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	n, err := json.Marshal(container.Engine)
+	con, err := container.Engine.InspectContainer(container.ID)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// insert Node field
-	data = bytes.Replace(data, []byte(`"Name":"/`), []byte(fmt.Sprintf(`"Node":%s,"Name":"/`, n)), -1)
+	con.Node = container.Engine.EngineToContainerNode()
 
-	// insert node IP
-	if engineIP := net.ParseIP(container.Engine.IP); engineIP != nil {
-		var orig string
-		if engineIP.To4() != nil {
-			orig = fmt.Sprintf(`"HostIp":"%s"`, net.IPv4zero.String())
-		} else {
-			orig = fmt.Sprintf(`"HostIp":"%s"`, net.IPv6zero.String())
+	// update zero ip to engine ip, including IPv4 and IPv6
+	if con.NetworkSettings != nil {
+		for _, portBindings := range con.NetworkSettings.Ports {
+			for key, portBinding := range portBindings {
+				if ip := net.ParseIP(portBinding.HostIP); ip == nil || ip.IsUnspecified() {
+					portBindings[key].HostIP = container.Engine.IP
+				}
+			}
 		}
-		replace := fmt.Sprintf(`"HostIp":"%s"`, container.Engine.IP)
-		data = bytes.Replace(data, []byte(orig), []byte(replace), -1)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(data)
+	json.NewEncoder(w).Encode(con)
 }
 
 // POST /containers/create
@@ -921,52 +894,29 @@ func postContainersExec(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, scheme, err := container.Engine.HTTPClientAndScheme()
+	execConfig := apitypes.ExecConfig{}
+	if err := json.NewDecoder(r.Body).Decode(&execConfig); err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if len(execConfig.Cmd) == 0 {
+		httpError(w, fmt.Sprintf("No exec command specified"), http.StatusBadRequest)
+		return
+	}
+
+	execCreateResp, err := container.Engine.CreateContainerExec(container.ID, execConfig)
 	if err != nil {
-		httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	resp, err := client.Post(scheme+"://"+container.Engine.Addr+"/containers/"+container.ID+"/exec", "application/json", r.Body)
-	container.Engine.CheckConnectionErr(err)
-	if err != nil {
-		httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// cleanup
-	defer resp.Body.Close()
-
-	// check status code
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			httpError(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		httpError(w, string(body), http.StatusInternalServerError)
-		return
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	id := struct{ ID string }{}
-
-	if err := json.Unmarshal(data, &id); err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// add execID to the container, so the later exec/start will work
-	container.Info.ExecIDs = append(container.Info.ExecIDs, id.ID)
+	container.Info.ExecIDs = append(container.Info.ExecIDs, execCreateResp.ID)
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
-	w.Write(data)
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(execCreateResp)
 }
 
 // DELETE /images/{name:.*}

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -443,6 +443,19 @@ func (e *Engine) CheckConnectionErr(err error) {
 	// other errors may be ambiguous.
 }
 
+// EngineToContainerNode constructs types.ContainerNode from engine
+func (e *Engine) EngineToContainerNode() *types.ContainerNode {
+	return &types.ContainerNode{
+		ID:        e.ID,
+		IPAddress: e.IP,
+		Addr:      e.Addr,
+		Name:      e.Name,
+		Cpus:      int(e.Cpus),
+		Memory:    int64(e.Memory),
+		Labels:    e.Labels,
+	}
+}
+
 // Update API Version in apiClient
 func (e *Engine) updateClientVersionFromServer(serverVersion string) {
 	// v will be >= 1.8, since this is checked earlier
@@ -1409,6 +1422,28 @@ func (e *Engine) StartContainer(container *Container, hostConfig *dockerclient.H
 	}
 
 	return err
+}
+
+// InspectContainer inspects a container
+func (e *Engine) InspectContainer(id string) (*types.ContainerJSON, error) {
+	container, err := e.apiClient.ContainerInspect(context.Background(), id)
+	e.CheckConnectionErr(err)
+	if err != nil {
+		return nil, err
+	}
+
+	return &container, nil
+}
+
+// CreateContainerExec creates a container exec
+func (e *Engine) CreateContainerExec(id string, config types.ExecConfig) (types.IDResponse, error) {
+	execCreateResp, err := e.apiClient.ContainerExecCreate(context.Background(), id, config)
+	e.CheckConnectionErr(err)
+	if err != nil {
+		return types.IDResponse{}, err
+	}
+
+	return execCreateResp, nil
 }
 
 // RenameContainer renames a container


### PR DESCRIPTION
I found with API `GET /containers/{name:.*}/json` and `POST /containers/{name:.*}/exec` in handler.go, Swarm constructs a request by his own to get an response, then manually inserts Node and others in response.

It is costy to insert data and do the replace thing. And this is inconsistency in form data.

This PR did:
1. add InspectContainer and CreateContainerExec in engine.go;
2. in handler, just call InspectContainer and CreateContainerExec;
3. In engine.go add EngineToContainerNode.

Signed-off-by: allencloud allen.sun@daocloud.io
