### PR TITLE
Fix typo in Swarm API doc

### DIFF
--- a/docs/swarm-api.md
+++ b/docs/swarm-api.md
@@ -40,8 +40,8 @@ POST "/images/create" : "docker import" flow not implement
             New field <code>Node</code> added:<br />
 <pre>
 "Node": {
-    "Id": "ODAI:IC6Q:MSBL:TPB5:HIEE:6IKC:VCAM:QRNH:PRGX:ERZT:OK46:PMFX",
-    "Ip": "0.0.0.0",
+    "ID": "ODAI:IC6Q:MSBL:TPB5:HIEE:6IKC:VCAM:QRNH:PRGX:ERZT:OK46:PMFX",
+    "IP": "0.0.0.0",
     "Addr": "http://0.0.0.0:4243",
     "Name": "vagrant-ubuntu-saucy-64"
 }


### PR DESCRIPTION
Very small doc fix to change the cases of "ID" and "IP".

Fixes #2378.

Signed-off-by: Misty Stanley-Jones <misty@docker.com>