### PR TITLE
Use volume.Scope to determine create scheduling

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -602,6 +602,16 @@ func (e *Engine) AddNetwork(network *Network) {
 	e.Unlock()
 }
 
+// AddVolume adds a volume to the internal engine state
+func (e *Engine) AddVolume(volume *Volume) {
+	e.Lock()
+	e.volumes[volume.Name] = &Volume{
+		Volume: volume.Volume,
+		Engine: e,
+	}
+	e.Unlock()
+}
+
 // RemoveVolume deletes a volume from the engine.
 func (e *Engine) RemoveVolume(name string) error {
 	err := e.apiClient.VolumeRemove(context.Background(), name)


### PR DESCRIPTION
Volumes in engine now have a `Scope` field similar to networks.
This makes `VolumeCreate` take advantage of it so that only 1 node needs
the create action if the `volume.Scope == "global"`.

Please lmk on implementation, not incredibly familiar with this codebase.
This seems like it's working. I notice that networks have some in-memory state that volumes don't seem to have.
