### PR TITLE
Fixed #2460, go vetting warning unkeyed fields

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -187,7 +187,7 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	// but still keeps their Engine infos as an array.
 	groupImages := make(map[string]apitypes.Image)
 	opts := cluster.ImageFilterOptions{
-		apitypes.ImageListOptions{
+		ImageListOptions: apitypes.ImageListOptions{
 			All:       boolValue(r, "all"),
 			MatchName: r.FormValue("filter"),
 			Filters:   filters,

--- a/scheduler/filter/dependency_test.go
+++ b/scheduler/filter/dependency_test.go
@@ -57,54 +57,72 @@ func TestDependencyFilterSimple(t *testing.T) {
 	assert.Equal(t, result, nodes)
 
 	// volumes-from.
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// volumes-from:rw
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0:rw"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0:rw"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// volumes-from:ro
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0:ro"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0:ro"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// link.
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		Links: []string{"c1:foobar"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			Links: []string{"c1:foobar"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[1])
 
 	// net.
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		NetworkMode: containertypes.NetworkMode("container:c2"),
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			NetworkMode: containertypes.NetworkMode("container:c2"),
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[2])
 
 	// net not prefixed by "container:" should be ignored.
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		NetworkMode: containertypes.NetworkMode("bridge"),
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			NetworkMode: containertypes.NetworkMode("bridge"),
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Equal(t, result, nodes)
@@ -157,36 +175,48 @@ func TestDependencyFilterMulti(t *testing.T) {
 	)
 
 	// Depend on c0 which is on nodes[0]
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Depend on c1 which is on nodes[0]
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c1"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c1"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Depend on c0 AND c1 which are both on nodes[0]
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0", "c1"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0", "c1"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Depend on c0 AND c2 which are on different nodes.
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0", "c2"},
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0", "c2"},
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.Error(t, err)
 }
@@ -238,22 +268,28 @@ func TestDependencyFilterChaining(t *testing.T) {
 	)
 
 	// Different dependencies on c0 and c1
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0"},
-		Links:       []string{"c1"},
-		NetworkMode: containertypes.NetworkMode("container:c1"),
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0"},
+			Links:       []string{"c1"},
+			NetworkMode: containertypes.NetworkMode("container:c1"),
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, result[0], nodes[0])
 
 	// Different dependencies on c0 and c2
-	config = &cluster.ContainerConfig{containertypes.Config{}, containertypes.HostConfig{
-		VolumesFrom: []string{"c0"},
-		Links:       []string{"c2"},
-		NetworkMode: containertypes.NetworkMode("container:c1"),
-	}, networktypes.NetworkingConfig{}}
+	config = &cluster.ContainerConfig{
+		Config: containertypes.Config{},
+		HostConfig: containertypes.HostConfig{
+			VolumesFrom: []string{"c0"},
+			Links:       []string{"c2"},
+			NetworkMode: containertypes.NetworkMode("container:c1"),
+		},
+		NetworkingConfig: networktypes.NetworkingConfig{}}
 	result, err = f.Filter(config, nodes, true)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
Came across golang composite literal uses unkeyed fields warning. want to
report it.

Signed-off-by: Deshi Xiao <xiaods@gmail.com>