### PR TITLE
Tasks to continue running after swarm crash

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -47,7 +47,7 @@ Options:
                                     {{printf "\t * swarm.createretry=0\tcontainer create retry count after initial failure"}}
                                     {{printf "\t * mesos.address=\taddress to bind on [$SWARM_MESOS_ADDRESS]"}}
                                     {{printf "\t * mesos.frameworkid=\tspecify a framework id, if not set mesos assigns a random id [$SWARM_MESOS_FRAMEWORKID]"}}
-                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks launched by this framework running for this number of seconds in case this Swarm manager crashes (mesos will reattach the tasks to a new Swarm manager started with the same framework id) [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
+                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks launched by this framework running for this number of seconds in case this Swarm manager crashes [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
                                     {{printf "\t * mesos.checkpointfailover=false\tcheckpointing allows a restarted slave to reconnect with old executors and recover status updates, at the cost of disk I/O [$SWARM_MESOS_CHECKPOINT_FAILOVER]"}}
                                     {{printf "\t * mesos.port=\tport to bind on [$SWARM_MESOS_PORT]"}}
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}

--- a/cli/help.go
+++ b/cli/help.go
@@ -46,8 +46,8 @@ Options:
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.createretry=0\tcontainer create retry count after initial failure"}}
                                     {{printf "\t * mesos.address=\taddress to bind on [$SWARM_MESOS_ADDRESS]"}}
-                                    {{printf "\t * mesos.frameworkid=\tspecify a framework id, allows restarting with the same id in case of a manager crash, if not set mesos assigns a random id [$SWARM_MESOS_FRAMEWORKID]"}}
-                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks running for this number of seconds after a swarm manager crash, recover by restarting with the same framwrodk id [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
+                                    {{printf "\t * mesos.frameworkid=\tspecify a framework id, if not set mesos assigns a random id [$SWARM_MESOS_FRAMEWORKID]"}}
+                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks launched by this framework running for this number of seconds in case this Swarm manager crashes (mesos will reattach the tasks to a new Swarm manager started with the same framework id) [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
                                     {{printf "\t * mesos.checkpointfailover=false\tcheckpointing allows a restarted slave to reconnect with old executors and recover status updates, at the cost of disk I/O [$SWARM_MESOS_CHECKPOINT_FAILOVER]"}}
                                     {{printf "\t * mesos.port=\tport to bind on [$SWARM_MESOS_PORT]"}}
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}

--- a/cli/help.go
+++ b/cli/help.go
@@ -46,6 +46,8 @@ Options:
    {{end}}{{if (eq .Name "manage")}}{{printf "\t * swarm.overcommit=0.05\tovercommit to apply on resources"}}
                                     {{printf "\t * swarm.createretry=0\tcontainer create retry count after initial failure"}}
                                     {{printf "\t * mesos.address=\taddress to bind on [$SWARM_MESOS_ADDRESS]"}}
+                                    {{printf "\t * mesos.frameworkid=\tspecify a framework id, allows restarting with the same id in case of a manager crash, if not set mesos assigns a random id [$SWARM_MESOS_FRAMEWORKID]"}}
+                                    {{printf "\t * mesos.failovertimeout=0\tkeep tasks running for this number of seconds after a swarm manager crash, recover by restarting with the same framwrodk id [$SWARM_MESOS_FAILOVER_TIMEOUT]"}}
                                     {{printf "\t * mesos.checkpointfailover=false\tcheckpointing allows a restarted slave to reconnect with old executors and recover status updates, at the cost of disk I/O [$SWARM_MESOS_CHECKPOINT_FAILOVER]"}}
                                     {{printf "\t * mesos.port=\tport to bind on [$SWARM_MESOS_PORT]"}}
                                     {{printf "\t * mesos.offertimeout=30s\ttimeout for offers [$SWARM_MESOS_OFFER_TIMEOUT]"}}

--- a/docs/reference/join.md
+++ b/docs/reference/join.md
@@ -40,7 +40,7 @@ When you create the Swarm node, use the `<discovery>` argument to specify one of
 
 * `token://<token>`
 * `consul://<ip1>/<path>`
-* `etcd://<ip1>,<ip2>,<ip2>/<path>`
+* `etcd://<ip1>,<ip2>,<ip3>/<path>`
 * `file://<path/to/file>`
 * `zk://<ip1>,<ip2>/<path>`
 * `[nodes://]<iprange>,<iprange>`

--- a/docs/reference/manage.md
+++ b/docs/reference/manage.md
@@ -40,7 +40,7 @@ When you create the swarm node, use the `<discovery>` argument to specify one of
 
 * `token://<token>`
 * `consul://<ip1>/<path>`
-* `etcd://<ip1>,<ip2>,<ip2>/<path>`
+* `etcd://<ip1>,<ip2>,<ip3>/<path>`
 * `file://<path/to/file>`
 * `zk://<ip1>,<ip2>/<path>`
 * `[nodes://]<iprange>,<iprange>`


### PR DESCRIPTION
By default, when a framework fails, Mesos will terminate any tasks started by a framework

The failovertimeout parameter allows the tasks to continue running for this number of seconds after the swarm manager dies. If not specified mesos will kill the tasks immediately (default behaviour). Mesos documentation recommends setting this value to 1 week time.

The frameworkid allows to specify a unique id. If Swarm manages to reconnect with the same task ID it had before the crash then mesos will reassigned the tasks to it. The ID must follow the mesos format for IDs (i.e. b2853a78-7cba-455a-99c7-d73bb5cbda95-0024). Refer to mesos for ID formats.

Signed-off-by: Guillermo Rodriguez <grodriguez@cmcrc.com>