### PR TITLE
Check port conflict with pending containers

### DIFF
--- a/scheduler/filter/port.go
+++ b/scheduler/filter/port.go
@@ -80,7 +80,7 @@ func (p *PortFilter) portAlreadyInUse(node *node.Node, requested nat.PortBinding
 		// HostConfig.PortBindings contains the requested ports.
 		// NetworkSettings.Ports contains the actual ports.
 		//
-		// We have to check both because:
+		// We have to check 3 cases because:
 		// 1/ If the port was not specifically bound (e.g. -p 80), then
 		//    HostConfig.PortBindings.HostPort will be empty and we have to check
 		//    NetworkSettings.Port.HostPort to find out which port got dynamically
@@ -88,9 +88,22 @@ func (p *PortFilter) portAlreadyInUse(node *node.Node, requested nat.PortBinding
 		// 2/ If the port was bound (e.g. -p 80:80) but the container is stopped,
 		//    NetworkSettings.Port will be null and we have to check
 		//    HostConfig.PortBindings to find out the mapping.
+		// 3/ If the container is a pending container where ID is empty, it's under
+		//    construction on the selected node, another container requesting
+		//    the same ports should not be scheduled on the node, otherwise the
+		//    second container would fail to start.
+		//    This corner case is amplified by Docker compose 'scale' command.
+		//    See https://github.com/docker/swarm/issues/2499.
 
-		if (c.Info.HostConfig != nil && p.compare(requested, c.Info.HostConfig.PortBindings)) || (c.Info.NetworkSettings != nil && p.compare(requested, c.Info.NetworkSettings.Ports)) {
-			return true
+		if c.ID != "" {
+			if (c.Info.HostConfig != nil && p.compare(requested, c.Info.HostConfig.PortBindings)) || (c.Info.NetworkSettings != nil && p.compare(requested, c.Info.NetworkSettings.Ports)) {
+				return true
+			}
+		} else {
+			// container is a pending container, check its configuration
+			if c.Config != nil && p.compare(requested, c.Config.HostConfig.PortBindings) {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Swarm checks port conflict with existing containers at create time. In concurrent container creation, it should also check **pending** containers which are under construction. This corner case is amplified by Docker compose.   

Fix #2499. 

Signed-off-by: Dong Chen dongluo.chen@docker.com
