### PR TITLE
Pass size parameter through on container inspect

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -486,6 +486,10 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 // GET /containers/{name:.*}/json
 func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
+	sizeQuery := ""
+	if boolValue(r, "size") {
+		sizeQuery = "?size=1"
+	}
 	container := c.cluster.Container(name)
 	if container == nil {
 		httpError(w, fmt.Sprintf("No such container %s", name), http.StatusNotFound)
@@ -503,7 +507,7 @@ func getContainerJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := client.Get(scheme + "://" + container.Engine.Addr + "/containers/" + container.ID + "/json")
+	resp, err := client.Get(scheme + "://" + container.Engine.Addr + "/containers/" + container.ID + "/json" + sizeQuery)
 	container.Engine.CheckConnectionErr(err)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
This change passes the size parameter through on container
inspect requests.

Signed-off-by: Daniel Hiltgen daniel.hiltgen@docker.com