### PR TITLE
Updating engine-api to latest, with a new client interface

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/docker/swarm",
 	"GoVersion": "go1.5",
-	"GodepVersion": "v70",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -101,63 +101,63 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport/cancellable",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/blkiodev",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/container",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/events",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/filters",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/network",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/registry",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/strslice",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/time",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",
@@ -369,13 +369,18 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/reference",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/versions",
-			"Comment": "v0.3.1-109-g0e47ff2",
-			"Rev": "0e47ff24937634cc55e1ebadfe73eaf1db856ba0"
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+		},
+		{
+			"ImportPath": "github.com/docker/engine-api/types/swarm",
+			"Comment": "v0.3.1-236-gd505506",
+			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
 		}
 	]
 }

--- a/api/mockclient/mock.go
+++ b/api/mockclient/mock.go
@@ -2,6 +2,7 @@ package mockclient
 
 import (
 	"io"
+	"time"
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
@@ -161,7 +162,7 @@ func (client *MockClient) ContainerResize(ctx context.Context, container string,
 }
 
 // ContainerRestart stops and starts a container again
-func (client *MockClient) ContainerRestart(ctx context.Context, container string, timeout int) error {
+func (client *MockClient) ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error {
 	args := client.Mock.Called(ctx, container, timeout)
 	return args.Error(0)
 }
@@ -179,13 +180,13 @@ func (client *MockClient) ContainerStats(ctx context.Context, container string, 
 }
 
 // ContainerStart sends a request to the docker daemon to start a container
-func (client *MockClient) ContainerStart(ctx context.Context, container string, checkpointID string) error {
-	args := client.Mock.Called(ctx, container, checkpointID)
+func (client *MockClient) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
+	args := client.Mock.Called(ctx, container, options)
 	return args.Error(0)
 }
 
 // ContainerStop stops a container without terminating the process
-func (client *MockClient) ContainerStop(ctx context.Context, container string, timeout int) error {
+func (client *MockClient) ContainerStop(ctx context.Context, container string, timeout *time.Duration) error {
 	args := client.Mock.Called(ctx, container, timeout)
 	return args.Error(0)
 }
@@ -305,8 +306,8 @@ func (client *MockClient) ImageSave(ctx context.Context, images []string) (io.Re
 }
 
 // ImageTag tags an image in the docker host
-func (client *MockClient) ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error {
-	args := client.Mock.Called(ctx, image, ref, options)
+func (client *MockClient) ImageTag(ctx context.Context, image, ref string) error {
+	args := client.Mock.Called(ctx, image, ref)
 	return args.Error(0)
 }
 

--- a/api/mockclient/mock_test.go
+++ b/api/mockclient/mock_test.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/swarm/swarmclient"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -27,10 +27,10 @@ func TestMock(t *testing.T) {
 }
 
 func TestMockInterface(t *testing.T) {
-	iface := reflect.TypeOf((*client.APIClient)(nil)).Elem()
+	iface := reflect.TypeOf((*swarmclient.SwarmAPIClient)(nil)).Elem()
 	mockClient := NewMockClient()
 
 	if !reflect.TypeOf(mockClient).Implements(iface) {
-		t.Fatalf("Mock does not implement the APIClient interface")
+		t.Fatalf("Mock does not implement the SwarmAPIClient interface")
 	}
 }

--- a/api/nopclient/nop.go
+++ b/api/nopclient/nop.go
@@ -3,6 +3,7 @@ package nopclient
 import (
 	"errors"
 	"io"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -142,7 +143,7 @@ func (client *NopClient) ContainerResize(ctx context.Context, container string, 
 }
 
 // ContainerRestart stops and starts a container again
-func (client *NopClient) ContainerRestart(ctx context.Context, container string, timeout int) error {
+func (client *NopClient) ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error {
 	return errNoEngine
 }
 
@@ -157,12 +158,12 @@ func (client *NopClient) ContainerStats(ctx context.Context, container string, s
 }
 
 // ContainerStart sends a request to the docker daemon to start a container
-func (client *NopClient) ContainerStart(ctx context.Context, container string, checkpointID string) error {
+func (client *NopClient) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
 	return errNoEngine
 }
 
 // ContainerStop stops a container without terminating the process
-func (client *NopClient) ContainerStop(ctx context.Context, container string, timeout int) error {
+func (client *NopClient) ContainerStop(ctx context.Context, container string, timeout *time.Duration) error {
 	return errNoEngine
 }
 
@@ -262,7 +263,7 @@ func (client *NopClient) ImageSave(ctx context.Context, images []string) (io.Rea
 }
 
 // ImageTag tags an image in the docker host
-func (client *NopClient) ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error {
+func (client *NopClient) ImageTag(ctx context.Context, image, ref string) error {
 	return errNoEngine
 }
 

--- a/api/nopclient/nop_test.go
+++ b/api/nopclient/nop_test.go
@@ -4,9 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/swarm/swarmclient"
 	"golang.org/x/net/context"
-
-	"github.com/docker/engine-api/client"
 )
 
 func TestNop(t *testing.T) {
@@ -18,10 +17,10 @@ func TestNop(t *testing.T) {
 }
 
 func TestNopInterface(t *testing.T) {
-	iface := reflect.TypeOf((*client.APIClient)(nil)).Elem()
+	iface := reflect.TypeOf((*swarmclient.SwarmAPIClient)(nil)).Elem()
 	nop := NewNopClient()
 
 	if !reflect.TypeOf(nop).Implements(iface) {
-		t.Fatalf("Nop does not implement the APIClient interface")
+		t.Fatalf("Nop does not implement the SwarmAPIClient interface")
 	}
 }

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/engine-api/types/filters"
 	networktypes "github.com/docker/engine-api/types/network"
 	engineapinop "github.com/docker/swarm/api/nopclient"
+	"github.com/docker/swarm/swarmclient"
 	"github.com/samalba/dockerclient"
 	"github.com/samalba/dockerclient/nopclient"
 )
@@ -123,7 +124,7 @@ type Engine struct {
 	networks        map[string]*Network
 	volumes         map[string]*Volume
 	client          dockerclient.Client
-	apiClient       engineapi.APIClient
+	apiClient       swarmclient.SwarmAPIClient
 	eventHandler    EventHandler
 	state           engineState
 	lastError       string
@@ -209,7 +210,7 @@ func (e *Engine) StartMonitorEvents() {
 }
 
 // ConnectWithClient is exported
-func (e *Engine) ConnectWithClient(client dockerclient.Client, apiClient engineapi.APIClient) error {
+func (e *Engine) ConnectWithClient(client dockerclient.Client, apiClient swarmclient.SwarmAPIClient) error {
 	e.client = client
 	e.apiClient = apiClient
 	e.eventsMonitor = NewEventsMonitor(e.apiClient, e.handler)
@@ -1335,8 +1336,8 @@ func (e *Engine) StartContainer(id string, hostConfig *dockerclient.HostConfig) 
 	if hostConfig != nil {
 		err = e.client.StartContainer(id, hostConfig)
 	} else {
-		// TODO(nishanttotla): Figure out what the checkpoint id (second string argument) should be
-		err = e.apiClient.ContainerStart(context.Background(), id, "")
+		// TODO(nishanttotla): Should ContainerStartOptions be provided?
+		err = e.apiClient.ContainerStart(context.Background(), id, types.ContainerStartOptions{})
 	}
 	e.CheckConnectionErr(err)
 	if err != nil {
@@ -1375,11 +1376,7 @@ func (e *Engine) BuildImage(buildContext io.Reader, buildImage *types.ImageBuild
 // TagImage tags an image
 func (e *Engine) TagImage(IDOrName string, ref string, force bool) error {
 	// send tag request to docker engine
-	opts := types.ImageTagOptions{
-		Force: force,
-	}
-
-	err := e.apiClient.ImageTag(context.Background(), IDOrName, ref, opts)
+	err := e.apiClient.ImageTag(context.Background(), IDOrName, ref)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err

--- a/cluster/event_monitor.go
+++ b/cluster/event_monitor.go
@@ -4,16 +4,16 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/events"
+	"github.com/docker/swarm/swarmclient"
 	"golang.org/x/net/context"
 )
 
 //EventsMonitor monitors events
 type EventsMonitor struct {
 	stopChan chan struct{}
-	cli      client.APIClient
+	cli      swarmclient.SwarmAPIClient
 	handler  func(msg events.Message) error
 }
 
@@ -23,7 +23,7 @@ type decodingResult struct {
 }
 
 // NewEventsMonitor returns an EventsMonitor
-func NewEventsMonitor(cli client.APIClient, handler func(msg events.Message) error) *EventsMonitor {
+func NewEventsMonitor(cli swarmclient.SwarmAPIClient, handler func(msg events.Message) error) *EventsMonitor {
 	return &EventsMonitor{
 		cli:     cli,
 		handler: handler,

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -264,7 +264,7 @@ func TestTagImage(t *testing.T) {
 	c.engines[engine.ID] = engine
 
 	// tag image
-	apiClient.On("ImageTag", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("types.ImageTagOptions")).Return(nil).Once()
+	apiClient.On("ImageTag", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	assert.Nil(t, c.TagImage("busybox", "test_busybox:latest", false))
 	assert.NotNil(t, c.TagImage("busybox_not_exists", "test_busybox:latest", false))
 }

--- a/swarmclient/interface.go
+++ b/swarmclient/interface.go
@@ -1,0 +1,19 @@
+package swarmclient
+
+import (
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// SwarmAPIClient contains the subset of the engine-api interface relevant to Docker Swarm
+type SwarmAPIClient interface {
+	client.ContainerAPIClient
+	client.ImageAPIClient
+	client.NetworkAPIClient
+	client.SystemAPIClient
+	client.VolumeAPIClient
+	ClientVersion() string
+	ServerVersion(ctx context.Context) (types.Version, error)
+	UpdateClientVersion(v string)
+}

--- a/vendor/github.com/docker/engine-api/client/client.go
+++ b/vendor/github.com/docker/engine-api/client/client.go
@@ -12,6 +12,9 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
+// DefaultVersion is the version of the current stable API
+const DefaultVersion string = "1.23"
+
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
@@ -59,13 +62,22 @@ func NewEnvClient() (*Client, error) {
 	if host == "" {
 		host = DefaultDockerHost
 	}
-	return NewClient(host, os.Getenv("DOCKER_API_VERSION"), client, nil)
+
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		version = DefaultVersion
+	}
+
+	return NewClient(host, version, client, nil)
 }
 
 // NewClient initializes a new API client for the given host and API version.
-// It won't send any version information if the version number is empty.
 // It uses the given http client as transport.
 // It also initializes the custom http headers to add to each request.
+//
+// It won't send any version information if the version number is empty. It is
+// highly recommended that you set a version or your client may break if the
+// server is upgraded.
 func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
 	proto, addr, basePath, err := ParseHost(host)
 	if err != nil {

--- a/vendor/github.com/docker/engine-api/client/container_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/container_inspect.go
@@ -27,7 +27,7 @@ func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (ty
 	return response, err
 }
 
-// ContainerInspectWithRaw returns the container information and it's raw representation.
+// ContainerInspectWithRaw returns the container information and its raw representation.
 func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID string, getSize bool) (types.ContainerJSON, []byte, error) {
 	query := url.Values{}
 	if getSize {

--- a/vendor/github.com/docker/engine-api/client/container_restart.go
+++ b/vendor/github.com/docker/engine-api/client/container_restart.go
@@ -2,17 +2,20 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout *time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	if timeout != nil {
+		query.Set("t", timetypes.DurationToSecondsString(*timeout))
+	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/github.com/docker/engine-api/client/container_start.go
+++ b/vendor/github.com/docker/engine-api/client/container_start.go
@@ -4,12 +4,16 @@ import (
 	"net/url"
 
 	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/types"
 )
 
 // ContainerStart sends a request to the docker daemon to start a container.
-func (cli *Client) ContainerStart(ctx context.Context, containerID string, checkpointID string) error {
+func (cli *Client) ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error {
 	query := url.Values{}
-	query.Set("checkpoint", checkpointID)
+	if len(options.CheckpointID) != 0 {
+		query.Set("checkpoint", options.CheckpointID)
+	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/vendor/github.com/docker/engine-api/client/container_stop.go
+++ b/vendor/github.com/docker/engine-api/client/container_stop.go
@@ -2,16 +2,19 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	if timeout != nil {
+		query.Set("t", timetypes.DurationToSecondsString(*timeout))
+	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/github.com/docker/engine-api/client/errors.go
+++ b/vendor/github.com/docker/engine-api/client/errors.go
@@ -8,26 +8,47 @@ import (
 // ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
+type notFound interface {
+	error
+	NotFound() bool // Is the error a NotFound error
+}
+
+// IsErrNotFound returns true if the error is caused with an
+// object (image, container, network, volume, …) is not found in the docker host.
+func IsErrNotFound(err error) bool {
+	te, ok := err.(notFound)
+	return ok && te.NotFound()
+}
+
 // imageNotFoundError implements an error returned when an image is not in the docker host.
 type imageNotFoundError struct {
 	imageID string
 }
 
+// NoFound indicates that this error type is of NotFound
+func (e imageNotFoundError) NotFound() bool {
+	return true
+}
+
 // Error returns a string representation of an imageNotFoundError
-func (i imageNotFoundError) Error() string {
-	return fmt.Sprintf("Error: No such image: %s", i.imageID)
+func (e imageNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such image: %s", e.imageID)
 }
 
 // IsErrImageNotFound returns true if the error is caused
 // when an image is not found in the docker host.
 func IsErrImageNotFound(err error) bool {
-	_, ok := err.(imageNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // containerNotFoundError implements an error returned when a container is not in the docker host.
 type containerNotFoundError struct {
 	containerID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e containerNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a containerNotFoundError
@@ -38,13 +59,17 @@ func (e containerNotFoundError) Error() string {
 // IsErrContainerNotFound returns true if the error is caused
 // when a container is not found in the docker host.
 func IsErrContainerNotFound(err error) bool {
-	_, ok := err.(containerNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // networkNotFoundError implements an error returned when a network is not in the docker host.
 type networkNotFoundError struct {
 	networkID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e networkNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -55,13 +80,17 @@ func (e networkNotFoundError) Error() string {
 // IsErrNetworkNotFound returns true if the error is caused
 // when a network is not found in the docker host.
 func IsErrNetworkNotFound(err error) bool {
-	_, ok := err.(networkNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // volumeNotFoundError implements an error returned when a volume is not in the docker host.
 type volumeNotFoundError struct {
 	volumeID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e volumeNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -72,8 +101,7 @@ func (e volumeNotFoundError) Error() string {
 // IsErrVolumeNotFound returns true if the error is caused
 // when a volume is not found in the docker host.
 func IsErrVolumeNotFound(err error) bool {
-	_, ok := err.(volumeNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // unauthorizedError represents an authorization error in a remote registry.
@@ -90,5 +118,86 @@ func (u unauthorizedError) Error() string {
 // when a remote registry authentication fails
 func IsErrUnauthorized(err error) bool {
 	_, ok := err.(unauthorizedError)
+	return ok
+}
+
+// nodeNotFoundError implements an error returned when a node is not found.
+type nodeNotFoundError struct {
+	nodeID string
+}
+
+// Error returns a string representation of a nodeNotFoundError
+func (e nodeNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such node: %s", e.nodeID)
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e nodeNotFoundError) NotFound() bool {
+	return true
+}
+
+// IsErrNodeNotFound returns true if the error is caused
+// when a node is not found.
+func IsErrNodeNotFound(err error) bool {
+	_, ok := err.(nodeNotFoundError)
+	return ok
+}
+
+// serviceNotFoundError implements an error returned when a service is not found.
+type serviceNotFoundError struct {
+	serviceID string
+}
+
+// Error returns a string representation of a serviceNotFoundError
+func (e serviceNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such service: %s", e.serviceID)
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e serviceNotFoundError) NotFound() bool {
+	return true
+}
+
+// IsErrServiceNotFound returns true if the error is caused
+// when a service is not found.
+func IsErrServiceNotFound(err error) bool {
+	_, ok := err.(serviceNotFoundError)
+	return ok
+}
+
+// taskNotFoundError implements an error returned when a task is not found.
+type taskNotFoundError struct {
+	taskID string
+}
+
+// Error returns a string representation of a taskNotFoundError
+func (e taskNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such task: %s", e.taskID)
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e taskNotFoundError) NotFound() bool {
+	return true
+}
+
+// IsErrTaskNotFound returns true if the error is caused
+// when a task is not found.
+func IsErrTaskNotFound(err error) bool {
+	_, ok := err.(taskNotFoundError)
+	return ok
+}
+
+type pluginPermissionDenied struct {
+	name string
+}
+
+func (e pluginPermissionDenied) Error() string {
+	return "Permission denied while installing plugin " + e.name
+}
+
+// IsErrPluginPermissionDenied returns true if the error is caused
+// when a user denies a plugin's permissions
+func IsErrPluginPermissionDenied(err error) bool {
+	_, ok := err.(pluginPermissionDenied)
 	return ok
 }

--- a/vendor/github.com/docker/engine-api/client/image_search.go
+++ b/vendor/github.com/docker/engine-api/client/image_search.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -17,6 +18,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)
+	query.Set("limit", fmt.Sprintf("%d", options.Limit))
 
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToParam(options.Filters)

--- a/vendor/github.com/docker/engine-api/client/image_tag.go
+++ b/vendor/github.com/docker/engine-api/client/image_tag.go
@@ -8,12 +8,11 @@ import (
 	"golang.org/x/net/context"
 
 	distreference "github.com/docker/distribution/reference"
-	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/reference"
 )
 
 // ImageTag tags an image in the docker host
-func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options types.ImageTagOptions) error {
+func (cli *Client) ImageTag(ctx context.Context, imageID, ref string) error {
 	distributionRef, err := distreference.ParseNamed(ref)
 	if err != nil {
 		return fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", ref)
@@ -28,9 +27,6 @@ func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options ty
 	query := url.Values{}
 	query.Set("repo", distributionRef.Name())
 	query.Set("tag", tag)
-	if options.Force {
-		query.Set("force", "1")
-	}
 
 	resp, err := cli.post(ctx, "/images/"+imageID+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/vendor/github.com/docker/engine-api/client/interface.go
+++ b/vendor/github.com/docker/engine-api/client/interface.go
@@ -2,22 +2,34 @@ package client
 
 import (
 	"io"
-
-	"golang.org/x/net/context"
+	"time"
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
 )
 
-// APIClient is an interface that clients that talk with a docker server must implement.
-type APIClient interface {
+// CommonAPIClient is the common methods between stable and experimental versions of APIClient.
+type CommonAPIClient interface {
+	ContainerAPIClient
+	ImageAPIClient
+	NodeAPIClient
+	NetworkAPIClient
+	ServiceAPIClient
+	SwarmAPIClient
+	SystemAPIClient
+	VolumeAPIClient
 	ClientVersion() string
-	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
-	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
-	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
+	ServerVersion(ctx context.Context) (types.Version, error)
+	UpdateClientVersion(v string)
+}
+
+// ContainerAPIClient defines API client methods for the containers
+type ContainerAPIClient interface {
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
@@ -37,18 +49,21 @@ type APIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout int) error
+	ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
-	ContainerStart(ctx context.Context, container string, checkpointID string) error
-	ContainerStop(ctx context.Context, container string, timeout int) error
+	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
+	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error
 	ContainerWait(ctx context.Context, container string) (int, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
-	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
+}
+
+// ImageAPIClient defines API client methods for the images
+type ImageAPIClient interface {
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]types.ImageHistory, error)
@@ -61,8 +76,11 @@ type APIClient interface {
 	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDelete, error)
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
-	ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error
-	Info(ctx context.Context) (types.Info, error)
+	ImageTag(ctx context.Context, image, ref string) error
+}
+
+// NetworkAPIClient defines API client methods for the networks
+type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
 	NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error
@@ -70,15 +88,48 @@ type APIClient interface {
 	NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, networkID string) error
+}
+
+// NodeAPIClient defines API client methods for the nodes
+type NodeAPIClient interface {
+	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
+	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
+	NodeRemove(ctx context.Context, nodeID string) error
+	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
+}
+
+// ServiceAPIClient defines API client methods for the services
+type ServiceAPIClient interface {
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error)
+	ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error)
+	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
+	ServiceRemove(ctx context.Context, serviceID string) error
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) error
+	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
+	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
+}
+
+// SwarmAPIClient defines API client methods for the swarm
+type SwarmAPIClient interface {
+	SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error)
+	SwarmJoin(ctx context.Context, req swarm.JoinRequest) error
+	SwarmLeave(ctx context.Context, force bool) error
+	SwarmInspect(ctx context.Context) (swarm.Swarm, error)
+	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error
+}
+
+// SystemAPIClient defines API client methods for the system
+type SystemAPIClient interface {
+	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
+	Info(ctx context.Context) (types.Info, error)
 	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
-	ServerVersion(ctx context.Context) (types.Version, error)
-	UpdateClientVersion(v string)
+}
+
+// VolumeAPIClient defines API client methods for the volumes
+type VolumeAPIClient interface {
 	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string) error
 }
-
-// Ensure that Client always implements APIClient.
-var _ APIClient = &Client{}

--- a/vendor/github.com/docker/engine-api/client/interface_experimental.go
+++ b/vendor/github.com/docker/engine-api/client/interface_experimental.go
@@ -1,0 +1,37 @@
+// +build experimental
+
+package client
+
+import (
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// APIClient is an interface that clients that talk with a docker server must implement.
+type APIClient interface {
+	CommonAPIClient
+	CheckpointAPIClient
+	PluginAPIClient
+}
+
+// CheckpointAPIClient defines API client methods for the checkpoints
+type CheckpointAPIClient interface {
+	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
+	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
+	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
+}
+
+// PluginAPIClient defines API client methods for the plugins
+type PluginAPIClient interface {
+	PluginList(ctx context.Context) (types.PluginsListResponse, error)
+	PluginRemove(ctx context.Context, name string) error
+	PluginEnable(ctx context.Context, name string) error
+	PluginDisable(ctx context.Context, name string) error
+	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) error
+	PluginPush(ctx context.Context, name string, registryAuth string) error
+	PluginSet(ctx context.Context, name string, args []string) error
+	PluginInspect(ctx context.Context, name string) (*types.Plugin, error)
+}
+
+// Ensure that Client always implements APIClient.
+var _ APIClient = &Client{}

--- a/vendor/github.com/docker/engine-api/client/interface_stable.go
+++ b/vendor/github.com/docker/engine-api/client/interface_stable.go
@@ -1,0 +1,11 @@
+// +build !experimental
+
+package client
+
+// APIClient is an interface that clients that talk with a docker server must implement.
+type APIClient interface {
+	CommonAPIClient
+}
+
+// Ensure that Client always implements APIClient.
+var _ APIClient = &Client{}

--- a/vendor/github.com/docker/engine-api/client/network_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/network_inspect.go
@@ -16,7 +16,7 @@ func (cli *Client) NetworkInspect(ctx context.Context, networkID string) (types.
 	return networkResource, err
 }
 
-// NetworkInspectWithRaw returns the information for a specific network configured in the docker host and it's raw representation.
+// NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
 func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error) {
 	var networkResource types.NetworkResource
 	resp, err := cli.get(ctx, "/networks/"+networkID, nil, nil)

--- a/vendor/github.com/docker/engine-api/client/node_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/node_inspect.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NodeInspectWithRaw returns the node information.
+func (cli *Client) NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error) {
+	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
+	if err != nil {
+		if serverResp.statusCode == http.StatusNotFound {
+			return swarm.Node{}, nil, nodeNotFoundError{nodeID}
+		}
+		return swarm.Node{}, nil, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	body, err := ioutil.ReadAll(serverResp.body)
+	if err != nil {
+		return swarm.Node{}, nil, err
+	}
+
+	var response swarm.Node
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&response)
+	return response, body, err
+}

--- a/vendor/github.com/docker/engine-api/client/node_list.go
+++ b/vendor/github.com/docker/engine-api/client/node_list.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NodeList returns the list of nodes.
+func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/nodes", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []swarm.Node
+	err = json.NewDecoder(resp.body).Decode(&nodes)
+	ensureReaderClosed(resp)
+	return nodes, err
+}

--- a/vendor/github.com/docker/engine-api/client/node_remove.go
+++ b/vendor/github.com/docker/engine-api/client/node_remove.go
@@ -1,0 +1,10 @@
+package client
+
+import "golang.org/x/net/context"
+
+// NodeRemove removes a Node.
+func (cli *Client) NodeRemove(ctx context.Context, nodeID string) error {
+	resp, err := cli.delete(ctx, "/nodes/"+nodeID, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/node_update.go
+++ b/vendor/github.com/docker/engine-api/client/node_update.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NodeUpdate updates a Node.
+func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error {
+	query := url.Values{}
+	query.Set("version", strconv.FormatUint(version.Index, 10))
+	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_disable.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_disable.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginDisable disables a plugin
+func (cli *Client) PluginDisable(ctx context.Context, name string) error {
+	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", nil, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_enable.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_enable.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginEnable enables a plugin
+func (cli *Client) PluginEnable(ctx context.Context, name string) error {
+	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", nil, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_inspect.go
@@ -1,0 +1,22 @@
+// +build experimental
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginInspect inspects an existing plugin
+func (cli *Client) PluginInspect(ctx context.Context, name string) (*types.Plugin, error) {
+	var p types.Plugin
+	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	err = json.NewDecoder(resp.body).Decode(&p)
+	ensureReaderClosed(resp)
+	return &p, err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_install.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_install.go
@@ -1,0 +1,59 @@
+// +build experimental
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginInstall installs a plugin
+func (cli *Client) PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) error {
+	// FIXME(vdemeester) name is a ref, we might want to parse/validate it here.
+	query := url.Values{}
+	query.Set("name", name)
+	resp, err := cli.tryPluginPull(ctx, query, options.RegistryAuth)
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
+		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		if privilegeErr != nil {
+			ensureReaderClosed(resp)
+			return privilegeErr
+		}
+		resp, err = cli.tryPluginPull(ctx, query, newAuthHeader)
+	}
+	if err != nil {
+		ensureReaderClosed(resp)
+		return err
+	}
+	var privileges types.PluginPrivileges
+	if err := json.NewDecoder(resp.body).Decode(&privileges); err != nil {
+		ensureReaderClosed(resp)
+		return err
+	}
+	ensureReaderClosed(resp)
+
+	if !options.AcceptAllPermissions && options.AcceptPermissionsFunc != nil && len(privileges) > 0 {
+		accept, err := options.AcceptPermissionsFunc(privileges)
+		if err != nil {
+			return err
+		}
+		if !accept {
+			resp, _ := cli.delete(ctx, "/plugins/"+name, nil, nil)
+			ensureReaderClosed(resp)
+			return pluginPermissionDenied{name}
+		}
+	}
+	if options.Disabled {
+		return nil
+	}
+	return cli.PluginEnable(ctx, name)
+}
+
+func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, registryAuth string) (*serverResponse, error) {
+	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
+	return cli.post(ctx, "/plugins/pull", query, nil, headers)
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_list.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_list.go
@@ -1,0 +1,23 @@
+// +build experimental
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginList returns the installed plugins
+func (cli *Client) PluginList(ctx context.Context) (types.PluginsListResponse, error) {
+	var plugins types.PluginsListResponse
+	resp, err := cli.get(ctx, "/plugins", nil, nil)
+	if err != nil {
+		return plugins, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&plugins)
+	ensureReaderClosed(resp)
+	return plugins, err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_push.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_push.go
@@ -1,0 +1,15 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginPush pushes a plugin to a registry
+func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) error {
+	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
+	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, headers)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_remove.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_remove.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginRemove removes a plugin
+func (cli *Client) PluginRemove(ctx context.Context, name string) error {
+	resp, err := cli.delete(ctx, "/plugins/"+name, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_set.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_set.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginSet modifies settings for an existing plugin
+func (cli *Client) PluginSet(ctx context.Context, name string, args []string) error {
+	resp, err := cli.post(ctx, "/plugins/"+name+"/set", nil, args, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/request.go
+++ b/vendor/github.com/docker/engine-api/client/request.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/client/transport/cancellable"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/versions"
 	"golang.org/x/net/context"
 )
 
@@ -111,7 +113,7 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)
 		}
 
-		if cli.transport.Secure() && strings.Contains(err.Error(), "remote error: bad certificate") {
+		if cli.transport.Secure() && strings.Contains(err.Error(), "bad certificate") {
 			return serverResp, fmt.Errorf("The server probably has client authentication (--tlsverify) enabled. Please check your TLS client certification settings: %v", err)
 		}
 
@@ -130,7 +132,20 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 		if len(body) == 0 {
 			return serverResp, fmt.Errorf("Error: request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), req.URL)
 		}
-		return serverResp, fmt.Errorf("Error response from daemon: %s", bytes.TrimSpace(body))
+
+		var errorMessage string
+		if (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) &&
+			resp.Header.Get("Content-Type") == "application/json" {
+			var errorResponse types.ErrorResponse
+			if err := json.Unmarshal(body, &errorResponse); err != nil {
+				return serverResp, fmt.Errorf("Error reading JSON: %v", err)
+			}
+			errorMessage = errorResponse.Message
+		} else {
+			errorMessage = string(body)
+		}
+
+		return serverResp, fmt.Errorf("Error response from daemon: %s", strings.TrimSpace(errorMessage))
 	}
 
 	serverResp.body = resp.Body

--- a/vendor/github.com/docker/engine-api/client/service_create.go
+++ b/vendor/github.com/docker/engine-api/client/service_create.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceCreate creates a new Service.
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
+	var headers map[string][]string
+
+	if options.EncodedRegistryAuth != "" {
+		headers = map[string][]string{
+			"X-Registry-Auth": []string{options.EncodedRegistryAuth},
+		}
+	}
+
+	var response types.ServiceCreateResponse
+	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/service_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/service_inspect.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceInspectWithRaw returns the service information and the raw data.
+func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error) {
+	serverResp, err := cli.get(ctx, "/services/"+serviceID, nil, nil)
+	if err != nil {
+		if serverResp.statusCode == http.StatusNotFound {
+			return swarm.Service{}, nil, serviceNotFoundError{serviceID}
+		}
+		return swarm.Service{}, nil, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	body, err := ioutil.ReadAll(serverResp.body)
+	if err != nil {
+		return swarm.Service{}, nil, err
+	}
+
+	var response swarm.Service
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&response)
+	return response, body, err
+}

--- a/vendor/github.com/docker/engine-api/client/service_list.go
+++ b/vendor/github.com/docker/engine-api/client/service_list.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceList returns the list of services.
+func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/services", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var services []swarm.Service
+	err = json.NewDecoder(resp.body).Decode(&services)
+	ensureReaderClosed(resp)
+	return services, err
+}

--- a/vendor/github.com/docker/engine-api/client/service_remove.go
+++ b/vendor/github.com/docker/engine-api/client/service_remove.go
@@ -1,0 +1,10 @@
+package client
+
+import "golang.org/x/net/context"
+
+// ServiceRemove kills and removes a service.
+func (cli *Client) ServiceRemove(ctx context.Context, serviceID string) error {
+	resp, err := cli.delete(ctx, "/services/"+serviceID, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/service_update.go
+++ b/vendor/github.com/docker/engine-api/client/service_update.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceUpdate updates a Service.
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) error {
+	var (
+		headers map[string][]string
+		query   = url.Values{}
+	)
+
+	if options.EncodedRegistryAuth != "" {
+		headers = map[string][]string{
+			"X-Registry-Auth": []string{options.EncodedRegistryAuth},
+		}
+	}
+
+	query.Set("version", strconv.FormatUint(version.Index, 10))
+
+	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_init.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_init.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmInit initializes the Swarm.
+func (cli *Client) SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error) {
+	serverResp, err := cli.post(ctx, "/swarm/init", nil, req, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var response string
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_inspect.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmInspect inspects the Swarm.
+func (cli *Client) SwarmInspect(ctx context.Context) (swarm.Swarm, error) {
+	serverResp, err := cli.get(ctx, "/swarm", nil, nil)
+	if err != nil {
+		return swarm.Swarm{}, err
+	}
+
+	var response swarm.Swarm
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_join.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_join.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmJoin joins the Swarm.
+func (cli *Client) SwarmJoin(ctx context.Context, req swarm.JoinRequest) error {
+	resp, err := cli.post(ctx, "/swarm/join", nil, req, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_leave.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_leave.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+// SwarmLeave leaves the Swarm.
+func (cli *Client) SwarmLeave(ctx context.Context, force bool) error {
+	query := url.Values{}
+	if force {
+		query.Set("force", "1")
+	}
+	resp, err := cli.post(ctx, "/swarm/leave", query, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_update.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_update.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmUpdate updates the Swarm.
+func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error {
+	query := url.Values{}
+	query.Set("version", strconv.FormatUint(version.Index, 10))
+	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/task_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/task_inspect.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+
+	"golang.org/x/net/context"
+)
+
+// TaskInspectWithRaw returns the task information and its raw representation..
+func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error) {
+	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
+	if err != nil {
+		if serverResp.statusCode == http.StatusNotFound {
+			return swarm.Task{}, nil, taskNotFoundError{taskID}
+		}
+		return swarm.Task{}, nil, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	body, err := ioutil.ReadAll(serverResp.body)
+	if err != nil {
+		return swarm.Task{}, nil, err
+	}
+
+	var response swarm.Task
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&response)
+	return response, body, err
+}

--- a/vendor/github.com/docker/engine-api/client/task_list.go
+++ b/vendor/github.com/docker/engine-api/client/task_list.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// TaskList returns the list of tasks.
+func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/tasks", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tasks []swarm.Task
+	err = json.NewDecoder(resp.body).Decode(&tasks)
+	ensureReaderClosed(resp)
+	return tasks, err
+}

--- a/vendor/github.com/docker/engine-api/client/transport/cancellable/cancellable.go
+++ b/vendor/github.com/docker/engine-api/client/transport/cancellable/cancellable.go
@@ -30,7 +30,7 @@ var (
 //
 // This function deviates from the upstream version in golang.org/x/net/context/ctxhttp by
 // taking a Sender interface rather than a *http.Client directly. That allow us to use
-// this funcion with mocked clients and hijacked connections.
+// this function with mocked clients and hijacked connections.
 func Do(ctx context.Context, client transport.Sender, req *http.Request) (*http.Response, error) {
 	if client == nil {
 		client = http.DefaultClient

--- a/vendor/github.com/docker/engine-api/client/volume_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/volume_inspect.go
@@ -16,7 +16,7 @@ func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Vo
 	return volume, err
 }
 
-// VolumeInspectWithRaw returns the information about a specific volume in the docker host and it's raw representation
+// VolumeInspectWithRaw returns the information about a specific volume in the docker host and its raw representation
 func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error) {
 	var volume types.Volume
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)

--- a/vendor/github.com/docker/engine-api/types/client.go
+++ b/vendor/github.com/docker/engine-api/types/client.go
@@ -73,6 +73,11 @@ type ContainerRemoveOptions struct {
 	Force         bool
 }
 
+// ContainerStartOptions holds parameters to start containers.
+type ContainerStartOptions struct {
+	CheckpointID string
+}
+
 // CopyToContainerOptions holds information
 // about files to copy into a container
 type CopyToContainerOptions struct {
@@ -213,11 +218,7 @@ type ImageSearchOptions struct {
 	RegistryAuth  string
 	PrivilegeFunc RequestPrivilegeFunc
 	Filters       filters.Args
-}
-
-// ImageTagOptions holds parameters to tag an image
-type ImageTagOptions struct {
-	Force bool
+	Limit         int
 }
 
 // ResizeOptions holds parameters to resize a tty.
@@ -238,4 +239,48 @@ type VersionResponse struct {
 // and parse the information received. It returns false otherwise.
 func (v VersionResponse) ServerOK() bool {
 	return v.Server != nil
+}
+
+// NodeListOptions holds parameters to list  nodes with.
+type NodeListOptions struct {
+	Filter filters.Args
+}
+
+// ServiceCreateOptions contains the options to use when creating a service.
+type ServiceCreateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+}
+
+// ServiceCreateResponse contains the information returned to a client
+// on the  creation of a new service.
+type ServiceCreateResponse struct {
+	// ID is the ID of the created service.
+	ID string
+}
+
+// ServiceUpdateOptions contains the options to be used for updating services.
+type ServiceUpdateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+
+	// TODO(stevvooe): Consider moving the version parameter of ServiceUpdate
+	// into this field. While it does open API users up to racy writes, most
+	// users may not need that level of consistency in practice.
+}
+
+// ServiceListOptions holds parameters to list  services with.
+type ServiceListOptions struct {
+	Filter filters.Args
+}
+
+// TaskListOptions holds parameters to list  tasks with.
+type TaskListOptions struct {
+	Filter filters.Args
 }

--- a/vendor/github.com/docker/engine-api/types/container/config.go
+++ b/vendor/github.com/docker/engine-api/types/container/config.go
@@ -1,9 +1,31 @@
 package container
 
 import (
+	"time"
+
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/docker/go-connections/nat"
 )
+
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout  time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
+}
 
 // Config contains the configuration data about a container.
 // It should hold only portable information about the container.
@@ -24,6 +46,7 @@ type Config struct {
 	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
 	Env             []string              // List of environment variable to set in the container
 	Cmd             strslice.StrSlice     // Command to run when starting the container
+	Healthcheck     *HealthConfig         `json:",omitempty"` // Healthcheck describes how to check the container is healthy
 	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
 	Image           string                // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container
@@ -34,4 +57,6 @@ type Config struct {
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
 	StopSignal      string                `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                  `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           strslice.StrSlice     `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/vendor/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/github.com/docker/engine-api/types/container/host_config.go
@@ -303,12 +303,13 @@ type HostConfig struct {
 	PublishAllPorts bool              // Should docker publish all exposed port for the container
 	ReadonlyRootfs  bool              // Is the container root filesystem in read-only
 	SecurityOpt     []string          // List of string values to customize labels for MLS systems, such as SELinux.
-	StorageOpt      map[string]string // Storage driver options per container.
+	StorageOpt      map[string]string `json:",omitempty"` // Storage driver options per container.
 	Tmpfs           map[string]string `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container
 	ShmSize         int64             // Total shm memory usage
 	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
+	Runtime         string            `json:",omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
 	ConsoleSize [2]int    // Initial console size

--- a/vendor/github.com/docker/engine-api/types/errors.go
+++ b/vendor/github.com/docker/engine-api/types/errors.go
@@ -1,0 +1,6 @@
+package types
+
+// ErrorResponse is the response body of API errors.
+type ErrorResponse struct {
+	Message string `json:"message"`
+}

--- a/vendor/github.com/docker/engine-api/types/network/network.go
+++ b/vendor/github.com/docker/engine-api/types/network/network.go
@@ -23,8 +23,9 @@ type IPAMConfig struct {
 
 // EndpointIPAMConfig represents IPAM configurations for the endpoint
 type EndpointIPAMConfig struct {
-	IPv4Address string `json:",omitempty"`
-	IPv6Address string `json:",omitempty"`
+	IPv4Address  string   `json:",omitempty"`
+	IPv6Address  string   `json:",omitempty"`
+	LinkLocalIPs []string `json:",omitempty"`
 }
 
 // EndpointSettings stores the network endpoint details

--- a/vendor/github.com/docker/engine-api/types/plugin.go
+++ b/vendor/github.com/docker/engine-api/types/plugin.go
@@ -1,0 +1,169 @@
+// +build experimental
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PluginInstallOptions holds parameters to install a plugin.
+type PluginInstallOptions struct {
+	Disabled              bool
+	AcceptAllPermissions  bool
+	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
+	PrivilegeFunc         RequestPrivilegeFunc
+	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
+}
+
+// PluginConfig represents the values of settings potentially modifiable by a user
+type PluginConfig struct {
+	Mounts  []PluginMount
+	Env     []string
+	Args    []string
+	Devices []PluginDevice
+}
+
+// Plugin represents a Docker plugin for the remote API
+type Plugin struct {
+	ID       string `json:"Id,omitempty"`
+	Name     string
+	Tag      string
+	Active   bool
+	Config   PluginConfig
+	Manifest PluginManifest
+}
+
+// PluginsListResponse contains the response for the remote API
+type PluginsListResponse []*Plugin
+
+const (
+	authzDriver   = "AuthzDriver"
+	graphDriver   = "GraphDriver"
+	ipamDriver    = "IpamDriver"
+	networkDriver = "NetworkDriver"
+	volumeDriver  = "VolumeDriver"
+)
+
+// PluginInterfaceType represents a type that a plugin implements.
+type PluginInterfaceType struct {
+	Prefix     string // This is always "docker"
+	Capability string // Capability should be validated against the above list.
+	Version    string // Plugin API version. Depends on the capability
+}
+
+// UnmarshalJSON implements json.Unmarshaler for PluginInterfaceType
+func (t *PluginInterfaceType) UnmarshalJSON(p []byte) error {
+	versionIndex := len(p)
+	prefixIndex := 0
+	if len(p) < 2 || p[0] != '"' || p[len(p)-1] != '"' {
+		return fmt.Errorf("%q is not a plugin interface type", p)
+	}
+	p = p[1 : len(p)-1]
+loop:
+	for i, b := range p {
+		switch b {
+		case '.':
+			prefixIndex = i
+		case '/':
+			versionIndex = i
+			break loop
+		}
+	}
+	t.Prefix = string(p[:prefixIndex])
+	t.Capability = string(p[prefixIndex+1 : versionIndex])
+	if versionIndex < len(p) {
+		t.Version = string(p[versionIndex+1:])
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for PluginInterfaceType
+func (t *PluginInterfaceType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+// String implements fmt.Stringer for PluginInterfaceType
+func (t PluginInterfaceType) String() string {
+	return fmt.Sprintf("%s.%s/%s", t.Prefix, t.Capability, t.Version)
+}
+
+// PluginInterface describes the interface between Docker and plugin
+type PluginInterface struct {
+	Types  []PluginInterfaceType
+	Socket string
+}
+
+// PluginSetting is to be embedded in other structs, if they are supposed to be
+// modifiable by the user.
+type PluginSetting struct {
+	Name        string
+	Description string
+	Settable    []string
+}
+
+// PluginNetwork represents the network configuration for a plugin
+type PluginNetwork struct {
+	Type string
+}
+
+// PluginMount represents the mount configuration for a plugin
+type PluginMount struct {
+	PluginSetting
+	Source      *string
+	Destination string
+	Type        string
+	Options     []string
+}
+
+// PluginEnv represents an environment variable for a plugin
+type PluginEnv struct {
+	PluginSetting
+	Value *string
+}
+
+// PluginArgs represents the command line arguments for a plugin
+type PluginArgs struct {
+	PluginSetting
+	Value []string
+}
+
+// PluginDevice represents a device for a plugin
+type PluginDevice struct {
+	PluginSetting
+	Path *string
+}
+
+// PluginUser represents the user for the plugin's process
+type PluginUser struct {
+	UID uint32 `json:"Uid,omitempty"`
+	GID uint32 `json:"Gid,omitempty"`
+}
+
+// PluginManifest represents the manifest of a plugin
+type PluginManifest struct {
+	ManifestVersion string
+	Description     string
+	Documentation   string
+	Interface       PluginInterface
+	Entrypoint      []string
+	Workdir         string
+	User            PluginUser `json:",omitempty"`
+	Network         PluginNetwork
+	Capabilities    []string
+	Mounts          []PluginMount
+	Devices         []PluginDevice
+	Env             []PluginEnv
+	Args            PluginArgs
+}
+
+// PluginPrivilege describes a permission the user has to accept
+// upon installing a plugin.
+type PluginPrivilege struct {
+	Name        string
+	Description string
+	Value       []string
+}
+
+// PluginPrivileges is a list of PluginPrivilege
+type PluginPrivileges []PluginPrivilege

--- a/vendor/github.com/docker/engine-api/types/seccomp.go
+++ b/vendor/github.com/docker/engine-api/types/seccomp.go
@@ -24,6 +24,11 @@ const (
 	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
 	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
 	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+	ArchPPC         Arch = "SCMP_ARCH_PPC"
+	ArchPPC64       Arch = "SCMP_ARCH_PPC64"
+	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
+	ArchS390        Arch = "SCMP_ARCH_S390"
+	ArchS390X       Arch = "SCMP_ARCH_S390X"
 )
 
 // Action taken upon Seccomp rule match

--- a/vendor/github.com/docker/engine-api/types/swarm/common.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/common.go
@@ -1,0 +1,21 @@
+package swarm
+
+import "time"
+
+// Version represent the internal object version.
+type Version struct {
+	Index uint64 `json:",omitempty"`
+}
+
+// Meta is  base object inherited by most of the other once.
+type Meta struct {
+	Version   Version   `json:",omitempty"`
+	CreatedAt time.Time `json:",omitempty"`
+	UpdatedAt time.Time `json:",omitempty"`
+}
+
+// Annotations represents how to describe an object.
+type Annotations struct {
+	Name   string            `json:",omitempty"`
+	Labels map[string]string `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/container.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/container.go
@@ -1,0 +1,67 @@
+package swarm
+
+import "time"
+
+// ContainerSpec represents the spec of a container.
+type ContainerSpec struct {
+	Image           string            `json:",omitempty"`
+	Labels          map[string]string `json:",omitempty"`
+	Command         []string          `json:",omitempty"`
+	Args            []string          `json:",omitempty"`
+	Env             []string          `json:",omitempty"`
+	Dir             string            `json:",omitempty"`
+	User            string            `json:",omitempty"`
+	Mounts          []Mount           `json:",omitempty"`
+	StopGracePeriod *time.Duration    `json:",omitempty"`
+}
+
+// MountType represents the type of a mount.
+type MountType string
+
+const (
+	// MountTypeBind BIND
+	MountTypeBind MountType = "bind"
+	// MountTypeVolume VOLUME
+	MountTypeVolume MountType = "volume"
+)
+
+// Mount represents a mount (volume).
+type Mount struct {
+	Type     MountType `json:",omitempty"`
+	Source   string    `json:",omitempty"`
+	Target   string    `json:",omitempty"`
+	ReadOnly bool      `json:",omitempty"`
+
+	BindOptions   *BindOptions   `json:",omitempty"`
+	VolumeOptions *VolumeOptions `json:",omitempty"`
+}
+
+// MountPropagation represents the propagation of a mount.
+type MountPropagation string
+
+const (
+	// MountPropagationRPrivate RPRIVATE
+	MountPropagationRPrivate MountPropagation = "rprivate"
+	// MountPropagationPrivate PRIVATE
+	MountPropagationPrivate MountPropagation = "private"
+	// MountPropagationRShared RSHARED
+	MountPropagationRShared MountPropagation = "rshared"
+	// MountPropagationShared SHARED
+	MountPropagationShared MountPropagation = "shared"
+	// MountPropagationRSlave RSLAVE
+	MountPropagationRSlave MountPropagation = "rslave"
+	// MountPropagationSlave SLAVE
+	MountPropagationSlave MountPropagation = "slave"
+)
+
+// BindOptions defines options specific to mounts of type "bind".
+type BindOptions struct {
+	Propagation MountPropagation `json:",omitempty"`
+}
+
+// VolumeOptions represents the options for a mount of type volume.
+type VolumeOptions struct {
+	NoCopy       bool              `json:",omitempty"`
+	Labels       map[string]string `json:",omitempty"`
+	DriverConfig *Driver           `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/network.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/network.go
@@ -1,0 +1,99 @@
+package swarm
+
+// Endpoint represents an endpoint.
+type Endpoint struct {
+	Spec       EndpointSpec        `json:",omitempty"`
+	Ports      []PortConfig        `json:",omitempty"`
+	VirtualIPs []EndpointVirtualIP `json:",omitempty"`
+}
+
+// EndpointSpec represents the spec of an endpoint.
+type EndpointSpec struct {
+	Mode  ResolutionMode `json:",omitempty"`
+	Ports []PortConfig   `json:",omitempty"`
+}
+
+// ResolutionMode represents a resolution mode.
+type ResolutionMode string
+
+const (
+	// ResolutionModeVIP VIP
+	ResolutionModeVIP ResolutionMode = "vip"
+	// ResolutionModeDNSRR DNSRR
+	ResolutionModeDNSRR ResolutionMode = "dnsrr"
+)
+
+// PortConfig represents the config of a port.
+type PortConfig struct {
+	Name          string             `json:",omitempty"`
+	Protocol      PortConfigProtocol `json:",omitempty"`
+	TargetPort    uint32             `json:",omitempty"`
+	PublishedPort uint32             `json:",omitempty"`
+}
+
+// PortConfigProtocol represents the protocol of a port.
+type PortConfigProtocol string
+
+const (
+	// TODO(stevvooe): These should be used generally, not just for PortConfig.
+
+	// PortConfigProtocolTCP TCP
+	PortConfigProtocolTCP PortConfigProtocol = "tcp"
+	// PortConfigProtocolUDP UDP
+	PortConfigProtocolUDP PortConfigProtocol = "udp"
+)
+
+// EndpointVirtualIP represents the virtual ip of a port.
+type EndpointVirtualIP struct {
+	NetworkID string `json:",omitempty"`
+	Addr      string `json:",omitempty"`
+}
+
+// Network represents a network.
+type Network struct {
+	ID string
+	Meta
+	Spec        NetworkSpec  `json:",omitempty"`
+	DriverState Driver       `json:",omitempty"`
+	IPAMOptions *IPAMOptions `json:",omitempty"`
+}
+
+// NetworkSpec represents the spec of a network.
+type NetworkSpec struct {
+	Annotations
+	DriverConfiguration *Driver      `json:",omitempty"`
+	IPv6Enabled         bool         `json:",omitempty"`
+	Internal            bool         `json:",omitempty"`
+	IPAMOptions         *IPAMOptions `json:",omitempty"`
+}
+
+// NetworkAttachmentConfig represents the configuration of a network attachment.
+type NetworkAttachmentConfig struct {
+	Target  string   `json:",omitempty"`
+	Aliases []string `json:",omitempty"`
+}
+
+// NetworkAttachment represents a network attachment.
+type NetworkAttachment struct {
+	Network   Network  `json:",omitempty"`
+	Addresses []string `json:",omitempty"`
+}
+
+// IPAMOptions represents ipam options.
+type IPAMOptions struct {
+	Driver  Driver       `json:",omitempty"`
+	Configs []IPAMConfig `json:",omitempty"`
+}
+
+// IPAMConfig represents ipam configuration.
+type IPAMConfig struct {
+	Subnet  string `json:",omitempty"`
+	Range   string `json:",omitempty"`
+	Gateway string `json:",omitempty"`
+}
+
+// Driver represents a driver (network/volume).
+type Driver struct {
+	Name    string            `json:",omitempty"`
+	Options map[string]string `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/node.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/node.go
@@ -1,0 +1,118 @@
+package swarm
+
+// Node represents a node.
+type Node struct {
+	ID string
+	Meta
+
+	Spec          NodeSpec        `json:",omitempty"`
+	Description   NodeDescription `json:",omitempty"`
+	Status        NodeStatus      `json:",omitempty"`
+	ManagerStatus *ManagerStatus  `json:",omitempty"`
+}
+
+// NodeSpec represents the spec of a node.
+type NodeSpec struct {
+	Annotations
+	Role         NodeRole         `json:",omitempty"`
+	Membership   NodeMembership   `json:",omitempty"`
+	Availability NodeAvailability `json:",omitempty"`
+}
+
+// NodeRole represents the role of a node.
+type NodeRole string
+
+const (
+	// NodeRoleWorker WORKER
+	NodeRoleWorker NodeRole = "worker"
+	// NodeRoleManager MANAGER
+	NodeRoleManager NodeRole = "manager"
+)
+
+// NodeMembership represents the membership of a node.
+type NodeMembership string
+
+const (
+	// NodeMembershipPending PENDING
+	NodeMembershipPending NodeMembership = "pending"
+	// NodeMembershipAccepted ACCEPTED
+	NodeMembershipAccepted NodeMembership = "accepted"
+)
+
+// NodeAvailability represents the availability of a node.
+type NodeAvailability string
+
+const (
+	// NodeAvailabilityActive ACTIVE
+	NodeAvailabilityActive NodeAvailability = "active"
+	// NodeAvailabilityPause PAUSE
+	NodeAvailabilityPause NodeAvailability = "pause"
+	// NodeAvailabilityDrain DRAIN
+	NodeAvailabilityDrain NodeAvailability = "drain"
+)
+
+// NodeDescription represents the description of a node.
+type NodeDescription struct {
+	Hostname  string            `json:",omitempty"`
+	Platform  Platform          `json:",omitempty"`
+	Resources Resources         `json:",omitempty"`
+	Engine    EngineDescription `json:",omitempty"`
+}
+
+// Platform represents the platfrom (Arch/OS).
+type Platform struct {
+	Architecture string `json:",omitempty"`
+	OS           string `json:",omitempty"`
+}
+
+// EngineDescription represents the description of an engine.
+type EngineDescription struct {
+	EngineVersion string              `json:",omitempty"`
+	Labels        map[string]string   `json:",omitempty"`
+	Plugins       []PluginDescription `json:",omitempty"`
+}
+
+// PluginDescription represents the description of an engine plugin.
+type PluginDescription struct {
+	Type string `json:",omitempty"`
+	Name string `json:",omitempty"`
+}
+
+// NodeStatus represents the status of a node.
+type NodeStatus struct {
+	State   NodeState `json:",omitempty"`
+	Message string    `json:",omitempty"`
+}
+
+// Reachability represents the reachability of a node.
+type Reachability string
+
+const (
+	// ReachabilityUnknown UNKNOWN
+	ReachabilityUnknown Reachability = "unknown"
+	// ReachabilityUnreachable UNREACHABLE
+	ReachabilityUnreachable Reachability = "unreachable"
+	// ReachabilityReachable REACHABLE
+	ReachabilityReachable Reachability = "reachable"
+)
+
+// ManagerStatus represents the status of a manager.
+type ManagerStatus struct {
+	Leader       bool         `json:",omitempty"`
+	Reachability Reachability `json:",omitempty"`
+	Addr         string       `json:",omitempty"`
+}
+
+// NodeState represents the state of a node.
+type NodeState string
+
+const (
+	// NodeStateUnknown UNKNOWN
+	NodeStateUnknown NodeState = "unknown"
+	// NodeStateDown DOWN
+	NodeStateDown NodeState = "down"
+	// NodeStateReady READY
+	NodeStateReady NodeState = "ready"
+	// NodeStateDisconnected DISCONNECTED
+	NodeStateDisconnected NodeState = "disconnected"
+)

--- a/vendor/github.com/docker/engine-api/types/swarm/service.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/service.go
@@ -1,0 +1,44 @@
+package swarm
+
+import "time"
+
+// Service represents a service.
+type Service struct {
+	ID string
+	Meta
+	Spec     ServiceSpec `json:",omitempty"`
+	Endpoint Endpoint    `json:",omitempty"`
+}
+
+// ServiceSpec represents the spec of a service.
+type ServiceSpec struct {
+	Annotations
+
+	// TaskTemplate defines how the service should construct new tasks when
+	// orchestrating this service.
+	TaskTemplate TaskSpec                  `json:",omitempty"`
+	Mode         ServiceMode               `json:",omitempty"`
+	UpdateConfig *UpdateConfig             `json:",omitempty"`
+	Networks     []NetworkAttachmentConfig `json:",omitempty"`
+	EndpointSpec *EndpointSpec             `json:",omitempty"`
+}
+
+// ServiceMode represents the mode of a service.
+type ServiceMode struct {
+	Replicated *ReplicatedService `json:",omitempty"`
+	Global     *GlobalService     `json:",omitempty"`
+}
+
+// ReplicatedService is a kind of ServiceMode.
+type ReplicatedService struct {
+	Replicas *uint64 `json:",omitempty"`
+}
+
+// GlobalService is a kind of ServiceMode.
+type GlobalService struct{}
+
+// UpdateConfig represents the update configuration.
+type UpdateConfig struct {
+	Parallelism uint64        `json:",omitempty"`
+	Delay       time.Duration `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/swarm.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/swarm.go
@@ -1,0 +1,129 @@
+package swarm
+
+import "time"
+
+// Swarm represents a swarm.
+type Swarm struct {
+	ID string
+	Meta
+	Spec Spec
+}
+
+// Spec represents the spec of a swarm.
+type Spec struct {
+	Annotations
+
+	AcceptancePolicy AcceptancePolicy    `json:",omitempty"`
+	Orchestration    OrchestrationConfig `json:",omitempty"`
+	Raft             RaftConfig          `json:",omitempty"`
+	Dispatcher       DispatcherConfig    `json:",omitempty"`
+	CAConfig         CAConfig            `json:",omitempty"`
+}
+
+// AcceptancePolicy represents the list of policies.
+type AcceptancePolicy struct {
+	Policies []Policy `json:",omitempty"`
+}
+
+// Policy represents a role, autoaccept and secret.
+type Policy struct {
+	Role       NodeRole
+	Autoaccept bool
+	Secret     *string `json:",omitempty"`
+}
+
+// OrchestrationConfig represents orchestration configuration.
+type OrchestrationConfig struct {
+	TaskHistoryRetentionLimit int64 `json:",omitempty"`
+
+	// DefaultLogDriver selects the log driver to use for tasks created in the
+	// orchestrator if unspecified by a service.
+	//
+	// Updating this value will only have an affect on new tasks. Old tasks
+	// will continue use their previously configured log driver until
+	// recreated.
+	DefaultLogDriver *Driver `json:",omitempty"`
+}
+
+// RaftConfig represents raft configuration.
+type RaftConfig struct {
+	SnapshotInterval           uint64 `json:",omitempty"`
+	KeepOldSnapshots           uint64 `json:",omitempty"`
+	LogEntriesForSlowFollowers uint64 `json:",omitempty"`
+	HeartbeatTick              uint32 `json:",omitempty"`
+	ElectionTick               uint32 `json:",omitempty"`
+}
+
+// DispatcherConfig represents dispatcher configuration.
+type DispatcherConfig struct {
+	HeartbeatPeriod uint64 `json:",omitempty"`
+}
+
+// CAConfig represents CA configuration.
+type CAConfig struct {
+	NodeCertExpiry time.Duration `json:",omitempty"`
+	ExternalCAs    []*ExternalCA `json:",omitempty"`
+}
+
+// ExternalCAProtocol represents type of external CA.
+type ExternalCAProtocol string
+
+// ExternalCAProtocolCFSSL CFSSL
+const ExternalCAProtocolCFSSL ExternalCAProtocol = "cfssl"
+
+// ExternalCA defines external CA to be used by the cluster.
+type ExternalCA struct {
+	Protocol ExternalCAProtocol
+	URL      string
+	Options  map[string]string `json:",omitempty"`
+}
+
+// InitRequest is the request used to init a swarm.
+type InitRequest struct {
+	ListenAddr      string
+	ForceNewCluster bool
+	Spec            Spec
+}
+
+// JoinRequest is the request used to join a swarm.
+type JoinRequest struct {
+	ListenAddr  string
+	RemoteAddrs []string
+	Secret      string // accept by secret
+	CACertHash  string
+	Manager     bool
+}
+
+// LocalNodeState represents the state of the local node.
+type LocalNodeState string
+
+const (
+	// LocalNodeStateInactive INACTIVE
+	LocalNodeStateInactive LocalNodeState = "inactive"
+	// LocalNodeStatePending PENDING
+	LocalNodeStatePending LocalNodeState = "pending"
+	// LocalNodeStateActive ACTIVE
+	LocalNodeStateActive LocalNodeState = "active"
+	// LocalNodeStateError ERROR
+	LocalNodeStateError LocalNodeState = "error"
+)
+
+// Info represents generic information about swarm.
+type Info struct {
+	NodeID string
+
+	LocalNodeState   LocalNodeState
+	ControlAvailable bool
+	Error            string
+
+	RemoteManagers []Peer
+	Nodes          int
+	Managers       int
+	CACertHash     string
+}
+
+// Peer represents a peer.
+type Peer struct {
+	NodeID string
+	Addr   string
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/task.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/task.go
@@ -1,0 +1,115 @@
+package swarm
+
+import "time"
+
+// TaskState represents the state of a task.
+type TaskState string
+
+const (
+	// TaskStateNew NEW
+	TaskStateNew TaskState = "new"
+	// TaskStateAllocated ALLOCATED
+	TaskStateAllocated TaskState = "allocated"
+	// TaskStatePending PENDING
+	TaskStatePending TaskState = "pending"
+	// TaskStateAssigned ASSIGNED
+	TaskStateAssigned TaskState = "assigned"
+	// TaskStateAccepted ACCEPTED
+	TaskStateAccepted TaskState = "accepted"
+	// TaskStatePreparing PREPARING
+	TaskStatePreparing TaskState = "preparing"
+	// TaskStateReady READY
+	TaskStateReady TaskState = "ready"
+	// TaskStateStarting STARTING
+	TaskStateStarting TaskState = "starting"
+	// TaskStateRunning RUNNING
+	TaskStateRunning TaskState = "running"
+	// TaskStateComplete COMPLETE
+	TaskStateComplete TaskState = "complete"
+	// TaskStateShutdown SHUTDOWN
+	TaskStateShutdown TaskState = "shutdown"
+	// TaskStateFailed FAILED
+	TaskStateFailed TaskState = "failed"
+	// TaskStateRejected REJECTED
+	TaskStateRejected TaskState = "rejected"
+)
+
+// Task represents a task.
+type Task struct {
+	ID string
+	Meta
+
+	Spec                TaskSpec            `json:",omitempty"`
+	ServiceID           string              `json:",omitempty"`
+	Slot                int                 `json:",omitempty"`
+	NodeID              string              `json:",omitempty"`
+	Status              TaskStatus          `json:",omitempty"`
+	DesiredState        TaskState           `json:",omitempty"`
+	NetworksAttachments []NetworkAttachment `json:",omitempty"`
+}
+
+// TaskSpec represents the spec of a task.
+type TaskSpec struct {
+	ContainerSpec ContainerSpec         `json:",omitempty"`
+	Resources     *ResourceRequirements `json:",omitempty"`
+	RestartPolicy *RestartPolicy        `json:",omitempty"`
+	Placement     *Placement            `json:",omitempty"`
+
+	// LogDriver specifies the LogDriver to use for tasks created from this
+	// spec. If not present, the one on cluster default on swarm.Spec will be
+	// used, finally falling back to the engine default if not specified.
+	LogDriver *Driver `json:",omitempty"`
+}
+
+// Resources represents resources (CPU/Memory).
+type Resources struct {
+	NanoCPUs    int64 `json:",omitempty"`
+	MemoryBytes int64 `json:",omitempty"`
+}
+
+// ResourceRequirements represents resources requirements.
+type ResourceRequirements struct {
+	Limits       *Resources `json:",omitempty"`
+	Reservations *Resources `json:",omitempty"`
+}
+
+// Placement represents orchestration parameters.
+type Placement struct {
+	Constraints []string `json:",omitempty"`
+}
+
+// RestartPolicy represents the restart policy.
+type RestartPolicy struct {
+	Condition   RestartPolicyCondition `json:",omitempty"`
+	Delay       *time.Duration         `json:",omitempty"`
+	MaxAttempts *uint64                `json:",omitempty"`
+	Window      *time.Duration         `json:",omitempty"`
+}
+
+// RestartPolicyCondition represents when to restart.
+type RestartPolicyCondition string
+
+const (
+	// RestartPolicyConditionNone NONE
+	RestartPolicyConditionNone RestartPolicyCondition = "none"
+	// RestartPolicyConditionOnFailure ON_FAILURE
+	RestartPolicyConditionOnFailure RestartPolicyCondition = "on-failure"
+	// RestartPolicyConditionAny ANY
+	RestartPolicyConditionAny RestartPolicyCondition = "any"
+)
+
+// TaskStatus represents the status of a task.
+type TaskStatus struct {
+	Timestamp       time.Time       `json:",omitempty"`
+	State           TaskState       `json:",omitempty"`
+	Message         string          `json:",omitempty"`
+	Err             string          `json:",omitempty"`
+	ContainerStatus ContainerStatus `json:",omitempty"`
+}
+
+// ContainerStatus represents the status of a container.
+type ContainerStatus struct {
+	ContainerID string `json:",omitempty"`
+	PID         int    `json:",omitempty"`
+	ExitCode    int    `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/time/duration_convert.go
+++ b/vendor/github.com/docker/engine-api/types/time/duration_convert.go
@@ -1,0 +1,12 @@
+package time
+
+import (
+	"strconv"
+	"time"
+)
+
+// DurationToSecondsString converts the specified duration to the number
+// seconds it represents, formatted as a string.
+func DurationToSecondsString(duration time.Duration) string {
+	return strconv.FormatFloat(duration.Seconds(), 'f', 0, 64)
+}

--- a/vendor/github.com/docker/engine-api/types/types.go
+++ b/vendor/github.com/docker/engine-api/types/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -252,6 +253,9 @@ type Info struct {
 	ClusterStore       string
 	ClusterAdvertise   string
 	SecurityOptions    []string
+	Runtimes           map[string]Runtime
+	DefaultRuntime     string
+	Swarm              swarm.Info
 }
 
 // PluginsInfo is a temp struct holding Plugins name
@@ -274,6 +278,28 @@ type ExecStartCheck struct {
 	Tty bool
 }
 
+// HealthcheckResult stores information about a single run of a healthcheck probe
+type HealthcheckResult struct {
+	Start    time.Time // Start is the time this check started
+	End      time.Time // End is the time this check ended
+	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=starting, else=error running probe
+	Output   string    // Output from last check
+}
+
+// Health states
+const (
+	Starting  = "starting"  // Starting indicates that the container is not yet ready
+	Healthy   = "healthy"   // Healthy indicates that the container is running correctly
+	Unhealthy = "unhealthy" // Unhealthy indicates that the container has a problem
+)
+
+// Health stores information about the container's healthcheck results
+type Health struct {
+	Status        string               // Status is one of Starting, Healthy or Unhealthy
+	FailingStreak int                  // FailingStreak is the number of consecutive failures
+	Log           []*HealthcheckResult // Log contains the last few results (oldest first)
+}
+
 // ContainerState stores container's running state
 // it's part of ContainerJSONBase and will return by "inspect" command
 type ContainerState struct {
@@ -288,6 +314,7 @@ type ContainerState struct {
 	Error      string
 	StartedAt  string
 	FinishedAt string
+	Health     *Health `json:",omitempty"`
 }
 
 // ContainerNode stores information about the node that a container
@@ -298,7 +325,7 @@ type ContainerNode struct {
 	Addr      string
 	Name      string
 	Cpus      int
-	Memory    int
+	Memory    int64
 	Labels    map[string]string
 }
 
@@ -416,13 +443,13 @@ type VolumeCreateRequest struct {
 
 // NetworkResource is the body of the "get network" http response message
 type NetworkResource struct {
-	Name       string                      // Name is the requested name of the volume
-	ID         string                      `json:"Id"` // ID uniquely indentifies a network on a single machine
+	Name       string                      // Name is the requested name of the network
+	ID         string                      `json:"Id"` // ID uniquely identifies a network on a single machine
 	Scope      string                      // Scope describes the level at which the network exists (e.g. `global` for cluster-wide or `local` for machine level)
-	Driver     string                      // Driver is the Driver name used to create the volume (e.g. `bridge`, `overlay`)
+	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
 	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
 	IPAM       network.IPAM                // IPAM is the network's IP Address Management
-	Internal   bool                        // Internal respresents if the network is used internal only
+	Internal   bool                        // Internal represents if the network is used internal only
 	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
 	Options    map[string]string           // Options holds the network specific options to use for when creating the network
 	Labels     map[string]string           // Labels holds metadata specific to the network being created
@@ -475,4 +502,10 @@ type NetworkDisconnect struct {
 // Checkpoint represents the details of a checkpoint
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint
+}
+
+// Runtime describes an OCI runtime
+type Runtime struct {
+	Path string   `json:"path"`
+	Args []string `json:"runtimeArgs,omitempty"`
 }

--- a/vendor/github.com/docker/engine-api/types/versions/README.md
+++ b/vendor/github.com/docker/engine-api/types/versions/README.md
@@ -9,6 +9,6 @@ Consider moving a type here when you need to keep backwards compatibility in the
 The package name convention is to use `v` as a prefix for the version number and `p`(patch) as a separator. We use this nomenclature due to a few restrictions in the Go package name convention:
 
 1. We cannot use `.` because it's interpreted by the language, think of `v1.20.CallFunction`.
-2. We cannot use `_` because golint complains abount it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
+2. We cannot use `_` because golint complains about it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
 
 For instance, if you want to modify a type that was available in the version `1.21` of the API but it will have different fields in the version `1.22`, you want to create a new package under `api/types/versions/v1p21`.


### PR DESCRIPTION
Fix #2404 

This is an alternative to #2422, and adds a new interface called `swarmclient.SwarmAPIClient` that only contains a subset of the methods in the `engine-api` interface. This skips all the ones that are relevant to swarm mode, and not to Docker Swarm.