### PR TITLE
Reduce CPU usage

### DIFF
--- a/scheduler/filter/expr.go
+++ b/scheduler/filter/expr.go
@@ -77,7 +77,6 @@ func (e *expr) Match(whats ...string) bool {
 	var (
 		pattern string
 		match   bool
-		err     error
 	)
 
 	if e.value[0] == '/' && e.value[len(e.value)-1] == '/' {
@@ -88,12 +87,16 @@ func (e *expr) Match(whats ...string) bool {
 		pattern = "^" + strings.Replace(e.value, "*", ".*", -1) + "$"
 	}
 
-	for _, what := range whats {
-		if match, err = regexp.MatchString(pattern, what); match {
-			break
-		} else if err != nil {
-			log.Error(err)
+	re, err := regexp.Compile(pattern)
+	if err == nil {
+		for _, what := range whats {
+			if match = re.MatchString(what); match {
+				break
+			}
 		}
+	} else {
+		match = false
+		log.Error(err)
 	}
 
 	switch e.operator {


### PR DESCRIPTION
In my case, I start 1000 goroutine to create container. I monitor the swarm find that it's CPU usage is very high, almost beyond 300%(equal to 3 core). Using golang profile message, we find that it's regular expressions `Compile`. This action cost much CPU and I fix this problem by reducing compile times.  Having this PR, CPU usage could reduce to 130%(equals to 1.3 core).

@allencloud @dongluochen @nishanttotla WDYT ?

Signed-off-by: Xianlu <xianlu.cxl@alibaba-inc.com>