### PR TITLE
Send Swarm logs to stdout

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,7 @@ func Run() {
 
 	// logs
 	app.Before = func(c *cli.Context) error {
-		log.SetOutput(os.Stderr)
+		log.SetOutput(os.Stdout)
 		level, err := log.ParseLevel(c.String("log-level"))
 		if err != nil {
 			log.Fatalf(err.Error())

--- a/test/integration/discovery/discovery_helpers.bash
+++ b/test/integration/discovery/discovery_helpers.bash
@@ -9,7 +9,8 @@ function discovery_check_swarm_info_empty() {
 
 # Returns true if all nodes have joined the discovery.
 function discovery_check_swarm_list() {
-	local joined=`swarm list "$1" | wc -l`
+	# IPv4 address is used in this test. use relative matching
+	local joined=`swarm list "$1" | egrep '(([0-9]{1,3})\.){3}([0-9]{1,3}):[0-9]+' | wc -l`
 	local total="$2"
 	[ -z "$total" ] && total="${#HOSTS[@]}"
 


### PR DESCRIPTION
Fix #2546. 

Need to include this in release log in case users are getting logs from `stderr`. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>