### PR TITLE
Add healthcheck info to CLI

### DIFF
--- a/cluster/container.go
+++ b/cluster/container.go
@@ -54,6 +54,19 @@ func FullStateString(state *types.ContainerState) string {
 		if state.Restarting {
 			return fmt.Sprintf("Restarting (%d) %s ago", state.ExitCode, units.HumanDuration(time.Now().UTC().Sub(finishedAt)))
 		}
+		// Container is Up. Add Health check info when healthcheck is defined.
+		healthText := ""
+		if h := state.Health; h != nil {
+			switch h.Status {
+			case types.Starting:
+				healthText = "health: starting"
+			default: // Healthy and Unhealthy are clear on their own
+				healthText = h.Status
+			}
+		}
+		if len(healthText) > 0 {
+			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(startedAt)), healthText)
+		}
 		return fmt.Sprintf("Up %s", units.HumanDuration(time.Now().UTC().Sub(startedAt)))
 	}
 


### PR DESCRIPTION
Make CLI output consistent with Docker CLI. Fix #2415.

This change depends on engine-api vendoring.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>