### PR TITLE
fix dangling filters to Swarm

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -117,7 +117,7 @@ func (eh *eventsHandler) Handle(e *cluster.Event) error {
 
 	var failed []string
 
-	eh.RLock()
+	eh.Lock()
 
 	for key, w := range eh.ws {
 		if _, err := fmt.Fprint(w, string(data)); err != nil {
@@ -130,8 +130,6 @@ func (eh *eventsHandler) Handle(e *cluster.Event) error {
 			f.Flush()
 		}
 	}
-	eh.RUnlock()
-	eh.Lock()
 	if len(failed) > 0 {
 		for _, key := range failed {
 			if ch, ok := eh.cs[key]; ok {

--- a/api/events.go
+++ b/api/events.go
@@ -53,17 +53,20 @@ func (eh *eventsHandler) Wait(remoteAddr string, until int64) {
 	}
 
 	// subscribe to http client close event
+	eh.RLock()
 	w := eh.ws[remoteAddr]
+	ch := eh.cs[remoteAddr]
+	eh.RUnlock()
 	var closeNotify <-chan bool
 	if closeNotifier, ok := w.(http.CloseNotifier); ok {
 		closeNotify = closeNotifier.CloseNotify()
 	}
 
 	select {
-	case <-eh.cs[remoteAddr]:
+	case <-ch:
 	case <-closeNotify:
 	case <-timer.C: // `--until` timeout
-		close(eh.cs[remoteAddr])
+		close(ch)
 	}
 	eh.cleanupHandler(remoteAddr)
 }

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -332,6 +332,7 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	names := filters.Get("name")
+	nodes := filters.Get("node")
 	for _, volume := range c.cluster.Volumes() {
 		// Check if the volume matches any name filters
 		found := false
@@ -341,6 +342,7 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
+
 		if len(names) > 0 && !found {
 			// Do not include this volume in the response if it doesn't match
 			// a name filter, if any exist.
@@ -349,6 +351,17 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 
 		tmp := (*volume).Volume
 		if tmp.Driver == "local" {
+			// Check if the volume matches any node filters
+			found = false
+			for _, node := range nodes {
+				if volume.Engine.Name == node {
+					found = true
+					break
+				}
+			}
+			if len(nodes) > 0 && !found {
+				continue
+			}
 			tmp.Name = volume.Engine.Name + "/" + volume.Name
 		}
 		volumesListResponse.Volumes = append(volumesListResponse.Volumes, &tmp)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -10,100 +10,100 @@ import (
 
 // Cluster is exported
 type Cluster interface {
-	// Create a container
+	// CreateContainer creates a container.
 	CreateContainer(config *ContainerConfig, name string, authConfig *types.AuthConfig) (*Container, error)
 
-	// Remove a container
+	// RemoveContainer removes a container.
 	RemoveContainer(container *Container, force, volumes bool) error
 
-	// Return all images
+	// Images returns all images.
 	Images() Images
 
-	// Return one image matching `IDOrName`
+	// Image returns one image matching `IDOrName`.
 	Image(IDOrName string) *Image
 
-	// Remove images from the cluster
+	// RemoveImages removes images from the cluster.
 	RemoveImages(name string, force bool) ([]types.ImageDelete, error)
 
-	// Return all containers
+	// Containers returns all containers.
 	Containers() Containers
 
-	// Start a container
+	// StartContainer starts a container.
 	StartContainer(container *Container, hostConfig *dockerclient.HostConfig) error
 
-	// Return container the matching `IDOrName`
+	// Container returns the container matching `IDOrName`.
 	// TODO: remove this method from the interface as we can use
-	// cluster.Containers().Get(IDOrName)
+	// cluster.Containers().Get(IDOrName).
 	Container(IDOrName string) *Container
 
-	// Return all networks
+	// Networks returns all networks.
 	Networks() Networks
 
-	// Create a network
+	// CreateNetwork creates a network.
 	CreateNetwork(name string, request *types.NetworkCreate) (*types.NetworkCreateResponse, error)
 
-	// Remove a network from the cluster
+	// RemoveNetwork removes a network from the cluster.
 	RemoveNetwork(network *Network) error
 
-	// Create a volume
+	// CreateVolume creates a volume.
 	CreateVolume(request *volume.VolumesCreateBody) (*types.Volume, error)
 
-	// Return all volumes
+	// Volumes returns all volumes.
 	Volumes() Volumes
 
-	// Remove volumes from the cluster
+	// RemoveVolumes removes volumes from the cluster.
 	RemoveVolumes(name string) (bool, error)
 
 	// Pull images
 	// `callback` can be called multiple time
 	//  `where` is where it is being pulled
-	//  `status` is the current status, like "", "in progress" or "downloaded"
+	//  `status` is the current status, like "", "in progress" or "downloaded".
 	Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error))
 
 	// Import image
 	// `callback` can be called multiple time
 	// `where` is where it is being imported
-	// `status` is the current status, like "", "in progress" or "imported"
+	// `status` is the current status, like "", "in progress" or "imported".
 	Import(source string, ref string, tag string, imageReader io.Reader, callback func(where, status string, err error))
 
 	// Load images
 	// `callback` can be called multiple time
 	// `what` is what is being loaded
-	// `status` is the current status, like "", "in progress" or "loaded"
+	// `status` is the current status, like "", "in progress" or "loaded".
 	Load(imageReader io.Reader, callback func(what, status string, err error))
 
-	// Return some info about the cluster, like nb of containers / images
+	// Info returns some info about the cluster, like nb of containers / images.
 	// It is pretty open, so the implementation decides what to return.
 	Info() [][2]string
 
-	// Return the total memory of the cluster
+	// TotalMemory returns the total memory of the cluster.
 	TotalMemory() int64
 
-	// Return the number of CPUs in the cluster
+	// TotalCpus returns the number of CPUs in the cluster.
 	TotalCpus() int64
 
-	// Register an event handler for cluster-wide events.
+	// RegisterEventHandler registers an event handler for cluster-wide events.
 	RegisterEventHandler(h EventHandler) error
 
-	// Unregister an event handler.
+	// UnregisterEventHandler unregisters an event handler.
 	UnregisterEventHandler(h EventHandler)
 
 	// FIXME: remove this method
-	// Return a random engine
+	// RANDOMENGINE returns a random engine.
 	RANDOMENGINE() (*Engine, error)
 
-	// Rename a container
+	// RenameContainer renames a container.
 	RenameContainer(container *Container, newName string) error
 
-	// Build an image
+	// BuildImage builds an image.
 	BuildImage(io.Reader, *types.ImageBuildOptions, io.Writer) error
 
-	// Tag an image
+	// TagImage tags an image.
 	TagImage(IDOrName string, ref string, force bool) error
 
-	// Refresh a single cluster engine
+	// RefreshEngine refreshes a single cluster engine.
 	RefreshEngine(hostname string) error
 
-	// Refresh all engines in the cluster
+	// RefreshEngines refreshes all engines in the cluster.
 	RefreshEngines() error
 }

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -41,28 +41,20 @@ func parseEnv(e string) (bool, string, string) {
 
 // ConsolidateResourceFields is a temporary fix to handle forward/backward compatibility between Docker <1.6 and >=1.7
 func ConsolidateResourceFields(c *OldContainerConfig) {
-	if c.Memory != c.HostConfig.Memory {
-		if c.Memory != 0 {
-			c.HostConfig.Memory = c.Memory
-		}
+	if c.Memory != c.HostConfig.Memory && c.Memory != 0 {
+		c.HostConfig.Memory = c.Memory
 	}
 
-	if c.MemorySwap != c.HostConfig.MemorySwap {
-		if c.MemorySwap != 0 {
-			c.HostConfig.MemorySwap = c.MemorySwap
-		}
+	if c.MemorySwap != c.HostConfig.MemorySwap && c.MemorySwap != 0 {
+		c.HostConfig.MemorySwap = c.MemorySwap
 	}
 
-	if c.CPUShares != c.HostConfig.CPUShares {
-		if c.CPUShares != 0 {
-			c.HostConfig.CPUShares = c.CPUShares
-		}
+	if c.CPUShares != c.HostConfig.CPUShares && c.CPUShares != 0 {
+		c.HostConfig.CPUShares = c.CPUShares
 	}
 
-	if c.CPUSet != c.HostConfig.CpusetCpus {
-		if c.CPUSet != "" {
-			c.HostConfig.CpusetCpus = c.CPUSet
-		}
+	if c.CPUSet != c.HostConfig.CpusetCpus && c.CPUSet != "" {
+		c.HostConfig.CpusetCpus = c.CPUSet
 	}
 }
 

--- a/cluster/image.go
+++ b/cluster/image.go
@@ -93,7 +93,8 @@ func (images Images) Filter(opts ImageFilterOptions) Images {
 		// TODO: this is wrong if RepoTags == []
 		return opts.All ||
 			(len(image.RepoTags) != 0 && image.RepoTags[0] != "<none>:<none>") ||
-			(len(image.RepoDigests) != 0 && image.RepoDigests[0] != "<none>@<none>")
+			(len(image.RepoDigests) != 0 && image.RepoDigests[0] != "<none>@<none>") ||
+			opts.Filters.Include("dangling") // delegate dangling filter to decide
 	}
 
 	includeFilter := func(image *Image) bool {
@@ -126,9 +127,30 @@ func (images Images) Filter(opts ImageFilterOptions) Images {
 		return false
 	}
 
+	danglingFilter := func(image Image) bool {
+		if opts.Filters.Include("dangling") {
+			if len(image.RepoTags) == 0 {
+				image.RepoTags = []string{"<none>:<none>"}
+			}
+
+			if opts.Filters.ExactMatch("dangling", "true") {
+				// for dangling true, filter out non-dangling images
+				if image.RepoTags[0] != "<none>:<none>" {
+					return false
+				}
+			} else if opts.Filters.ExactMatch("dangling", "false") {
+				// for dangling false, filter out dangling images
+				if image.RepoTags[0] == "<none>:<none>" {
+					return false
+				}
+			}
+		}
+		return true
+	}
+
 	filtered := make([]*Image, 0, len(images))
 	for _, image := range images {
-		if includeAll(image) && includeFilter(image) && referenceFilter(image, "reference") {
+		if includeAll(image) && includeFilter(image) && referenceFilter(image, "reference") && danglingFilter(*image) {
 			filtered = append(filtered, image)
 		}
 	}

--- a/cluster/image_test.go
+++ b/cluster/image_test.go
@@ -122,6 +122,74 @@ func TestImagesFilterWithMatchNameWithTag(t *testing.T) {
 	assert.Equal(t, len(result), 2)
 }
 
+func TestImageFilterWithDangling(t *testing.T) {
+	danglingFilters := dockerfilters.NewArgs()
+	danglingFilters.Add("dangling", "true")
+
+	nonDanglingFilters := dockerfilters.NewArgs()
+	nonDanglingFilters.Add("dangling", "false")
+
+	illegalDanglingFilters := dockerfilters.NewArgs()
+	illegalDanglingFilters.Add("dangling", "nonexisting")
+
+	engine := NewEngine("test", 0, engOpts)
+	images := Images{
+		{
+			types.ImageSummary{
+				ID:       "a",
+				RepoTags: []string{"example:latest", "example:2"},
+			},
+			engine,
+		},
+		{
+			types.ImageSummary{ID: "b"},
+			engine,
+		},
+		{
+			types.ImageSummary{ID: "c", RepoTags: []string{"foo:latest"}},
+			engine,
+		},
+		{
+			types.ImageSummary{ID: "d", RepoTags: []string{"<none>:<none>"}},
+			engine,
+		},
+	}
+
+	result := images.Filter(ImageFilterOptions{types.ImageListOptions{All: true, Filters: danglingFilters}})
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, "b", result[0].ID)
+	assert.Equal(t, "d", result[1].ID)
+
+	result = images.Filter(ImageFilterOptions{types.ImageListOptions{All: false, Filters: danglingFilters}})
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, "b", result[0].ID)
+	assert.Equal(t, "d", result[1].ID)
+
+	result = images.Filter(ImageFilterOptions{types.ImageListOptions{All: true, Filters: nonDanglingFilters}})
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, "a", result[0].ID)
+	assert.Equal(t, "c", result[1].ID)
+
+	result = images.Filter(ImageFilterOptions{types.ImageListOptions{All: false, Filters: nonDanglingFilters}})
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, "a", result[0].ID)
+	assert.Equal(t, "c", result[1].ID)
+
+	result = images.Filter(ImageFilterOptions{types.ImageListOptions{All: true, Filters: illegalDanglingFilters}})
+	assert.Equal(t, 4, len(result))
+	assert.Equal(t, "a", result[0].ID)
+	assert.Equal(t, "b", result[1].ID)
+	assert.Equal(t, "c", result[2].ID)
+	assert.Equal(t, "d", result[3].ID)
+
+	result = images.Filter(ImageFilterOptions{types.ImageListOptions{All: false, Filters: illegalDanglingFilters}})
+	assert.Equal(t, 4, len(result))
+	assert.Equal(t, "a", result[0].ID)
+	assert.Equal(t, "b", result[1].ID)
+	assert.Equal(t, "c", result[2].ID)
+	assert.Equal(t, "d", result[3].ID)
+}
+
 func TestParseRepositoryTag(t *testing.T) {
 
 	repo, tag := ParseRepositoryTag("localhost.localdomain:5000/samalba/hipache:latest")

--- a/cluster/jsonmessage.go
+++ b/cluster/jsonmessage.go
@@ -1,0 +1,35 @@
+package cluster
+
+import "encoding/json"
+
+// Types lifted from docker/docker/pkg/jsonmessage to avoid TTY build breakages
+
+// JSONError represents a JSON Error
+type JSONError struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// JSONProgress represents a JSON-encoded progress instance
+type JSONProgress struct {
+	//terminalFd uintptr
+	Current int64 `json:"current,omitempty"`
+	Total   int64 `json:"total,omitempty"`
+	Start   int64 `json:"start,omitempty"`
+}
+
+// JSONMessage represents a JSON-encoded message regarding the status of a stream
+type JSONMessage struct {
+	Stream          string        `json:"stream,omitempty"`
+	Status          string        `json:"status,omitempty"`
+	Progress        *JSONProgress `json:"progressDetail,omitempty"`
+	ProgressMessage string        `json:"progress,omitempty"` //deprecated
+	ID              string        `json:"id,omitempty"`
+	From            string        `json:"from,omitempty"`
+	Time            int64         `json:"time,omitempty"`
+	TimeNano        int64         `json:"timeNano,omitempty"`
+	Error           *JSONError    `json:"errorDetail,omitempty"`
+	ErrorMessage    string        `json:"error,omitempty"` //deprecated
+	// Aux contains out-of-band data, such as digests for push signing.
+	Aux *json.RawMessage `json:"aux,omitempty"`
+}

--- a/cluster/network.go
+++ b/cluster/network.go
@@ -46,7 +46,7 @@ func (networks Networks) Uniq() Networks {
 	return uniq
 }
 
-// Filter returns networks filtered by names, IDs, labels, etc.
+// Filter returns networks filtered by names, IDs, nodes, labels, etc.
 func (networks Networks) Filter(filter filters.Args) Networks {
 	includeFilter := func(network *Network) bool {
 		for _, typ := range filter.Get("type") {
@@ -64,6 +64,11 @@ func (networks Networks) Filter(filter filters.Args) Networks {
 		}
 		if filter.Include("driver") {
 			if !filter.ExactMatch("driver", network.Driver) {
+				return false
+			}
+		}
+		for _, node := range filter.Get("node") {
+			if network.Engine.Name != node {
 				return false
 			}
 		}

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -619,7 +619,14 @@ func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(
 			if callback != nil {
 				callback(engine.Name, "", nil)
 			}
-			err := engine.Pull(name, authConfig)
+
+			var engineCallback func(msg cluster.JSONMessage)
+			if callback != nil {
+				engineCallback = func(msg cluster.JSONMessage) {
+					callback(engine.Name, msg.Status, nil)
+				}
+			}
+			err := engine.Pull(name, authConfig, engineCallback)
 			if callback != nil {
 				if err != nil {
 					callback(engine.Name, "", err)
@@ -651,7 +658,13 @@ func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string
 			defer reader.Close()
 
 			// call engine load image
-			err := engine.Load(reader)
+			var engineCallback func(msg cluster.JSONMessage)
+			if callback != nil {
+				engineCallback = func(msg cluster.JSONMessage) {
+					callback(engine.Name, msg.Status, nil)
+				}
+			}
+			err := engine.Load(reader, engineCallback)
 			if callback != nil {
 				if err != nil {
 					callback(engine.Name, "", err)
@@ -699,7 +712,13 @@ func (c *Cluster) Import(source string, ref string, tag string, imageReader io.R
 			defer reader.Close()
 
 			// call engine import
-			err := engine.Import(source, ref, tag, reader)
+			var engineCallback func(msg cluster.JSONMessage)
+			if callback != nil {
+				engineCallback = func(msg cluster.JSONMessage) {
+					callback(engine.Name, msg.Status, nil)
+				}
+			}
+			err := engine.Import(source, ref, tag, reader, engineCallback)
 			if callback != nil {
 				if err != nil {
 					callback(engine.Name, "", err)

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -54,7 +54,7 @@ func (p *pendingContainer) ToContainer() *cluster.Container {
 	return container
 }
 
-// Cluster is exported
+// Cluster is exported.
 type Cluster struct {
 	sync.RWMutex
 
@@ -71,7 +71,7 @@ type Cluster struct {
 	TLSConfig       *tls.Config
 }
 
-// NewCluster is exported
+// NewCluster is exported.
 func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, discovery discovery.Backend, options cluster.DriverOpts, engineOptions *cluster.EngineOpts) (cluster.Cluster, error) {
 	log.WithFields(log.Fields{"name": "swarm"}).Debug("Initializing cluster")
 
@@ -113,7 +113,7 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, discovery
 	return cluster, nil
 }
 
-// Handle callbacks for the events
+// Handle callbacks for the events.
 func (c *Cluster) Handle(e *cluster.Event) error {
 	c.eventHandlers.Handle(e)
 	return nil
@@ -129,7 +129,7 @@ func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 	c.eventHandlers.UnregisterEventHandler(h)
 }
 
-// Generate a globally (across the cluster) unique ID.
+// generateUniqueID generates a globally (across the cluster) unique ID.
 func (c *Cluster) generateUniqueID() string {
 	for {
 		id := stringid.GenerateRandomID()
@@ -139,7 +139,7 @@ func (c *Cluster) generateUniqueID() string {
 	}
 }
 
-// StartContainer starts a container
+// StartContainer starts a container.
 func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *dockerclient.HostConfig) error {
 	return container.Engine.StartContainer(container, hostConfig)
 }
@@ -249,7 +249,7 @@ func (c *Cluster) RemoveContainer(container *cluster.Container, force, volumes b
 	return container.Engine.RemoveContainer(container, force, volumes)
 }
 
-// RemoveNetwork removes a network from the cluster
+// RemoveNetwork removes a network from the cluster.
 func (c *Cluster) RemoveNetwork(network *cluster.Network) error {
 	err := network.Engine.RemoveNetwork(network)
 	if err == nil {
@@ -463,7 +463,7 @@ func (c *Cluster) Image(IDOrName string) *cluster.Image {
 	return nil
 }
 
-// RemoveImages removes all the images that match `name` from the cluster
+// RemoveImages removes all the images that match `name` from the cluster.
 func (c *Cluster) RemoveImages(name string, force bool) ([]types.ImageDelete, error) {
 	c.Lock()
 	defer c.Unlock()
@@ -491,7 +491,7 @@ func (c *Cluster) RemoveImages(name string, force bool) ([]types.ImageDelete, er
 	return out, err
 }
 
-// CreateNetwork creates a network in the cluster
+// CreateNetwork creates a network in the cluster.
 func (c *Cluster) CreateNetwork(name string, request *types.NetworkCreate) (response *types.NetworkCreateResponse, err error) {
 	var (
 		parts  = strings.SplitN(name, "/", 2)
@@ -524,7 +524,7 @@ func (c *Cluster) CreateNetwork(name string, request *types.NetworkCreate) (resp
 	return nil, nil
 }
 
-// CreateVolume creates a volume in the cluster
+// CreateVolume creates a volume in the cluster.
 func (c *Cluster) CreateVolume(request *volume.VolumesCreateBody) (*types.Volume, error) {
 	var (
 		wg     sync.WaitGroup
@@ -582,7 +582,7 @@ func (c *Cluster) CreateVolume(request *volume.VolumesCreateBody) (*types.Volume
 	return volume, err
 }
 
-// RemoveVolumes removes all the volumes that match `name` from the cluster
+// RemoveVolumes removes all the volumes that match `name` from the cluster.
 func (c *Cluster) RemoveVolumes(name string) (bool, error) {
 	c.Lock()
 	defer c.Unlock()
@@ -605,7 +605,7 @@ func (c *Cluster) RemoveVolumes(name string) (bool, error) {
 	return found, err
 }
 
-// Pull is exported
+// Pull is exported.
 func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error)) {
 	var wg sync.WaitGroup
 
@@ -634,7 +634,7 @@ func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(
 	wg.Wait()
 }
 
-// Load image
+// Load loads image.
 func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string, err error)) {
 	var wg sync.WaitGroup
 
@@ -682,7 +682,7 @@ func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string
 	wg.Wait()
 }
 
-// Import image
+// Import imports image.
 func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
 	var wg sync.WaitGroup
 	c.RLock()
@@ -844,7 +844,7 @@ func (c *Cluster) listEngines() []*cluster.Engine {
 	return out
 }
 
-// TotalMemory returns the total memory of the cluster
+// TotalMemory returns the total memory of the cluster.
 func (c *Cluster) TotalMemory() int64 {
 	var totalMemory int64
 	for _, engine := range c.engines {
@@ -853,7 +853,7 @@ func (c *Cluster) TotalMemory() int64 {
 	return totalMemory
 }
 
-// TotalCpus returns the total CPUs of the cluster
+// TotalCpus returns the total CPUs of the cluster.
 func (c *Cluster) TotalCpus() int64 {
 	var totalCpus int64
 	for _, engine := range c.engines {
@@ -862,7 +862,7 @@ func (c *Cluster) TotalCpus() int64 {
 	return totalCpus
 }
 
-// Info returns some info about the cluster, like nb or containers / images
+// Info returns some info about the cluster, like nb or containers / images.
 func (c *Cluster) Info() [][2]string {
 	info := [][2]string{
 		{"Strategy", c.scheduler.Strategy()},
@@ -968,7 +968,7 @@ func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuil
 	return nil
 }
 
-// RefreshEngines refreshes all containers in the cluster
+// RefreshEngines refreshes all containers in the cluster.
 func (c *Cluster) RefreshEngines() error {
 	for _, e := range c.engines {
 		err := e.RefreshContainers(true)
@@ -979,7 +979,7 @@ func (c *Cluster) RefreshEngines() error {
 	return nil
 }
 
-// RefreshEngine refreshes all containers in a specific engine
+// RefreshEngine refreshes all containers in a specific engine.
 func (c *Cluster) RefreshEngine(hostname string) error {
 	for _, e := range c.engines {
 		if e.Name == hostname {
@@ -993,7 +993,7 @@ func (c *Cluster) RefreshEngine(hostname string) error {
 	return fmt.Errorf("no engine found with hostname %s", hostname)
 }
 
-// TagImage tags an image
+// TagImage tags an image.
 func (c *Cluster) TagImage(IDOrName string, ref string, force bool) error {
 	c.RLock()
 	defer c.RUnlock()

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -719,7 +719,7 @@ func (c *Cluster) Import(source string, ref string, tag string, imageReader io.R
 	}
 	multiWriter := io.MultiWriter(listWriter...)
 
-	// copy image-reader to muti-writer
+	// copy image-reader to multi-writer
 	_, err := io.Copy(multiWriter, imageReader)
 	if err != nil {
 		log.Error(err)

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -129,7 +129,7 @@ func TestImportImage(t *testing.T) {
 		engines: make(map[string]*cluster.Engine),
 	}
 
-	// create engione
+	// create engine
 	id := "test-engine"
 	engine := cluster.NewEngine(id, 0, engOpts)
 	engine.Name = id
@@ -182,7 +182,7 @@ func TestLoadImage(t *testing.T) {
 		engines: make(map[string]*cluster.Engine),
 	}
 
-	// create engione
+	// create engine
 	id := "test-engine"
 	engine := cluster.NewEngine(id, 0, engOpts)
 	engine.Name = id

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -155,7 +155,7 @@ func TestImportImage(t *testing.T) {
 	c.engines[engine.ID] = engine
 
 	// import success
-	readCloser := nopCloser{bytes.NewBufferString("ok")}
+	readCloser := nopCloser{bytes.NewBufferString("")}
 	apiClient.On("ImageImport", mock.Anything, mock.AnythingOfType("types.ImageImportSource"), mock.Anything, mock.AnythingOfType("types.ImageImportOptions")).Return(readCloser, nil).Once()
 
 	callback := func(what, status string, err error) {
@@ -165,7 +165,7 @@ func TestImportImage(t *testing.T) {
 	c.Import("-", "testImageOK", "latest", bytes.NewReader(nil), callback)
 
 	// import error
-	readCloser = nopCloser{bytes.NewBufferString("error")}
+	readCloser = nopCloser{bytes.NewBufferString("")}
 	err := fmt.Errorf("Import error")
 	apiClient.On("ImageImport", mock.Anything, mock.AnythingOfType("types.ImageImportSource"), mock.Anything, mock.AnythingOfType("types.ImageImportOptions")).Return(readCloser, err).Once()
 

--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -89,7 +89,7 @@ func (w *Watchdog) rescheduleContainers(e *Engine) {
 			log.Errorf("container %s has no name", c.ID)
 			continue
 		}
-		// cut preceeding '/'
+		// cut preceding '/'
 		if name[0] == '/' {
 			name = name[1:]
 		}

--- a/discovery/token/token.go
+++ b/discovery/token/token.go
@@ -14,7 +14,7 @@ import (
 
 const discoveryURL = "https://discovery.hub.docker.com/v1"
 
-// Discovery is exported
+// Discovery is exported.
 type Discovery struct {
 	heartbeat time.Duration
 	ttl       time.Duration
@@ -26,12 +26,12 @@ func init() {
 	Init()
 }
 
-// Init is exported
+// Init is exported.
 func Init() {
 	discovery.Register("token", &Discovery{})
 }
 
-// Initialize is exported
+// Initialize is exported.
 func (s *Discovery) Initialize(urltoken string, heartbeat time.Duration, ttl time.Duration, _ map[string]string) error {
 	if i := strings.LastIndex(urltoken, "/"); i != -1 {
 		s.url = "https://" + urltoken[:i]
@@ -50,7 +50,7 @@ func (s *Discovery) Initialize(urltoken string, heartbeat time.Duration, ttl tim
 	return nil
 }
 
-// Fetch returns the list of entries for the discovery service at the specified endpoint
+// fetch returns the list of entries for the discovery service at the specified endpoint.
 func (s *Discovery) fetch() (discovery.Entries, error) {
 	resp, err := http.Get(fmt.Sprintf("%s/%s/%s", s.url, "clusters", s.token))
 	if err != nil {
@@ -71,7 +71,7 @@ func (s *Discovery) fetch() (discovery.Entries, error) {
 	return discovery.CreateEntries(addrs)
 }
 
-// Watch is exported
+// Watch is exported.
 func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
 	ch := make(chan discovery.Entries)
 	ticker := time.NewTicker(s.heartbeat)
@@ -114,7 +114,7 @@ func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-c
 	return ch, errCh
 }
 
-// Register adds a new entry identified by the into the discovery service
+// Register adds a new entry identified by the into the discovery service.
 func (s *Discovery) Register(addr string) error {
 	buf := strings.NewReader(addr)
 
@@ -129,7 +129,7 @@ func (s *Discovery) Register(addr string) error {
 	return nil
 }
 
-// CreateCluster returns a unique cluster token
+// CreateCluster returns a unique cluster token.
 func (s *Discovery) CreateCluster() (string, error) {
 	resp, err := http.Post(fmt.Sprintf("%s/%s", s.url, "clusters"), "", nil)
 	if err != nil {

--- a/scheduler/filter/constraint_test.go
+++ b/scheduler/filter/constraint_test.go
@@ -70,7 +70,7 @@ func TestConstraintFilter(t *testing.T) {
 	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:does_not_exist==true"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.Error(t, err)
 
-	// Set a contraint that can only be filled by a single node.
+	// Set a constraint that can only be filled by a single node.
 	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"constraint:name==node1"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)

--- a/scheduler/filter/dependency.go
+++ b/scheduler/filter/dependency.go
@@ -12,12 +12,12 @@ import (
 type DependencyFilter struct {
 }
 
-// Name returns the name of the filter
+// Name returns the name of the filter.
 func (f *DependencyFilter) Name() string {
 	return "dependency"
 }
 
-// Filter is exported
+// Filter is exported.
 func (f *DependencyFilter) Filter(config *cluster.ContainerConfig, nodes []*node.Node, _ bool) ([]*node.Node, error) {
 	if len(nodes) == 0 {
 		return nodes, nil
@@ -71,13 +71,13 @@ func (f *DependencyFilter) GetFilters(config *cluster.ContainerConfig) ([]string
 	return dependencies, nil
 }
 
-// Get a string representation of the dependencies found in the container config.
+// String gets a string representation of the dependencies found in the container config.
 func (f *DependencyFilter) String(config *cluster.ContainerConfig) string {
 	dependencies, _ := f.GetFilters(config)
 	return strings.Join(dependencies, " ")
 }
 
-// Ensure that the node contains all dependent containers.
+// check ensures that the node contains all dependent containers.
 func (f *DependencyFilter) check(dependencies []string, node *node.Node) bool {
 	for _, dependency := range dependencies {
 		if node.Container(dependency) == nil {

--- a/scheduler/filter/filter.go
+++ b/scheduler/filter/filter.go
@@ -13,16 +13,16 @@ import (
 type Filter interface {
 	Name() string
 
-	// Return a subset of nodes that were accepted by the filtering policy.
+	// Filter returns a subset of nodes that were accepted by the filtering policy.
 	Filter(*cluster.ContainerConfig, []*node.Node, bool) ([]*node.Node, error)
 
-	// Return a list of constraints/filters provided
+	// GetFilters returns a list of constraints/filters provided.
 	GetFilters(*cluster.ContainerConfig) ([]string, error)
 }
 
 var (
 	filters []Filter
-	// ErrNotSupported is exported
+	// ErrNotSupported is exported.
 	ErrNotSupported = errors.New("filter not supported")
 )
 
@@ -38,7 +38,7 @@ func init() {
 	}
 }
 
-// New is exported
+// New is exported.
 func New(names []string) ([]Filter, error) {
 	var selectedFilters []Filter
 
@@ -79,7 +79,7 @@ func ApplyFilters(filters []Filter, config *cluster.ContainerConfig, nodes []*no
 	return candidates, nil
 }
 
-// listAllFilters creates a string containing all applied filters
+// listAllFilters creates a string containing all applied filters.
 func listAllFilters(filters []Filter, config *cluster.ContainerConfig, lastFilter string) string {
 	allFilters := ""
 	for _, filter := range filters {
@@ -94,7 +94,7 @@ func listAllFilters(filters []Filter, config *cluster.ContainerConfig, lastFilte
 	return allFilters
 }
 
-// List returns the names of all the available filters
+// List returns the names of all the available filters.
 func List() []string {
 	names := []string{}
 

--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -42,6 +42,25 @@ function teardown() {
 	[ "${#lines[@]}" -eq 2 ]
 }
 
+# docker network ls --filter node returns networks that are present on a specific node
+@test "docker network ls --filter node" {
+	# docker network ls --filter type is introduced in docker 1.10, skip older version without --filter type
+	run docker --version
+	if [[ "${output}" != "Docker version 1.1"* ]]; then
+		skip
+	fi
+
+	start_docker 2
+	swarm_manage
+
+	run docker_swarm network ls --filter node=node-0
+	[ "${#lines[@]}" -eq 4 ]
+
+	run docker_swarm network ls --filter node=node-1
+	[ "${#lines[@]}" -eq 4 ]
+}
+
+
 @test "docker network inspect" {
 	# Docker 1.12 client shows "Attachable" and "Created" fields while docker daemon 1.12
 	# doesn't return them. Network inspect from Swarm is different from daemon.

--- a/test/integration/api/volume.bats
+++ b/test/integration/api/volume.bats
@@ -15,13 +15,13 @@ function teardown() {
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 1 ]
 
-	# run
-	docker_swarm run -d -v=/tmp busybox true
+	# run on node-0
+	docker_swarm run -e constraint:node==node-0 -d -v=/tmp busybox true
 
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 2 ]
 
-	docker_swarm run -d -v=/tmp busybox true
+	docker_swarm run -e constraint:node==node-0 -d -v=/tmp busybox true
 
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 3 ]
@@ -36,6 +36,17 @@ function teardown() {
 	[ "${#lines[@]}" -eq 3 ] 
 	[[ "${lines[1]}" == *"testsubstrvol"* ]]
 	[[ "${lines[2]}" == *"testsubstrvol"* ]]
+
+	# filter for node-specific volumes
+	# node-0 should have three volumes
+	run docker_swarm volume ls --filter node=node-0
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 4 ] 
+
+	# node-1 should have one volume
+	run docker_swarm volume ls --filter node=node-1
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 2 ] 
 }
 
 @test "docker volume inspect" {

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -219,7 +219,15 @@ function start_docker() {
 
 	# Wait for the engines to be reachable.
 	for ((i=current; i < (current + instances); i++)); do
-		wait_until_reachable "${HOSTS[$i]}"
+		run wait_until_reachable "${HOSTS[$i]}"
+		if [[ "$status" -eq 0 ]] ; then
+			continue
+		fi
+		run docker_host inspect "${DOCKER_CONTAINERS[$i]}"
+		echo "$output"
+		run docker_host logs "${DOCKER_CONTAINERS[$i]}"
+		echo "$output"
+		false
 	done
 }
 


### PR DESCRIPTION
It's very useful to list and remove non used docker images. We  always run

```
docker images -q -a -f dangling=true
```

but when using docker swarm, we notice that there is no logic to handle dangling filter for docker images. And it also indicates that the behavior of docker api and docker swarm api for listing images are different.

[docker images api](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-images)

This is PR to fix the issue and keep the same behavior with docker engine. 
[docker/daemon/images.go](https://github.com/docker/docker/blob/master/daemon/images.go#L41)
