### PR TITLE
Dokku does not have swarm support

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,6 @@ Docker API, any tool that already communicates with a Docker daemon can use
 Swarm to transparently scale to multiple hosts. Supported tools include, but
 are not limited to, the following:
 
-- Dokku
 - Docker Compose
 - Docker Machine
 - Jenkins


### PR DESCRIPTION
Fix the docker swarm documentation, which is better than misleading users while we investigate support.

Refs https://github.com/dokku/dokku/issues/1795