### PR TITLE
Remove refresh network when creating container

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -921,8 +921,6 @@ func (e *Engine) CreateContainer(config *ContainerConfig, name string, pullImage
 	// Register the container immediately while waiting for a state refresh.
 	// Force a state refresh to pick up the newly created container.
 	e.refreshContainer(createResp.ID, true)
-	e.RefreshVolumes()
-	e.RefreshNetworks()
 
 	e.Lock()
 	container := e.containers[createResp.ID]


### PR DESCRIPTION
  When I use overlay network, swarm create container become more slowly with the increase number of containers. I found that it was `RefreshNetworks` method caused. A new created container hasn't networkID and EndpointID, it's useless to refresh network when creating container. For `docker network ls ` or `docker network inspect `, swarm has `RefreshContainers` to find new running container to a network driver. 

  In overlay network, `refreshNetwork` will visit etcd for every network endpoint , it will cost 6-8s if a node has 100+ containers. So I think swarm should remove this refresh method to improving speed of creating container. 

Update:
- For @allencloud advice, also remove `RefreshVolumes` method.

Thanks.

	// Force a state refresh to pick up the newly created container.
	e.refreshContainer(createResp.ID, true)
	//e.RefreshVolumes()
	//e.RefreshNetworks()

Signed-off-by: Xianlu <xianlu.cxl@alibaba-inc.com>