### PR TITLE
The UCP wwwurl redirects to DDC page, and UCP isn't in beta anymore

### DIFF
--- a/docs/plan-for-production.md
+++ b/docs/plan-for-production.md
@@ -350,4 +350,4 @@ planning, deployment, and ongoing management of your production Swarm clusters.
 * [Try Swarm at scale](swarm_at_scale/index.md)
 * [Swarm and container networks](networking.md)
 * [High availability in Docker Swarm](multi-manager-setup.md)
-* [Universal Control plane](https://www.docker.com/products/docker-universal-control-plane)
+* [Docker Data Center](https://www.docker.com/products/docker-datacenter)

--- a/docs/swarm_at_scale/troubleshoot.md
+++ b/docs/swarm_at_scale/troubleshoot.md
@@ -211,9 +211,8 @@ network latency and reliability is key to a smooth and workable solution.
 ## Related information
 
 The application in this example could be deployed on Docker Universal Control
-Plane (UCP) which is currently in Beta release. To try the application on UCP in
-your environment, [request access to the UCP Beta
-release](https://www.docker.com/products/docker-universal-control-plane). Other
+Plane (UCP) which is part of Docker Data Center. To try the application on UCP in
+your environment, [request a free trial](https://www.docker.com/products/docker-datacenter). Other
 useful documentation:
 
 * [Plan for Swarm in production](../plan-for-production.md)


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>