### PR TITLE
add build-arg for architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.7.1-alpine
 
 ARG GOOS
+ARG GOARCH
 
 COPY . /go/src/github.com/docker/swarm
 WORKDIR /go/src/github.com/docker/swarm
@@ -8,7 +9,7 @@ WORKDIR /go/src/github.com/docker/swarm
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
 	git \
-	&& GOOS=$GOOS CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags '-w -X "github.com/docker/swarm/version.GITCOMMIT=`git rev-parse --short HEAD`" -X "github.com/docker/swarm/version.BUILDTIME=`date -u`"'  \
+	&& GOARCH=$GOARCH GOOS=$GOOS CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags '-w -X "github.com/docker/swarm/version.GITCOMMIT=`git rev-parse --short HEAD`" -X "github.com/docker/swarm/version.BUILDTIME=`date -u`"'  \
 	&& apk del .build-deps
 
 ENV SWARM_HOST :2375


### PR DESCRIPTION
Add GOARCH as build-arg so we can build for arm too.

Signed-off-by: Andreas Eiermann andreas@hypriot.com
