### PR TITLE
[WIP] [RFC] Experimental implementation of using an external scheduler

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -29,7 +29,7 @@ var (
 				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry, flRefreshRetry,
 				flHeartBeat,
 				flEnableCors,
-				flCluster, flDiscoveryOpt, flClusterOpt, flRefreshOnNodeFilter, flContainerNameRefreshFilter},
+				flCluster, flDiscoveryOpt, flSchedulerOpt, flClusterOpt, flRefreshOnNodeFilter, flContainerNameRefreshFilter},
 			Action: manage,
 		},
 		{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -142,6 +142,11 @@ var (
 		Usage: "discovery options",
 		Value: &cli.StringSlice{},
 	}
+	flSchedulerOpt = cli.StringSliceFlag{
+		Name:  "scheduler-opt",
+		Usage: "scheduler options",
+		Value: &cli.StringSlice{},
+	}
 	flLeaderElection = cli.BoolFlag{
 		Name:  "replication",
 		Usage: "Enable Swarm manager replication",

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -116,16 +116,21 @@ func createDiscovery(uri string, c *cli.Context) discovery.Backend {
 	return discovery
 }
 
-func getDiscoveryOpt(c *cli.Context) map[string]string {
+func getKeyValOpts(c *cli.Context, from string) map[string]string {
 	// Process the store options
 	options := map[string]string{}
-	for _, option := range c.StringSlice("discovery-opt") {
+	for _, option := range c.StringSlice(from) {
 		if !strings.Contains(option, "=") {
-			log.Fatal("--discovery-opt must contain key=value strings")
+			log.Fatalf("--%s must contain key=value strings", from)
 		}
 		kvpair := strings.SplitN(option, "=", 2)
 		options[kvpair[0]] = kvpair[1]
 	}
+	return options
+}
+
+func getDiscoveryOpt(c *cli.Context) map[string]string {
+	options := getKeyValOpts(c, "discovery-opt")
 	if _, ok := options["kv.path"]; !ok {
 		options["kv.path"] = "docker/swarm/nodes"
 	}
@@ -269,7 +274,7 @@ func manage(c *cli.Context) {
 		log.Fatalf("discovery required to manage a cluster. See '%s manage --help'.", c.App.Name)
 	}
 	discovery := createDiscovery(uri, c)
-	s, err := strategy.New(c.String("strategy"))
+	s, err := strategy.New(c.String("strategy"), getKeyValOpts(c, "scheduler-opt"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scheduler/simplified-schema/schema.go
+++ b/scheduler/simplified-schema/schema.go
@@ -1,0 +1,102 @@
+package simplifiedschema
+
+import (
+	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/scheduler/node"
+)
+
+type Config struct {
+	Image     string
+	CpuShares int
+	MemShares int
+}
+
+type Container struct {
+	Names  []string          `json:"names"`
+	Image  string            `json:"image"`
+	State  string            `json:"state"`
+	Ports  []int             `json:"ports"`
+	Labels map[string]string `json:"labels"`
+}
+
+type Image struct {
+	RepoTags    []string          `json:"repo_tags"`
+	RepoDigests []string          `json:"repo_digests"`
+	Labels      map[string]string `json:"labels"`
+}
+
+type Resource struct {
+	Used  int64 `json:"used"`
+	Total int64 `json:"total"`
+}
+
+type Node struct {
+	ID              string            `json:"id"`
+	HealthIndicator int64             `json:"scheduling_health"`
+	Name            string            `json:"name"`
+	Addr            string            `json:"addr"`
+	Labels          map[string]string `json:"labels"`
+	Containers      []Container       `json:"containers"`
+	Images          []Image           `json:"images"`
+	CPUs            Resource          `json:"cpus"`
+	Memory          Resource          `json:"memory"`
+	//EngineVersion   string            `json:"engine_version"`
+}
+
+type Placement struct {
+	Config cluster.ContainerConfig `json:"config"`
+	Nodes  []Node                  `json:"nodes"`
+}
+
+func SimplifyPlacement(config *cluster.ContainerConfig, nodes []*node.Node) *Placement {
+	placement := &Placement{}
+	placement.Config = *config
+
+	for _, node := range nodes {
+		placement.Nodes = append(placement.Nodes, SimplifyNode(node))
+	}
+
+	return placement
+}
+
+func SimplifyNode(node *node.Node) Node {
+	var images []Image
+	for _, image := range node.Images {
+		simple_image := Image{
+			RepoTags:    image.RepoTags,
+			RepoDigests: image.RepoDigests,
+			Labels:      image.Labels,
+		}
+		images = append(images, simple_image)
+	}
+
+	var containers []Container
+	for _, container := range node.Containers {
+		simple_container := Container{
+			Names: container.Names,
+			Image: container.Image,
+			State: container.State,
+			//Ports:  container.Ports,
+			Labels: container.Labels,
+		}
+		containers = append(containers, simple_container)
+	}
+
+	return Node{
+		ID:              node.ID,
+		HealthIndicator: node.HealthIndicator,
+		Name:            node.Name,
+		Addr:            node.Addr,
+		CPUs: Resource{
+			Total: node.TotalCpus,
+			Used:  node.UsedCpus,
+		},
+		Memory: Resource{
+			Total: node.TotalMemory,
+			Used:  node.UsedMemory,
+		},
+		Labels:     node.Labels,
+		Containers: containers,
+		Images:     images,
+	}
+}

--- a/scheduler/simplified-schema/schema.go
+++ b/scheduler/simplified-schema/schema.go
@@ -1,35 +1,37 @@
 package simplifiedschema
 
 import (
+	apitypes "github.com/docker/engine-api/types"
 	"github.com/docker/swarm/cluster"
 	"github.com/docker/swarm/scheduler/node"
 )
 
-type Config struct {
-	Image     string
-	CpuShares int
-	MemShares int
-}
-
+// Container represents a container in simplified form
 type Container struct {
-	Names  []string          `json:"names"`
-	Image  string            `json:"image"`
-	State  string            `json:"state"`
-	Ports  []int             `json:"ports"`
-	Labels map[string]string `json:"labels"`
+	Id      string            `json:"id"`
+	Names   []string          `json:"names"`
+	Image   string            `json:"image"`
+	ImageId string            `json:"image_id"`
+	State   string            `json:"state"`
+	Ports   []apitypes.Port   `json:"ports"`
+	Labels  map[string]string `json:"labels"`
 }
 
+// Image represents a image in simplified form
 type Image struct {
-	RepoTags    []string          `json:"repo_tags"`
-	RepoDigests []string          `json:"repo_digests"`
-	Labels      map[string]string `json:"labels"`
+	Id      string            `json:"id"`
+	Tags    []string          `json:"repo_tags"`
+	Digests []string          `json:"repo_digests"`
+	Labels  map[string]string `json:"labels"`
 }
 
+// Resource represents some kind of consumable resource (e.g. cpu / ram)
 type Resource struct {
 	Used  int64 `json:"used"`
 	Total int64 `json:"total"`
 }
 
+// Node represents a node in simplified form
 type Node struct {
 	ID              string            `json:"id"`
 	HealthIndicator int64             `json:"scheduling_health"`
@@ -40,32 +42,36 @@ type Node struct {
 	Images          []Image           `json:"images"`
 	CPUs            Resource          `json:"cpus"`
 	Memory          Resource          `json:"memory"`
-	//EngineVersion   string            `json:"engine_version"`
+	EngineVersion   string            `json:"engine_version"`
 }
 
+// Placement is the top level simplified placement structure
 type Placement struct {
 	Config cluster.ContainerConfig `json:"config"`
 	Nodes  []Node                  `json:"nodes"`
 }
 
+// SimplifyPlacement takes a placement request and a list of nodes and simplfies it for wire transfer
 func SimplifyPlacement(config *cluster.ContainerConfig, nodes []*node.Node) *Placement {
 	placement := &Placement{}
 	placement.Config = *config
 
 	for _, node := range nodes {
-		placement.Nodes = append(placement.Nodes, SimplifyNode(node))
+		placement.Nodes = append(placement.Nodes, simplifyNode(node))
 	}
 
 	return placement
 }
 
-func SimplifyNode(node *node.Node) Node {
+// simplifyNode simplifies an individual node record
+func simplifyNode(node *node.Node) Node {
 	var images []Image
 	for _, image := range node.Images {
 		simple_image := Image{
-			RepoTags:    image.RepoTags,
-			RepoDigests: image.RepoDigests,
-			Labels:      image.Labels,
+			Id:      image.ID,
+			Tags:    image.RepoTags,
+			Digests: image.RepoDigests,
+			Labels:  image.Labels,
 		}
 		images = append(images, simple_image)
 	}
@@ -73,11 +79,13 @@ func SimplifyNode(node *node.Node) Node {
 	var containers []Container
 	for _, container := range node.Containers {
 		simple_container := Container{
-			Names: container.Names,
-			Image: container.Image,
-			State: container.State,
-			//Ports:  container.Ports,
-			Labels: container.Labels,
+			Id:      container.ID,
+			Names:   container.Names,
+			Image:   container.Image,
+			ImageId: container.ImageID,
+			State:   container.State,
+			Ports:   container.Ports,
+			Labels:  container.Labels,
 		}
 		containers = append(containers, simple_container)
 	}
@@ -87,6 +95,10 @@ func SimplifyNode(node *node.Node) Node {
 		HealthIndicator: node.HealthIndicator,
 		Name:            node.Name,
 		Addr:            node.Addr,
+		Labels:          node.Labels,
+		Containers:      containers,
+		Images:          images,
+		EngineVersion:   node.Engine.Version,
 		CPUs: Resource{
 			Total: node.TotalCpus,
 			Used:  node.UsedCpus,
@@ -95,8 +107,5 @@ func SimplifyNode(node *node.Node) Node {
 			Total: node.TotalMemory,
 			Used:  node.UsedMemory,
 		},
-		Labels:     node.Labels,
-		Containers: containers,
-		Images:     images,
 	}
 }

--- a/scheduler/strategy/binpack.go
+++ b/scheduler/strategy/binpack.go
@@ -12,7 +12,7 @@ type BinpackPlacementStrategy struct {
 }
 
 // Initialize a BinpackPlacementStrategy.
-func (p *BinpackPlacementStrategy) Initialize() error {
+func (p *BinpackPlacementStrategy) Initialize(opts map[string]string) error {
 	return nil
 }
 

--- a/scheduler/strategy/binpack_test.go
+++ b/scheduler/strategy/binpack_test.go
@@ -162,7 +162,8 @@ func TestPlaceContainerHuge(t *testing.T) {
 }
 
 func TestPlaceContainerOvercommit(t *testing.T) {
-	s, err := New("binpacking")
+	opts := make(map[string]string)
+	s, err := New("binpacking", opts)
 	assert.NoError(t, err)
 
 	nodes := []*node.Node{createNode("node-1", 100, 1)}

--- a/scheduler/strategy/external.go
+++ b/scheduler/strategy/external.go
@@ -107,7 +107,6 @@ func (p *ExternalPlacementStrategy) RankAndSort(config *cluster.ContainerConfig,
 		nodeMap[n.ID] = n
 	}
 
-	//fmt.Printf("CONFIG: %#v, NODES: %#v", config, nodes)
 	var placement *schema.Placement
 	if p.marshalState {
 		placement = schema.SimplifyPlacement(config, nodes)

--- a/scheduler/strategy/external.go
+++ b/scheduler/strategy/external.go
@@ -1,0 +1,196 @@
+package strategy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/scheduler/node"
+	schema "github.com/docker/swarm/scheduler/simplified-schema"
+)
+
+var (
+	ErrURLMissing        = "External scheduler requires a url"
+	ErrInvalidTimeoutOpt = "Invalid timeout value for external scheduler: %s"
+	ErrInvalidRetriesOpt = "Invalid retry value for external scheduler: %s"
+	ErrInvalidMarshalOpt = "Invalid marshal_cluster_state value for external scheduler: %s"
+
+	ErrTimeout        = "External scheduler timed out while waiting for a response"
+	ErrInvalidNodeID  = "External scheduler returned invalid node ID: %s"
+	ErrMarshalError   = "Could not marshal placement for external scheduler: %s"
+	ErrHTTPRequest    = "Error making HTTP request to external scheduler : %s"
+	ErrHTTPResponse   = "Error reading response from external scheduler: %s"
+	ErrJSONParseError = "Error parsing JSON from external scheduler: %s"
+)
+
+// ExternalPlacementStrategy uses an external service to make the placement decision
+type ExternalPlacementStrategy struct {
+	url          string
+	marshalState bool
+	timeout      time.Duration
+	retries      int
+	client       *http.Client
+}
+
+// Initialize an ExternalPlacementStrategy.
+func (p *ExternalPlacementStrategy) Initialize(opts map[string]string) error {
+	if opts["url"] == "" {
+		return errors.New(ErrURLMissing)
+	}
+
+	p.url = opts["url"]
+	p.client = &http.Client{}
+	p.marshalState = true
+	p.timeout = time.Duration(3000 * time.Millisecond)
+	p.retries = 3
+
+	if opts["marshal_cluster_state"] != "" {
+		marshal, err := strconv.ParseBool(opts["marshal_cluster_state"])
+		if err != nil {
+			return fmt.Errorf(ErrInvalidMarshalOpt, opts["marshal_cluster_state"])
+		}
+		p.marshalState = marshal
+	}
+
+	if opts["timeout"] != "" {
+		timeout, err := strconv.Atoi(opts["timeout"])
+		if err != nil {
+			return fmt.Errorf(ErrInvalidTimeoutOpt, opts["timeout"])
+		}
+
+		if timeout < 1 {
+			timeout = 1
+		}
+
+		p.timeout = time.Duration(timeout) * time.Millisecond
+	}
+
+	if opts["retries"] != "" {
+		retries, err := strconv.Atoi(opts["retries"])
+		if err != nil {
+			return fmt.Errorf(ErrInvalidRetriesOpt, opts["retries"])
+		}
+
+		if retries < 0 {
+			retries = 0
+		}
+
+		p.retries = retries
+	}
+
+	return nil
+}
+
+// Name returns the name of the strategy.
+func (p *ExternalPlacementStrategy) Name() string {
+	return "external"
+}
+
+// RankAndSort marshals config and node data to json, posts them to the http url and unmarshals the json response
+func (p *ExternalPlacementStrategy) RankAndSort(config *cluster.ContainerConfig, nodes []*node.Node) ([]*node.Node, error) {
+	nodeMap := make(map[string]*node.Node)
+	for _, n := range nodes {
+		nodeMap[n.ID] = n
+	}
+
+	var placement *schema.Placement
+	if p.marshalState {
+		placement = schema.SimplifyPlacement(config, nodes)
+	} else {
+		placement = schema.SimplifyPlacement(config, make([]*node.Node, 0))
+	}
+
+	data, err := json.Marshal(placement)
+	if err != nil {
+		return nil, fmt.Errorf(ErrMarshalError, err)
+	}
+
+	var errors []error
+	for len(errors) <= p.retries {
+		response, err := p.withTimeout(p.httpScheduler, &data)
+
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		output, err := p.processResponse(response, nodeMap)
+
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		return output, nil
+	}
+
+	for _, e := range errors {
+		log.WithField("error", e).Debugf("External scheduler error during placement")
+	}
+
+	return nil, errors[len(errors)-1]
+}
+
+// httpScheduler makes an actual request over HTTP and handles the response body
+func (p *ExternalPlacementStrategy) httpScheduler(data *[]byte) (io.Reader, error) {
+	response, err := p.client.Post(p.url, "application/json", bytes.NewReader(*data))
+
+	if err != nil {
+		return nil, fmt.Errorf(ErrHTTPRequest, err)
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf(ErrHTTPResponse, err)
+	}
+
+	return bytes.NewReader(body), nil
+}
+
+// withTimeout wraps the scheduler function (f) with timeout logic
+func (p *ExternalPlacementStrategy) withTimeout(f func(data *[]byte) (io.Reader, error), data *[]byte) (io.Reader, error) {
+	var extErr error
+	result := make(chan io.Reader, 1)
+	go func() {
+		r, err := f(data)
+		extErr = err
+		result <- r
+	}()
+
+	select {
+	case ret := <-result:
+		return ret, extErr
+	case <-time.After(p.timeout):
+		return nil, errors.New(ErrTimeout)
+	}
+}
+
+// processResponse decodes an external scheduler JSON response and turns it back in to a node list
+func (p *ExternalPlacementStrategy) processResponse(response io.Reader, nodeMap map[string]*node.Node) ([]*node.Node, error) {
+	var nodeIds []string
+
+	err := json.NewDecoder(response).Decode(&nodeIds)
+	if err != nil {
+		return nil, fmt.Errorf(ErrJSONParseError, err)
+	}
+
+	output := make([]*node.Node, len(nodeIds))
+	for i, n := range nodeIds {
+		if _, ok := nodeMap[n]; !ok {
+			return nil, fmt.Errorf(ErrInvalidNodeID, n)
+		}
+		output[i] = nodeMap[n]
+	}
+
+	return output, nil
+}

--- a/scheduler/strategy/external_test.go
+++ b/scheduler/strategy/external_test.go
@@ -1,0 +1,156 @@
+package strategy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/docker/swarm/scheduler/node"
+	schema "github.com/docker/swarm/scheduler/simplified-schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockExternalServer(scheduler func(req *schema.Placement) string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		p := &schema.Placement{}
+		data, _ := ioutil.ReadAll(r.Body)
+		json.Unmarshal(data, p)
+		fmt.Fprintf(w, scheduler(p))
+	}))
+}
+
+func mockSchedulerFirstNode(req *schema.Placement) string {
+	return fmt.Sprintf("[\"%s\"]", req.Nodes[0].ID)
+}
+
+func mockSchedulerTimeout(req *schema.Placement) string {
+	time.Sleep(20 * time.Millisecond)
+	return mockSchedulerFirstNode(req)
+}
+
+func mockSchedulerWithRetryFailures(targetCount int, failResult string, scheduler func(*schema.Placement) string) func(*schema.Placement) string {
+	count := 0
+	return func(req *schema.Placement) string {
+		if count >= targetCount {
+			return scheduler(req)
+		} else {
+			count++
+			return failResult
+		}
+	}
+}
+
+func setupExternalPlacementStrategy(url string, timeout int, retries int) (*ExternalPlacementStrategy, []*node.Node) {
+	opts := make(map[string]string)
+	opts["url"] = url
+	opts["retries"] = fmt.Sprintf("%d", retries)
+	opts["timeout"] = fmt.Sprintf("%d", timeout)
+
+	s := &ExternalPlacementStrategy{}
+	s.Initialize(opts)
+
+	nodes := []*node.Node{
+		createNode(fmt.Sprintf("node-0"), 1, 1),
+	}
+
+	return s, nodes
+}
+
+func TestExternalPlaceSimple(t *testing.T) {
+	server := mockExternalServer(mockSchedulerFirstNode)
+	defer server.Close()
+
+	s, nodes := setupExternalPlacementStrategy(server.URL, 3, 3) // url, timeout(ms), retries
+
+	// add 10 containers
+	for i := 0; i < 10; i++ {
+		config := createConfig(0, 0)
+		node := selectTopNode(t, s, config, nodes)
+		assert.NoError(t, node.AddContainer(createContainer(fmt.Sprintf("c%d", i), config)))
+	}
+
+	assert.Equal(t, 10, len(nodes[0].Containers))
+}
+
+func TestExternalPlaceRetries(t *testing.T) {
+	server := mockExternalServer(
+		mockSchedulerWithRetryFailures(1, "[]", mockSchedulerFirstNode),
+	)
+	defer server.Close()
+
+	s, nodes := setupExternalPlacementStrategy(server.URL, 10, 2) // url, timeout(ms), retries
+
+	config := createConfig(0, 0)
+	_, err := s.RankAndSort(config, nodes)
+
+	assert.NoError(t, err)
+}
+
+func TestExternalErrorTimeout(t *testing.T) {
+	server := mockExternalServer(mockSchedulerTimeout)
+	defer server.Close()
+
+	s, nodes := setupExternalPlacementStrategy(server.URL, 10, 0) // url, timeout(ms), retries
+
+	config := createConfig(0, 0)
+	_, err := s.RankAndSort(config, nodes)
+
+	assert.EqualError(t, err, "External scheduler timed out while waiting for a response")
+}
+
+func TestExternalErrorBadJson(t *testing.T) {
+	server := mockExternalServer(func(req *schema.Placement) string { return "{" })
+	defer server.Close()
+
+	s, nodes := setupExternalPlacementStrategy(server.URL, 3000, 0) // url, timeout(ms), retries
+
+	config := createConfig(0, 0)
+	_, err := s.RankAndSort(config, nodes)
+
+	assert.EqualError(t, err, "Error parsing JSON from external scheduler: unexpected EOF")
+}
+
+func TestExternalErrorBadNodeID(t *testing.T) {
+	server := mockExternalServer(func(req *schema.Placement) string { return "[\"bad-node\"]" })
+	defer server.Close()
+
+	s, nodes := setupExternalPlacementStrategy(server.URL, 3000, 0) // url, timeout(ms), retries
+
+	config := createConfig(0, 0)
+	_, err := s.RankAndSort(config, nodes)
+
+	assert.EqualError(t, err, "External scheduler returned invalid node ID: bad-node")
+}
+
+func TestExternalInitializeErrors(t *testing.T) {
+	opts1 := make(map[string]string)
+	s1 := &ExternalPlacementStrategy{}
+	err1 := s1.Initialize(opts1)
+	assert.EqualError(t, err1, "External scheduler requires a url")
+
+	opts2 := make(map[string]string)
+	opts2["url"] = "http://"
+	opts2["timeout"] = "badval"
+	s2 := &ExternalPlacementStrategy{}
+	err2 := s2.Initialize(opts2)
+	assert.EqualError(t, err2, "Invalid timeout value for external scheduler: badval")
+
+	opts3 := make(map[string]string)
+	opts3["url"] = "http://"
+	opts3["retries"] = "badval"
+	s3 := &ExternalPlacementStrategy{}
+	err3 := s3.Initialize(opts3)
+	assert.EqualError(t, err3, "Invalid retry value for external scheduler: badval")
+
+	opts4 := make(map[string]string)
+	opts4["url"] = "http://"
+	opts4["marshal_cluster_state"] = "badval"
+	s4 := &ExternalPlacementStrategy{}
+	err4 := s4.Initialize(opts4)
+	assert.EqualError(t, err4, "Invalid marshal_cluster_state value for external scheduler: badval")
+}

--- a/scheduler/strategy/random.go
+++ b/scheduler/strategy/random.go
@@ -14,7 +14,7 @@ type RandomPlacementStrategy struct {
 }
 
 // Initialize a RandomPlacementStrategy.
-func (p *RandomPlacementStrategy) Initialize() error {
+func (p *RandomPlacementStrategy) Initialize(opts map[string]string) error {
 	p.r = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	return nil
 }

--- a/scheduler/strategy/spread.go
+++ b/scheduler/strategy/spread.go
@@ -12,7 +12,7 @@ type SpreadPlacementStrategy struct {
 }
 
 // Initialize a SpreadPlacementStrategy.
-func (p *SpreadPlacementStrategy) Initialize() error {
+func (p *SpreadPlacementStrategy) Initialize(opts map[string]string) error {
 	return nil
 }
 

--- a/scheduler/strategy/strategy.go
+++ b/scheduler/strategy/strategy.go
@@ -15,7 +15,7 @@ type PlacementStrategy interface {
 	// Initialize performs any initial configuration required by the strategy and returns
 	// an error if one is encountered.
 	// If no initial configuration is needed, this may be a no-op and return a nil error.
-	Initialize() error
+	Initialize(opts map[string]string) error
 	// RankAndSort applies the strategy to a list of nodes and ranks them based
 	// on the best fit given the container configuration.  It returns a sorted
 	// list of nodes (based on their ranks) or an error if there is no
@@ -39,11 +39,12 @@ func init() {
 		&SpreadPlacementStrategy{},
 		&BinpackPlacementStrategy{},
 		&RandomPlacementStrategy{},
+		&ExternalPlacementStrategy{},
 	}
 }
 
 // New creates a new PlacementStrategy for the given strategy name.
-func New(name string) (PlacementStrategy, error) {
+func New(name string, opts map[string]string) (PlacementStrategy, error) {
 	if name == "binpacking" { //TODO: remove this compat
 		name = "binpack"
 	}
@@ -51,7 +52,7 @@ func New(name string) (PlacementStrategy, error) {
 	for _, strategy := range strategies {
 		if strategy.Name() == name {
 			log.WithField("name", name).Debugf("Initializing strategy")
-			err := strategy.Initialize()
+			err := strategy.Initialize(opts)
 			return strategy, err
 		}
 	}


### PR DESCRIPTION
This is a scheduler that uses an external service to determine placement. It presently marshals the scheduling data in to a simplified form (the default form is way too verbose to use verbatim) and encodes this as JSON. This JSON is then POST-ed to the service and decodes the response as a sorted array of engine ids (first being most preferred). These ids are then mapped back in to a node list and returned.

Our use case is incorporating custom decisions from our metrics / health services in placement decisions.

Obviously there is performance overhead in marshalling decisions out to external processes and back but we're only running 40 or so node swarms and the overhead is worth it to us to be able to experiment with better placement strategies.

If there is no interest, please feel free to close the PR, otherwise ideas welcome :smiley:
