### PR TITLE
Fix rescheduling test

### DIFF
--- a/test/integration/rescheduling.bats
+++ b/test/integration/rescheduling.bats
@@ -169,7 +169,7 @@ function containerRunning() {
 	docker_host start ${DOCKER_CONTAINERS[0]}
 	# Wait for node-0 to be healthy
 	# Failing node refresh interval increases over time. Provide enough retry here.
-	retry 30 1 eval "test \"$(docker_swarm info | grep \"Status: Unhealthy\" | wc -l)\" = '0'"
+	retry 30 1 eval "docker_swarm info | grep node-0 -A 5 | grep -q \"Status: Healthy\""
 
 	# c1 should still be on node-1
 	containerRunning "c3" "node-1"


### PR DESCRIPTION
The following line to wait for node-0 recovery doesn't work. Fix it with direct node-0 status validation.

```
retry 30 1 eval "test \"$(docker_swarm info | grep \"Status: Unhealthy\" | wc -l)\" = '0'"
```

This problem surfaces only in Docker-1.12, where `docker start` may be taking longer than before. 

cc @nishanttotla @abronan @allencloud. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>