### PR TITLE
Added issue template to direct users to right repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- Before filing an issue, double check that you're in the right repository.
+
+This repository is only for issues related to the standalone Docker Swarm project. 
+
+Issues related to Docker 1.12+ Swarm Mode are filed under the repository:
+
+  github.com/docker/swarmkit
+
+-->


### PR DESCRIPTION
Adds a comment to the issue template asking users to make sure they're in the right place before submitting an issue. Will hopefully cut down on the number of swarmkit issues filed in swarm.

We could add more than this (for example, copying docker/docker's issue template) but these instructions IMO are most important, and I feel like if we load too much stuff into the template, they'll get glossed over and ignored by users.

Signed-off-by: Drew Erny <drew.erny@docker.com>