### PR TITLE
add event top, resize, commit and so on support in swarm

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1259,8 +1259,13 @@ func (e *Engine) handler(msg events.Message) error {
 			action = "health_status"
 		}
 		switch action {
+		case "commit":
+			// commit a container will generate a new image
+			e.RefreshImages()
 		case "die", "kill", "oom", "pause", "start", "restart", "stop", "unpause", "rename", "update", "health_status":
 			e.refreshContainer(msg.ID, true)
+		case "top", "resize", "export", "exec_create", "exec_start", "exec_detach", "attach", "detach", "extract-to-dir", "copy", "archive-path":
+			// no action needed
 		default:
 			e.refreshContainer(msg.ID, false)
 		}
@@ -1284,6 +1289,8 @@ func (e *Engine) handler(msg events.Message) error {
 			e.refreshContainer(msg.ID, true)
 			e.RefreshVolumes()
 			e.RefreshNetworks()
+		case "top", "resize", "export", "exec_create", "exec_start", "attach", "extract-to-dir", "copy", "archive-path":
+			// no action needed
 		default:
 			// Otherwise, do a "soft" refresh of the container.
 			e.refreshContainer(msg.ID, false)


### PR DESCRIPTION
I found in docker version 1.10- and 1.10+, docker daemon supports event `top` which is missing in Swarm.
In docker 1.9.1: https://github.com/docker/docker/blob/v1.9.1/daemon/top_unix.go#L79
In docker 1.12.1: https://github.com/docker/docker/blob/v1.12.1/daemon/top_unix.go#L124

This PR adds `top` event in Swarm, and when getting an `top` event, I think nothing should be refreshed in containers, so just break for convenience.

In addition, I added some other events here to make swarm manager not to call engine node.

@dongluochen @nishanttotla 

Signed-off-by: allencloud allen.sun@daocloud.io
