### PR TITLE
Note the difference between binary and image for new users

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -98,7 +98,7 @@ swarm join \
 ```
 
 This works the same way for the Swarm `manage` and `list` commands, but
-remember, If you are running the swarm image rather than the binary the paths
+remember, if you are running the swarm image rather than the binary the paths
 must be available inside the container (e.g. within a data volume).
 
 ## A static file or list of nodes

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -97,7 +97,9 @@ swarm join \
     consul://<consul_addr>/<optional path prefix>
 ```
 
-This works the same way for the Swarm `manage` and `list` commands.
+This works the same way for the Swarm `manage` and `list` commands, but
+remember, If you are running the swarm image rather than the binary the paths
+must be available inside the container (e.g. within a data volume).
 
 ## A static file or list of nodes
 


### PR DESCRIPTION
When running the container image the certificate and key paths are relative to the container filesystem resulting in a bunch of "no such file or directory" errors. This pull request adds a little documentation to make the distinction explicit when not using the swarm binary.
