### PR TITLE
Mesos failover timeout

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -46,6 +46,8 @@ Options:
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.createretry=0\tcontainer create retry count after initial failure"}}
                                     {{printf "\t * mesos.address=\taddress to bind on [$SWARM_MESOS_ADDRESS]"}}
+                                    {{printf "\t * mesos.frameworkid=\tspecify a framework id, allows restarting with the same id in case of a manager crash, if not set mesos assigns a random id [$SWARM_MESOS_FRAMEWORKID]"}}
+                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks running for this number of seconds after a swarm manager crash, recover by restarting with the same framwrodk id [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
                                     {{printf "\t * mesos.checkpointfailover=false\tcheckpointing allows a restarted slave to reconnect with old executors and recover status updates, at the cost of disk I/O [$SWARM_MESOS_CHECKPOINT_FAILOVER]"}}
                                     {{printf "\t * mesos.port=\tport to bind on [$SWARM_MESOS_PORT]"}}
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -91,8 +91,14 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 	// Do not check error here, so mesos-go can still try.
 	hostname, _ := os.Hostname()
 
+	// Build a framework ID from params, if not defined, mesos will assign a random id
+	var frameworkID *mesosproto.FrameworkID
+	if frameworkUID, ok := options.String("mesos.frameworkid", "SWARM_MESOS_FRAMEWORKID"); ok {
+		frameworkID = &mesosproto.FrameworkID{Value: &frameworkUID}
+	}
+ 
 	driverConfig := mesosscheduler.DriverConfig{
-		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user},
+		Framework:        &mesosproto.FrameworkInfo{Name: proto.String(frameworkName), User: &user, Id: frameworkID},
 		Master:           cluster.master,
 		HostnameOverride: hostname,
 	}
@@ -121,6 +127,10 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 				value)
 		}
 		driverConfig.BindingAddress = bindingAddress
+	}
+	
+	if failoverTimeout, ok := options.Float("mesos.failovertimeout", "SWARM_MESOS_FAILOVER_TIMEOUT"); ok {
+		driverConfig.Framework.FailoverTimeout = &failoverTimeout
 	}
 
 	if checkpointFailover, ok := options.Bool("mesos.checkpointfailover", "SWARM_MESOS_CHECKPOINT_FAILOVER"); ok {


### PR DESCRIPTION
By default, when a framework fails, Mesos will terminate any tasks started by that framework.

The failovertimeout parameter allows the tasks to continue running for this number of seconds after the swarm manager dies. If not specified mesos will kill the tasks immediately (default behaviour). Mesos documentation recommends setting this value to 1 week time.

The frameworkid allows to specify a unique id. If Swarm manages to reconnect with the same task ID it had before the crash then mesos will reassigned the tasks to it. The ID must follow the mesos format for IDs (i.e. b2853a78-7cba-455a-99c7-d73bb5cbda95-0024). Refer to mesos for ID formats.

Signed-off-by: Guillermo Rodriguez <grodriguez@cmcrc.com>