### PR TITLE
move Docker Swarm menu under Component Projects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ description = "Swarm: a Docker-native clustering system"
 keywords = ["docker, swarm,  clustering"]
 [menu.main]
 identifier="workw_swarm"
+parent="mn_components"
 weight=-75
 +++
 <![end-metadata]-->


### PR DESCRIPTION
Moves "Docker Swarm" menu item underneath "Component Projects" menu item.

Signed-off-by: Charles Smith <charles.smith@docker.com>