### PR TITLE
Add instruction to upload binary in release

### DIFF
--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -13,6 +13,8 @@ git push $GITHUBUSER bump-<version>
 
 Open PR on docker/swarm. Merge the PR before moving to next step. If the release is an RC, then `CHANGELOG.md` should list the latest RC.
 
+If Go version is updated, please manually trigger `dockerswarm/swarm-test-env` build update at https://hub.docker.com/r/dockerswarm/swarm-test-env/~/dockerfile/. After successful build, Go version will be updated. This should be done whenever Go version is updated.
+
 ### 2. Rebase release branch on top of updated master branch and tag
 
 ```
@@ -73,4 +75,12 @@ Open PR on docker-library/official-images.
 
 ### 5. Create release on github
 
-Go to https://github.com/docker/swarm/releases/new use <tag> and changelog
+Go to https://github.com/docker/swarm/releases/new use <tag> and edit changelog.
+
+Upload Linux binary to the release. Copy the image built at docker/swarm-library-image.
+
+```
+tar czvf swarm-#tag#-linux-x86_64.tgz swarm
+```
+
+In the release page, upload swarm-#tag#-linux-x86_64.tgz.


### PR DESCRIPTION
Some users prefer not to run docker on manager nodes to reduce attack surface. Providing binary would help their deployment. 

Signed-off-by: Dong Chen dongluo.chen@docker.com
