### PR TITLE
fix event monitor restart failed

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -211,7 +211,6 @@ func (e *Engine) Connect(config *tls.Config) error {
 func (e *Engine) StartMonitorEvents() {
 	log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Debug("Start monitoring events")
 	ec := make(chan error)
-	e.eventsMonitor.Start(ec)
 
 	go func() {
 		if err := <-ec; err != nil {
@@ -223,6 +222,8 @@ func (e *Engine) StartMonitorEvents() {
 		}
 		close(ec)
 	}()
+
+	e.eventsMonitor.Start(ec)
 }
 
 // ConnectWithClient is exported


### PR DESCRIPTION
related issues: 
- #2309
- #2237 
- https://github.com/docker/swarm/issues/2108
- https://github.com/docker/swarm/issues/2495
- https://github.com/docker/swarm/issues/1937
- https://github.com/docker/swarm/issues/1468
- https://github.com/shipyard/shipyard/issues/728

In file `cluster/engine.go:208`, we make a channel named `ec` without size, and this will create an unbuffered channel.

So,  when `ec` receive an `"EOF"` error, that go func at line 210 will restart immediately, but may be will  block forever at `cluster/event_monitor.go:39`.

Just start the go func before `e.eventsMonitor.Start(ec)` will solve this issue.