### PR TITLE
Remove abronan as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,7 +11,6 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
-			"abronan",
 			"allencloud",
 			"aluzzardi",
 			"chanwit",
@@ -53,11 +52,6 @@
 # in the people section.
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
-
-	[people.abronan]
-	Name = "Alexandre Beslic"
-	Email = "abronan@docker.com"
-	GitHub = "abronan"
 
 	[people.aluzzardi]
 	Name = "Andrea Luzzardi"


### PR DESCRIPTION
Farewell 👋 

And thanks to all the contributors and maintainers for all the effort put into this repository and the past year and a half spent working together on this.

ping @docker/core-swarm-maintainers 

Signed-off-by: Alexandre Beslic <alexandre.beslic@gmail.com>