### PR TITLE
Listen to health_status events

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -714,9 +714,8 @@ func (e *Engine) refreshVolume(IDOrName string) error {
 			delete(e.volumes, IDOrName)
 			e.Unlock()
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 
 	e.Lock()
@@ -1254,8 +1253,13 @@ func (e *Engine) handler(msg events.Message) error {
 	case "image":
 		e.RefreshImages()
 	case "container":
-		switch msg.Action {
-		case "die", "kill", "oom", "pause", "start", "restart", "stop", "unpause", "rename", "update":
+		action := msg.Action
+		// healthcheck events are like 'health_status: unhealthy'
+		if strings.HasPrefix(action, "health_status") {
+			action = "health_status"
+		}
+		switch action {
+		case "die", "kill", "oom", "pause", "start", "restart", "stop", "unpause", "rename", "update", "health_status":
 			e.refreshContainer(msg.ID, true)
 		default:
 			e.refreshContainer(msg.ID, false)

--- a/test/integration/replication.bats
+++ b/test/integration/replication.bats
@@ -185,6 +185,7 @@ function containerRunning() {
 	# Bring up one manager, make sure it becomes primary.
 	swarm_manage --replication --replication-ttl "4s" --advertise 127.0.0.1:$SWARM_BASE_PORT "$NODE_1_URL"
 	run docker -H ${SWARM_HOSTS[0]} info
+	echo "$output"
 	[[ "${output}" == *"Role: primary"* ]]
 
 	# Fire up a second manager. Ensure it's a replica forwarding to the right primary.


### PR DESCRIPTION
Docker engine emits health_status events when health state changes. Swarm should refresh corresponding containers to catch up. 

```
2016-08-05T18:25:02.562998136Z container health_status: unhealthy ae0f727e2e0bdd12e8788d69c7375f316ed0aeb3be39237cae46f004b3cb703a (image=redis, name=healthtest)
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>