### PR TITLE
Update engine API version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -101,63 +101,63 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport/cancellable",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/blkiodev",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/container",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/events",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/filters",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/network",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/registry",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/strslice",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/time",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",
@@ -369,18 +369,23 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/reference",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/versions",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/swarm",
-			"Comment": "v0.3.1-236-gd505506",
-			"Rev": "d505506c67611e8364526339452c20d6d0babcf6"
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
+		},
+		{
+			"ImportPath": "github.com/docker/engine-api/types/mount",
+			"Comment": "v0.4.0-62-gf9cef59",
+			"Rev": "f9cef590446e4e6073b49b652f47a337b897c1a3"
 		}
 	]
 }

--- a/api/mockclient/mock.go
+++ b/api/mockclient/mock.go
@@ -204,9 +204,9 @@ func (client *MockClient) ContainerUnpause(ctx context.Context, container string
 }
 
 // ContainerUpdate updates resources of a container
-func (client *MockClient) ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error {
+func (client *MockClient) ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error) {
 	args := client.Mock.Called(ctx, container, updateConfig)
-	return args.Error(0)
+	return args.Get(0).(types.ContainerUpdateResponse), args.Error(1)
 }
 
 // ContainerWait pauses execution until a container exits
@@ -258,8 +258,8 @@ func (client *MockClient) ImageImport(ctx context.Context, source types.ImageImp
 }
 
 // ImageInspectWithRaw returns the image information and it's raw representation
-func (client *MockClient) ImageInspectWithRaw(ctx context.Context, image string, getSize bool) (types.ImageInspect, []byte, error) {
-	args := client.Mock.Called(ctx, image, getSize)
+func (client *MockClient) ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error) {
+	args := client.Mock.Called(ctx, image)
 	return args.Get(0).(types.ImageInspect), args.Get(1).([]byte), args.Error(2)
 }
 
@@ -400,7 +400,7 @@ func (client *MockClient) VolumeList(ctx context.Context, filter filters.Args) (
 }
 
 // VolumeRemove removes a volume from the docker host
-func (client *MockClient) VolumeRemove(ctx context.Context, volumeID string) error {
+func (client *MockClient) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
 	args := client.Mock.Called(ctx, volumeID)
 	return args.Error(0)
 }

--- a/api/nopclient/nop.go
+++ b/api/nopclient/nop.go
@@ -178,8 +178,8 @@ func (client *NopClient) ContainerUnpause(ctx context.Context, container string)
 }
 
 // ContainerUpdate updates resources of a container
-func (client *NopClient) ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error {
-	return errNoEngine
+func (client *NopClient) ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error) {
+	return types.ContainerUpdateResponse{}, errNoEngine
 }
 
 // ContainerWait pauses execution until a container exits
@@ -223,7 +223,7 @@ func (client *NopClient) ImageImport(ctx context.Context, source types.ImageImpo
 }
 
 // ImageInspectWithRaw returns the image information and it's raw representation
-func (client *NopClient) ImageInspectWithRaw(ctx context.Context, image string, getSize bool) (types.ImageInspect, []byte, error) {
+func (client *NopClient) ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error) {
 	return types.ImageInspect{}, nil, errNoEngine
 }
 
@@ -342,6 +342,6 @@ func (client *NopClient) VolumeList(ctx context.Context, filter filters.Args) (t
 }
 
 // VolumeRemove removes a volume from the docker host
-func (client *NopClient) VolumeRemove(ctx context.Context, volumeID string) error {
+func (client *NopClient) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
 	return errNoEngine
 }

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -538,9 +538,6 @@ func (e *Engine) updateSpecs() error {
 	if info.Driver != "" {
 		e.Labels["storagedriver"] = info.Driver
 	}
-	if info.ExecutionDriver != "" {
-		e.Labels["executiondriver"] = info.ExecutionDriver
-	}
 	if info.KernelVersion != "" {
 		e.Labels["kernelversion"] = info.KernelVersion
 	}
@@ -618,7 +615,7 @@ func (e *Engine) AddNetwork(network *Network) {
 
 // RemoveVolume deletes a volume from the engine.
 func (e *Engine) RemoveVolume(name string) error {
-	err := e.apiClient.VolumeRemove(context.Background(), name)
+	err := e.apiClient.VolumeRemove(context.Background(), name, false)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -38,7 +38,6 @@ var (
 		NCPU:            10,
 		MemTotal:        20,
 		Driver:          "driver-test",
-		ExecutionDriver: "execution-driver-test",
 		KernelVersion:   "1.2.3",
 		OperatingSystem: "golang",
 		Labels:          []string{"foo=bar"},
@@ -228,8 +227,6 @@ func TestEngineSpecs(t *testing.T) {
 	assert.Equal(t, engine.Cpus, int64(mockInfo2.NCPU))
 	assert.Equal(t, engine.Memory, mockInfo2.MemTotal)
 	assert.Equal(t, engine.Labels["storagedriver"], mockInfo2.Driver)
-
-	assert.Equal(t, engine.Labels["executiondriver"], mockInfo2.ExecutionDriver)
 
 	assert.Equal(t, engine.Labels["kernelversion"], mockInfo2.KernelVersion)
 	assert.Equal(t, engine.Labels["operatingsystem"], mockInfo2.OperatingSystem)

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -33,7 +33,6 @@ var (
 		NCPU:            10,
 		MemTotal:        20,
 		Driver:          "driver-test",
-		ExecutionDriver: "execution-driver-test",
 		KernelVersion:   "1.2.3",
 		OperatingSystem: "golang",
 		Labels:          []string{"foo=bar"},

--- a/test/integration/api/update.bats
+++ b/test/integration/api/update.bats
@@ -37,6 +37,7 @@ function teardown() {
 
 	run docker_swarm update \
 				-m=100M \
+				--memory-swap=200M \
 				--cpu-period=50000 \
 				--cpu-quota=5000 \
 				--blkio-weight=600 \

--- a/test/integration/nodemanagement/nodehealth.bats
+++ b/test/integration/nodemanagement/nodehealth.bats
@@ -32,7 +32,7 @@ function teardown() {
 	# Try to schedule a container. It'd first select node-1 and fail
 	run docker_swarm run -m 10m busybox sh
 	[ "$status" -ne 0 ]
-	[[ "${lines[0]}" == *"Cannot connect to the docker engine endpoint"* || "${lines[0]}" == *"Cannot connect to the Docker daemon"* ]]
+	[[ "${lines[0]}" == *"Cannot connect to the docker engine endpoint"* || "${lines[0]}" == *"Cannot connect to the Docker daemon"* || "${lines[0]}" == *"An error occurred trying to connect"* ]]
 
 	# Try to run it again. It'd select node-0 and succeed
 	run docker_swarm run -m 10m busybox sh

--- a/vendor/github.com/docker/engine-api/client/client.go
+++ b/vendor/github.com/docker/engine-api/client/client.go
@@ -18,6 +18,8 @@ const DefaultVersion string = "1.23"
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
+	// host holds the server address to connect to
+	host string
 	// proto holds the client protocol i.e. unix.
 	proto string
 	// addr holds the client address.
@@ -90,6 +92,7 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 	}
 
 	return &Client{
+		host:              host,
 		proto:             proto,
 		addr:              addr,
 		basePath:          basePath,

--- a/vendor/github.com/docker/engine-api/client/client_darwin.go
+++ b/vendor/github.com/docker/engine-api/client/client_darwin.go
@@ -1,4 +1,0 @@
-package client
-
-// DefaultDockerHost defines os specific default if DOCKER_HOST is unset
-const DefaultDockerHost = "tcp://127.0.0.1:2375"

--- a/vendor/github.com/docker/engine-api/client/client_unix.go
+++ b/vendor/github.com/docker/engine-api/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd solaris openbsd
+// +build linux freebsd solaris openbsd darwin
 
 package client
 

--- a/vendor/github.com/docker/engine-api/client/container_create.go
+++ b/vendor/github.com/docker/engine-api/client/container_create.go
@@ -34,7 +34,7 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 
 	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
 	if err != nil {
-		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
+		if serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 			return response, imageNotFoundError{config.Image}
 		}
 		return response, err

--- a/vendor/github.com/docker/engine-api/client/container_update.go
+++ b/vendor/github.com/docker/engine-api/client/container_update.go
@@ -1,13 +1,23 @@
 package client
 
 import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"golang.org/x/net/context"
 )
 
 // ContainerUpdate updates resources of a container
-func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
-	ensureReaderClosed(resp)
-	return err
+func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error) {
+	var response types.ContainerUpdateResponse
+	serverResp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+
+	ensureReaderClosed(serverResp)
+	return response, err
 }

--- a/vendor/github.com/docker/engine-api/client/errors.go
+++ b/vendor/github.com/docker/engine-api/client/errors.go
@@ -8,6 +8,11 @@ import (
 // ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
+// ErrorConnectionFailed returns an error with host in the error message when connection to docker daemon failed.
+func ErrorConnectionFailed(host string) error {
+	return fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", host)
+}
+
 type notFound interface {
 	error
 	NotFound() bool // Is the error a NotFound error

--- a/vendor/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/github.com/docker/engine-api/client/image_build.go
@@ -74,6 +74,10 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 		query.Set("pull", "1")
 	}
 
+	if options.Squash {
+		query.Set("squash", "1")
+	}
+
 	if !container.Isolation.IsDefault(options.Isolation) {
 		query.Set("isolation", string(options.Isolation))
 	}

--- a/vendor/github.com/docker/engine-api/client/image_create.go
+++ b/vendor/github.com/docker/engine-api/client/image_create.go
@@ -28,7 +28,7 @@ func (cli *Client) ImageCreate(ctx context.Context, parentReference string, opti
 	return resp.body, nil
 }
 
-func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (*serverResponse, error) {
+func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
 	return cli.post(ctx, "/images/create", query, nil, headers)
 }

--- a/vendor/github.com/docker/engine-api/client/image_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/image_inspect.go
@@ -5,19 +5,14 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
 // ImageInspectWithRaw returns the image information and its raw representation.
-func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (types.ImageInspect, []byte, error) {
-	query := url.Values{}
-	if getSize {
-		query.Set("size", "1")
-	}
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
+func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ImageInspect{}, nil, imageNotFoundError{imageID}

--- a/vendor/github.com/docker/engine-api/client/image_push.go
+++ b/vendor/github.com/docker/engine-api/client/image_push.go
@@ -48,7 +48,7 @@ func (cli *Client) ImagePush(ctx context.Context, ref string, options types.Imag
 	return resp.body, nil
 }
 
-func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (*serverResponse, error) {
+func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
 	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, headers)
 }

--- a/vendor/github.com/docker/engine-api/client/image_search.go
+++ b/vendor/github.com/docker/engine-api/client/image_search.go
@@ -45,7 +45,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	return results, err
 }
 
-func (cli *Client) tryImageSearch(ctx context.Context, query url.Values, registryAuth string) (*serverResponse, error) {
+func (cli *Client) tryImageSearch(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
 	return cli.get(ctx, "/images/search", query, headers)
 }

--- a/vendor/github.com/docker/engine-api/client/interface.go
+++ b/vendor/github.com/docker/engine-api/client/interface.go
@@ -56,7 +56,7 @@ type ContainerAPIClient interface {
 	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
-	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error
+	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error)
 	ContainerWait(ctx context.Context, container string) (int, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
@@ -68,7 +68,7 @@ type ImageAPIClient interface {
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]types.ImageHistory, error)
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error)
-	ImageInspectWithRaw(ctx context.Context, image string, getSize bool) (types.ImageInspect, []byte, error)
+	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
 	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error)
 	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
 	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
@@ -94,7 +94,7 @@ type NetworkAPIClient interface {
 type NodeAPIClient interface {
 	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
 	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
-	NodeRemove(ctx context.Context, nodeID string) error
+	NodeRemove(ctx context.Context, nodeID string, options types.NodeRemoveOptions) error
 	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
 }
 
@@ -115,7 +115,7 @@ type SwarmAPIClient interface {
 	SwarmJoin(ctx context.Context, req swarm.JoinRequest) error
 	SwarmLeave(ctx context.Context, force bool) error
 	SwarmInspect(ctx context.Context) (swarm.Swarm, error)
-	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error
+	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error
 }
 
 // SystemAPIClient defines API client methods for the system
@@ -131,5 +131,5 @@ type VolumeAPIClient interface {
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
-	VolumeRemove(ctx context.Context, volumeID string) error
+	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 }

--- a/vendor/github.com/docker/engine-api/client/interface_experimental.go
+++ b/vendor/github.com/docker/engine-api/client/interface_experimental.go
@@ -24,13 +24,13 @@ type CheckpointAPIClient interface {
 // PluginAPIClient defines API client methods for the plugins
 type PluginAPIClient interface {
 	PluginList(ctx context.Context) (types.PluginsListResponse, error)
-	PluginRemove(ctx context.Context, name string) error
+	PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error
 	PluginEnable(ctx context.Context, name string) error
 	PluginDisable(ctx context.Context, name string) error
 	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) error
 	PluginPush(ctx context.Context, name string, registryAuth string) error
 	PluginSet(ctx context.Context, name string, args []string) error
-	PluginInspect(ctx context.Context, name string) (*types.Plugin, error)
+	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)
 }
 
 // Ensure that Client always implements APIClient.

--- a/vendor/github.com/docker/engine-api/client/login.go
+++ b/vendor/github.com/docker/engine-api/client/login.go
@@ -14,7 +14,7 @@ import (
 func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error) {
 	resp, err := cli.post(ctx, "/auth", url.Values{}, auth, nil)
 
-	if resp != nil && resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized {
 		return types.AuthResponse{}, unauthorizedError{err}
 	}
 	if err != nil {

--- a/vendor/github.com/docker/engine-api/client/node_remove.go
+++ b/vendor/github.com/docker/engine-api/client/node_remove.go
@@ -1,10 +1,21 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+
+	"golang.org/x/net/context"
+)
 
 // NodeRemove removes a Node.
-func (cli *Client) NodeRemove(ctx context.Context, nodeID string) error {
-	resp, err := cli.delete(ctx, "/nodes/"+nodeID, nil, nil)
+func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options types.NodeRemoveOptions) error {
+	query := url.Values{}
+	if options.Force {
+		query.Set("force", "1")
+	}
+
+	resp, err := cli.delete(ctx, "/nodes/"+nodeID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/docker/engine-api/client/plugin_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_inspect.go
@@ -3,20 +3,28 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 
 	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
-// PluginInspect inspects an existing plugin
-func (cli *Client) PluginInspect(ctx context.Context, name string) (*types.Plugin, error) {
-	var p types.Plugin
+// PluginInspectWithRaw inspects an existing plugin
+func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error) {
 	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&p)
-	ensureReaderClosed(resp)
-	return &p, err
+
+	defer ensureReaderClosed(resp)
+	body, err := ioutil.ReadAll(resp.body)
+	if err != nil {
+		return nil, nil, err
+	}
+	var p types.Plugin
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&p)
+	return &p, body, err
 }

--- a/vendor/github.com/docker/engine-api/client/plugin_install.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_install.go
@@ -53,7 +53,7 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 	return cli.PluginEnable(ctx, name)
 }
 
-func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, registryAuth string) (*serverResponse, error) {
+func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
 	return cli.post(ctx, "/plugins/pull", query, nil, headers)
 }

--- a/vendor/github.com/docker/engine-api/client/plugin_remove.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_remove.go
@@ -3,12 +3,20 @@
 package client
 
 import (
+	"net/url"
+
+	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
 // PluginRemove removes a plugin
-func (cli *Client) PluginRemove(ctx context.Context, name string) error {
-	resp, err := cli.delete(ctx, "/plugins/"+name, nil, nil)
+func (cli *Client) PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error {
+	query := url.Values{}
+	if options.Force {
+		query.Set("force", "1")
+	}
+
+	resp, err := cli.delete(ctx, "/plugins/"+name, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/docker/engine-api/client/request.go
+++ b/vendor/github.com/docker/engine-api/client/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,47 +25,47 @@ type serverResponse struct {
 }
 
 // head sends an http request to the docker API using the method HEAD.
-func (cli *Client) head(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) head(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
 	return cli.sendRequest(ctx, "HEAD", path, query, nil, headers)
 }
 
 // getWithContext sends an http request to the docker API using the method GET with a specific go context.
-func (cli *Client) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
 	return cli.sendRequest(ctx, "GET", path, query, nil, headers)
 }
 
 // postWithContext sends an http request to the docker API using the method POST with a specific go context.
-func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (serverResponse, error) {
 	return cli.sendRequest(ctx, "POST", path, query, obj, headers)
 }
 
-func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
 	return cli.sendClientRequest(ctx, "POST", path, query, body, headers)
 }
 
 // put sends an http request to the docker API using the method PUT.
-func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (serverResponse, error) {
 	return cli.sendRequest(ctx, "PUT", path, query, obj, headers)
 }
 
 // put sends an http request to the docker API using the method PUT.
-func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
 	return cli.sendClientRequest(ctx, "PUT", path, query, body, headers)
 }
 
 // delete sends an http request to the docker API using the method DELETE.
-func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
 	return cli.sendRequest(ctx, "DELETE", path, query, nil, headers)
 }
 
-func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (serverResponse, error) {
 	var body io.Reader
 
 	if obj != nil {
 		var err error
 		body, err = encodeData(obj)
 		if err != nil {
-			return nil, err
+			return serverResponse{}, err
 		}
 		if headers == nil {
 			headers = make(map[string][]string)
@@ -75,8 +76,8 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	return cli.sendClientRequest(ctx, method, path, query, body, headers)
 }
 
-func (cli *Client) sendClientRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
-	serverResp := &serverResponse{
+func (cli *Client) sendClientRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
+	serverResp := serverResponse{
 		body:       nil,
 		statusCode: -1,
 	}
@@ -105,10 +106,6 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 
 	resp, err := cancellable.Do(ctx, cli.transport, req)
 	if err != nil {
-		if isTimeout(err) || strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
-			return serverResp, ErrConnectionFailed
-		}
-
 		if !cli.transport.Secure() && strings.Contains(err.Error(), "malformed HTTP response") {
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)
 		}
@@ -117,6 +114,23 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 			return serverResp, fmt.Errorf("The server probably has client authentication (--tlsverify) enabled. Please check your TLS client certification settings: %v", err)
 		}
 
+		// Don't decorate context sentinel errors; users may be comparing to
+		// them directly.
+		switch err {
+		case context.Canceled, context.DeadlineExceeded:
+			return serverResp, err
+		}
+
+		if err, ok := err.(net.Error); ok {
+			if err.Timeout() {
+				return serverResp, ErrorConnectionFailed(cli.host)
+			}
+			if !err.Temporary() {
+				if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
+					return serverResp, ErrorConnectionFailed(cli.host)
+				}
+			}
+		}
 		return serverResp, fmt.Errorf("An error occurred trying to connect: %v", err)
 	}
 
@@ -185,23 +199,10 @@ func encodeData(data interface{}) (*bytes.Buffer, error) {
 	return params, nil
 }
 
-func ensureReaderClosed(response *serverResponse) {
-	if response != nil && response.body != nil {
+func ensureReaderClosed(response serverResponse) {
+	if body := response.body; body != nil {
 		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
-		io.CopyN(ioutil.Discard, response.body, 512)
+		io.CopyN(ioutil.Discard, body, 512)
 		response.body.Close()
 	}
-}
-
-func isTimeout(err error) bool {
-	type timeout interface {
-		Timeout() bool
-	}
-	e := err
-	switch urlErr := err.(type) {
-	case *url.Error:
-		e = urlErr.Err
-	}
-	t, ok := e.(timeout)
-	return ok && t.Timeout()
 }

--- a/vendor/github.com/docker/engine-api/client/swarm_update.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_update.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -9,9 +10,11 @@ import (
 )
 
 // SwarmUpdate updates the Swarm.
-func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error {
+func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("rotateWorkerToken", fmt.Sprintf("%v", flags.RotateWorkerToken))
+	query.Set("rotateManagerToken", fmt.Sprintf("%v", flags.RotateManagerToken))
 	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/github.com/docker/engine-api/client/transport/cancellable/cancellable.go
+++ b/vendor/github.com/docker/engine-api/client/transport/cancellable/cancellable.go
@@ -8,6 +8,7 @@ package cancellable
 import (
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/docker/engine-api/client/transport"
 
@@ -82,7 +83,7 @@ func Do(ctx context.Context, client transport.Sender, req *http.Request) (*http.
 			// The response's Body is closed.
 		}
 	}()
-	resp.Body = &notifyingReader{resp.Body, c}
+	resp.Body = &notifyingReader{ReadCloser: resp.Body, notify: c}
 
 	return resp, nil
 }
@@ -91,23 +92,24 @@ func Do(ctx context.Context, client transport.Sender, req *http.Request) (*http.
 // Close is called or a Read fails on the underlying ReadCloser.
 type notifyingReader struct {
 	io.ReadCloser
-	notify chan<- struct{}
+	notify     chan<- struct{}
+	notifyOnce sync.Once
 }
 
 func (r *notifyingReader) Read(p []byte) (int, error) {
 	n, err := r.ReadCloser.Read(p)
-	if err != nil && r.notify != nil {
-		close(r.notify)
-		r.notify = nil
+	if err != nil {
+		r.notifyOnce.Do(func() {
+			close(r.notify)
+		})
 	}
 	return n, err
 }
 
 func (r *notifyingReader) Close() error {
 	err := r.ReadCloser.Close()
-	if r.notify != nil {
+	r.notifyOnce.Do(func() {
 		close(r.notify)
-		r.notify = nil
-	}
+	})
 	return err
 }

--- a/vendor/github.com/docker/engine-api/client/volume_remove.go
+++ b/vendor/github.com/docker/engine-api/client/volume_remove.go
@@ -1,10 +1,18 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // VolumeRemove removes a volume from the docker host.
-func (cli *Client) VolumeRemove(ctx context.Context, volumeID string) error {
-	resp, err := cli.delete(ctx, "/volumes/"+volumeID, nil, nil)
+func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
+	query := url.Values{}
+	if force {
+		query.Set("force", "1")
+	}
+	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/docker/engine-api/types/client.go
+++ b/vendor/github.com/docker/engine-api/types/client.go
@@ -147,6 +147,10 @@ type ImageBuildOptions struct {
 	AuthConfigs    map[string]AuthConfig
 	Context        io.Reader
 	Labels         map[string]string
+	// squash the resulting image's layers to the parent
+	// preserves the original image and creates a new one from the parent with all
+	// the changes applied to a single layer
+	Squash bool
 }
 
 // ImageBuildResponse holds information
@@ -241,9 +245,14 @@ func (v VersionResponse) ServerOK() bool {
 	return v.Server != nil
 }
 
-// NodeListOptions holds parameters to list  nodes with.
+// NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
 	Filter filters.Args
+}
+
+// NodeRemoveOptions holds parameters to remove nodes with.
+type NodeRemoveOptions struct {
+	Force bool
 }
 
 // ServiceCreateOptions contains the options to use when creating a service.
@@ -283,4 +292,9 @@ type ServiceListOptions struct {
 // TaskListOptions holds parameters to list  tasks with.
 type TaskListOptions struct {
 	Filter filters.Args
+}
+
+// PluginRemoveOptions holds parameters to remove plugins.
+type PluginRemoveOptions struct {
+	Force bool
 }

--- a/vendor/github.com/docker/engine-api/types/configs.go
+++ b/vendor/github.com/docker/engine-api/types/configs.go
@@ -45,9 +45,17 @@ type ExecConfig struct {
 	Privileged   bool     // Is the container in privileged mode
 	Tty          bool     // Attach standard streams to a tty.
 	AttachStdin  bool     // Attach the standard input, makes possible user interaction
-	AttachStderr bool     // Attach the standard output
-	AttachStdout bool     // Attach the standard error
+	AttachStderr bool     // Attach the standard error
+	AttachStdout bool     // Attach the standard output
 	Detach       bool     // Execute in detach mode
 	DetachKeys   string   // Escape keys for detach
+	Env          []string // Environment variables
 	Cmd          []string // Execution commands and args
+}
+
+// PluginRmConfig holds arguments for the plugin remove
+// operation. This struct is used to tell the backend what operations
+// to perform.
+type PluginRmConfig struct {
+	ForceRemove bool
 }

--- a/vendor/github.com/docker/engine-api/types/container/config.go
+++ b/vendor/github.com/docker/engine-api/types/container/config.go
@@ -36,7 +36,7 @@ type HealthConfig struct {
 type Config struct {
 	Hostname        string                // Hostname
 	Domainname      string                // Domainname
-	User            string                // User that will run the command(s) inside the container
+	User            string                // User that will run the command(s) inside the container, also support user:group
 	AttachStdin     bool                  // Attach the standard input, makes possible user interaction
 	AttachStdout    bool                  // Attach the standard output
 	AttachStderr    bool                  // Attach the standard error

--- a/vendor/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/github.com/docker/engine-api/types/container/host_config.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/types/blkiodev"
+	"github.com/docker/engine-api/types/mount"
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
@@ -317,4 +318,7 @@ type HostConfig struct {
 
 	// Contains container's resources (cgroups, ulimits)
 	Resources
+
+	// Mounts specs used by the container
+	Mounts []mount.Mount `json:",omitempty"`
 }

--- a/vendor/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/github.com/docker/engine-api/types/events/events.go
@@ -3,14 +3,16 @@ package events
 const (
 	// ContainerEventType is the event type that containers generate
 	ContainerEventType = "container"
-	// ImageEventType is the event type that images generate
-	ImageEventType = "image"
-	// VolumeEventType is the event type that volumes generate
-	VolumeEventType = "volume"
-	// NetworkEventType is the event type that networks generate
-	NetworkEventType = "network"
 	// DaemonEventType is the event type that daemon generate
 	DaemonEventType = "daemon"
+	// ImageEventType is the event type that images generate
+	ImageEventType = "image"
+	// NetworkEventType is the event type that networks generate
+	NetworkEventType = "network"
+	// PluginEventType is the event type that plugins generate
+	PluginEventType = "plugin"
+	// VolumeEventType is the event type that volumes generate
+	VolumeEventType = "volume"
 )
 
 // Actor describes something that generates events,

--- a/vendor/github.com/docker/engine-api/types/mount/mount.go
+++ b/vendor/github.com/docker/engine-api/types/mount/mount.go
@@ -1,0 +1,58 @@
+package mount
+
+// Type represents the type of a mount.
+type Type string
+
+const (
+	// TypeBind BIND
+	TypeBind Type = "bind"
+	// TypeVolume VOLUME
+	TypeVolume Type = "volume"
+)
+
+// Mount represents a mount (volume).
+type Mount struct {
+	Type     Type   `json:",omitempty"`
+	Source   string `json:",omitempty"`
+	Target   string `json:",omitempty"`
+	ReadOnly bool   `json:",omitempty"`
+
+	BindOptions   *BindOptions   `json:",omitempty"`
+	VolumeOptions *VolumeOptions `json:",omitempty"`
+}
+
+// Propagation represents the propagation of a mount.
+type Propagation string
+
+const (
+	// PropagationRPrivate RPRIVATE
+	PropagationRPrivate Propagation = "rprivate"
+	// PropagationPrivate PRIVATE
+	PropagationPrivate Propagation = "private"
+	// PropagationRShared RSHARED
+	PropagationRShared Propagation = "rshared"
+	// PropagationShared SHARED
+	PropagationShared Propagation = "shared"
+	// PropagationRSlave RSLAVE
+	PropagationRSlave Propagation = "rslave"
+	// PropagationSlave SLAVE
+	PropagationSlave Propagation = "slave"
+)
+
+// BindOptions defines options specific to mounts of type "bind".
+type BindOptions struct {
+	Propagation Propagation `json:",omitempty"`
+}
+
+// VolumeOptions represents the options for a mount of type volume.
+type VolumeOptions struct {
+	NoCopy       bool              `json:",omitempty"`
+	Labels       map[string]string `json:",omitempty"`
+	DriverConfig *Driver           `json:",omitempty"`
+}
+
+// Driver represents a volume driver.
+type Driver struct {
+	Name    string            `json:",omitempty"`
+	Options map[string]string `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/plugin.go
+++ b/vendor/github.com/docker/engine-api/types/plugin.go
@@ -26,10 +26,11 @@ type PluginConfig struct {
 
 // Plugin represents a Docker plugin for the remote API
 type Plugin struct {
-	ID       string `json:"Id,omitempty"`
-	Name     string
-	Tag      string
-	Active   bool
+	ID   string `json:"Id,omitempty"`
+	Name string
+	Tag  string
+	// Enabled is true when the plugin is running, is false when the plugin is not running, only installed.
+	Enabled  bool
 	Config   PluginConfig
 	Manifest PluginManifest
 }

--- a/vendor/github.com/docker/engine-api/types/registry/registry.go
+++ b/vendor/github.com/docker/engine-api/types/registry/registry.go
@@ -16,6 +16,11 @@ type ServiceConfig struct {
 // unmarshalled to JSON
 type NetIPNet net.IPNet
 
+// String returns the CIDR notation of ipnet
+func (ipnet *NetIPNet) String() string {
+	return (*net.IPNet)(ipnet).String()
+}
+
 // MarshalJSON returns the JSON representation of the IPNet
 func (ipnet *NetIPNet) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*net.IPNet)(ipnet).String())

--- a/vendor/github.com/docker/engine-api/types/seccomp.go
+++ b/vendor/github.com/docker/engine-api/types/seccomp.go
@@ -2,12 +2,22 @@ package types
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
-	DefaultAction Action     `json:"defaultAction"`
-	Architectures []Arch     `json:"architectures"`
-	Syscalls      []*Syscall `json:"syscalls"`
+	DefaultAction Action `json:"defaultAction"`
+	// Architectures is kept to maintain backward compatibility with the old
+	// seccomp profile.
+	Architectures []Arch         `json:"architectures,omitempty"`
+	ArchMap       []Architecture `json:"archMap,omitempty"`
+	Syscalls      []*Syscall     `json:"syscalls"`
 }
 
-// Arch used for additional architectures
+// Architecture is used to represent an specific architecture
+// and its sub-architectures
+type Architecture struct {
+	Arch      Arch   `json:"architecture"`
+	SubArches []Arch `json:"subArchitectures"`
+}
+
+// Arch used for architectures
 type Arch string
 
 // Additional architectures permitted to be used for system calls
@@ -65,9 +75,19 @@ type Arg struct {
 	Op       Operator `json:"op"`
 }
 
-// Syscall is used to match a syscall in Seccomp
+// Filter is used to conditionally apply Seccomp rules
+type Filter struct {
+	Caps   []string `json:"caps,omitempty"`
+	Arches []string `json:"arches,omitempty"`
+}
+
+// Syscall is used to match a group of syscalls in Seccomp
 type Syscall struct {
-	Name   string `json:"name"`
-	Action Action `json:"action"`
-	Args   []*Arg `json:"args"`
+	Name     string   `json:"name,omitempty"`
+	Names    []string `json:"names,omitempty"`
+	Action   Action   `json:"action"`
+	Args     []*Arg   `json:"args"`
+	Comment  string   `json:"comment"`
+	Includes Filter   `json:"includes"`
+	Excludes Filter   `json:"excludes"`
 }

--- a/vendor/github.com/docker/engine-api/types/swarm/container.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/container.go
@@ -1,6 +1,10 @@
 package swarm
 
-import "time"
+import (
+	"time"
+
+	"github.com/docker/engine-api/types/mount"
+)
 
 // ContainerSpec represents the spec of a container.
 type ContainerSpec struct {
@@ -11,57 +15,8 @@ type ContainerSpec struct {
 	Env             []string          `json:",omitempty"`
 	Dir             string            `json:",omitempty"`
 	User            string            `json:",omitempty"`
-	Mounts          []Mount           `json:",omitempty"`
+	Groups          []string          `json:",omitempty"`
+	TTY             bool              `json:",omitempty"`
+	Mounts          []mount.Mount     `json:",omitempty"`
 	StopGracePeriod *time.Duration    `json:",omitempty"`
-}
-
-// MountType represents the type of a mount.
-type MountType string
-
-const (
-	// MountTypeBind BIND
-	MountTypeBind MountType = "bind"
-	// MountTypeVolume VOLUME
-	MountTypeVolume MountType = "volume"
-)
-
-// Mount represents a mount (volume).
-type Mount struct {
-	Type     MountType `json:",omitempty"`
-	Source   string    `json:",omitempty"`
-	Target   string    `json:",omitempty"`
-	ReadOnly bool      `json:",omitempty"`
-
-	BindOptions   *BindOptions   `json:",omitempty"`
-	VolumeOptions *VolumeOptions `json:",omitempty"`
-}
-
-// MountPropagation represents the propagation of a mount.
-type MountPropagation string
-
-const (
-	// MountPropagationRPrivate RPRIVATE
-	MountPropagationRPrivate MountPropagation = "rprivate"
-	// MountPropagationPrivate PRIVATE
-	MountPropagationPrivate MountPropagation = "private"
-	// MountPropagationRShared RSHARED
-	MountPropagationRShared MountPropagation = "rshared"
-	// MountPropagationShared SHARED
-	MountPropagationShared MountPropagation = "shared"
-	// MountPropagationRSlave RSLAVE
-	MountPropagationRSlave MountPropagation = "rslave"
-	// MountPropagationSlave SLAVE
-	MountPropagationSlave MountPropagation = "slave"
-)
-
-// BindOptions defines options specific to mounts of type "bind".
-type BindOptions struct {
-	Propagation MountPropagation `json:",omitempty"`
-}
-
-// VolumeOptions represents the options for a mount of type volume.
-type VolumeOptions struct {
-	NoCopy       bool              `json:",omitempty"`
-	Labels       map[string]string `json:",omitempty"`
-	DriverConfig *Driver           `json:",omitempty"`
 }

--- a/vendor/github.com/docker/engine-api/types/swarm/network.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/network.go
@@ -64,6 +64,7 @@ type NetworkSpec struct {
 	DriverConfiguration *Driver      `json:",omitempty"`
 	IPv6Enabled         bool         `json:",omitempty"`
 	Internal            bool         `json:",omitempty"`
+	Attachable          bool         `json:",omitempty"`
 	IPAMOptions         *IPAMOptions `json:",omitempty"`
 }
 
@@ -92,7 +93,7 @@ type IPAMConfig struct {
 	Gateway string `json:",omitempty"`
 }
 
-// Driver represents a driver (network/volume).
+// Driver represents a network driver.
 type Driver struct {
 	Name    string            `json:",omitempty"`
 	Options map[string]string `json:",omitempty"`

--- a/vendor/github.com/docker/engine-api/types/swarm/node.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/node.go
@@ -15,7 +15,6 @@ type Node struct {
 type NodeSpec struct {
 	Annotations
 	Role         NodeRole         `json:",omitempty"`
-	Membership   NodeMembership   `json:",omitempty"`
 	Availability NodeAvailability `json:",omitempty"`
 }
 
@@ -27,16 +26,6 @@ const (
 	NodeRoleWorker NodeRole = "worker"
 	// NodeRoleManager MANAGER
 	NodeRoleManager NodeRole = "manager"
-)
-
-// NodeMembership represents the membership of a node.
-type NodeMembership string
-
-const (
-	// NodeMembershipPending PENDING
-	NodeMembershipPending NodeMembership = "pending"
-	// NodeMembershipAccepted ACCEPTED
-	NodeMembershipAccepted NodeMembership = "accepted"
 )
 
 // NodeAvailability represents the availability of a node.

--- a/vendor/github.com/docker/engine-api/types/swarm/service.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/service.go
@@ -6,8 +6,9 @@ import "time"
 type Service struct {
 	ID string
 	Meta
-	Spec     ServiceSpec `json:",omitempty"`
-	Endpoint Endpoint    `json:",omitempty"`
+	Spec         ServiceSpec  `json:",omitempty"`
+	Endpoint     Endpoint     `json:",omitempty"`
+	UpdateStatus UpdateStatus `json:",omitempty"`
 }
 
 // ServiceSpec represents the spec of a service.
@@ -16,9 +17,13 @@ type ServiceSpec struct {
 
 	// TaskTemplate defines how the service should construct new tasks when
 	// orchestrating this service.
-	TaskTemplate TaskSpec                  `json:",omitempty"`
-	Mode         ServiceMode               `json:",omitempty"`
-	UpdateConfig *UpdateConfig             `json:",omitempty"`
+	TaskTemplate TaskSpec      `json:",omitempty"`
+	Mode         ServiceMode   `json:",omitempty"`
+	UpdateConfig *UpdateConfig `json:",omitempty"`
+
+	// Networks field in ServiceSpec is being deprecated. Users of
+	// engine-api should start using the same field in
+	// TaskSpec. This field will be removed in future releases.
 	Networks     []NetworkAttachmentConfig `json:",omitempty"`
 	EndpointSpec *EndpointSpec             `json:",omitempty"`
 }
@@ -29,6 +34,26 @@ type ServiceMode struct {
 	Global     *GlobalService     `json:",omitempty"`
 }
 
+// UpdateState is the state of a service update.
+type UpdateState string
+
+const (
+	// UpdateStateUpdating is the updating state.
+	UpdateStateUpdating UpdateState = "updating"
+	// UpdateStatePaused is the paused state.
+	UpdateStatePaused UpdateState = "paused"
+	// UpdateStateCompleted is the completed state.
+	UpdateStateCompleted UpdateState = "completed"
+)
+
+// UpdateStatus reports the status of a service update.
+type UpdateStatus struct {
+	State       UpdateState `json:",omitempty"`
+	StartedAt   time.Time   `json:",omitempty"`
+	CompletedAt time.Time   `json:",omitempty"`
+	Message     string      `json:",omitempty"`
+}
+
 // ReplicatedService is a kind of ServiceMode.
 type ReplicatedService struct {
 	Replicas *uint64 `json:",omitempty"`
@@ -37,8 +62,16 @@ type ReplicatedService struct {
 // GlobalService is a kind of ServiceMode.
 type GlobalService struct{}
 
+const (
+	// UpdateFailureActionPause PAUSE
+	UpdateFailureActionPause = "pause"
+	// UpdateFailureActionContinue CONTINUE
+	UpdateFailureActionContinue = "continue"
+)
+
 // UpdateConfig represents the update configuration.
 type UpdateConfig struct {
-	Parallelism uint64        `json:",omitempty"`
-	Delay       time.Duration `json:",omitempty"`
+	Parallelism   uint64        `json:",omitempty"`
+	Delay         time.Duration `json:",omitempty"`
+	FailureAction string        `json:",omitempty"`
 }

--- a/vendor/github.com/docker/engine-api/types/swarm/task.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/task.go
@@ -38,6 +38,7 @@ const (
 type Task struct {
 	ID string
 	Meta
+	Annotations
 
 	Spec                TaskSpec            `json:",omitempty"`
 	ServiceID           string              `json:",omitempty"`
@@ -50,10 +51,11 @@ type Task struct {
 
 // TaskSpec represents the spec of a task.
 type TaskSpec struct {
-	ContainerSpec ContainerSpec         `json:",omitempty"`
-	Resources     *ResourceRequirements `json:",omitempty"`
-	RestartPolicy *RestartPolicy        `json:",omitempty"`
-	Placement     *Placement            `json:",omitempty"`
+	ContainerSpec ContainerSpec             `json:",omitempty"`
+	Resources     *ResourceRequirements     `json:",omitempty"`
+	RestartPolicy *RestartPolicy            `json:",omitempty"`
+	Placement     *Placement                `json:",omitempty"`
+	Networks      []NetworkAttachmentConfig `json:",omitempty"`
 
 	// LogDriver specifies the LogDriver to use for tasks created from this
 	// spec. If not present, the one on cluster default on swarm.Spec will be


### PR DESCRIPTION
Note that compose/up.bats and api/network.bats are now failing; the former
because docker-compose doesn't support creating Attachable networks yet, and
the latter because the Attachable key doesn't show up in docker network
responses.

Ping @dongluochen @nishanttotla

Signed-off-by: Wayne Song wsong@docker.com
