### PR TITLE
consider all nodes returning from the scheduler

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -205,8 +205,17 @@ func (c *Cluster) createContainer(config *cluster.ContainerConfig, name string, 
 		c.scheduler.Unlock()
 		return nil, err
 	}
-	n := nodes[0]
-	engine, ok := c.engines[n.ID]
+
+	var engine *cluster.Engine
+	var ok bool
+	var n *node.Node
+	for _, n = range nodes {
+		engine, ok = c.engines[n.ID]
+		if ok {
+			break
+		}
+	}
+
 	if !ok {
 		c.scheduler.Unlock()
 		return nil, fmt.Errorf("error creating container")


### PR DESCRIPTION
SelectNodesForContainer returns a list of node candidates (priority sorted) , but only the first one is used. In case that engine is faulty we can try the other nodes.
