### PR TITLE
Add a node whitelist filter

### DIFF
--- a/scheduler/filter/filter.go
+++ b/scheduler/filter/filter.go
@@ -34,6 +34,7 @@ func init() {
 		&DependencyFilter{},
 		&AffinityFilter{},
 		&ConstraintFilter{},
+		&WhitelistFilter{},
 	}
 }
 

--- a/scheduler/filter/whitelist.go
+++ b/scheduler/filter/whitelist.go
@@ -1,0 +1,71 @@
+package filter
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/scheduler/node"
+)
+
+// WhitelistFilter selects only nodes that are defined in a whitelist by the user
+type WhitelistFilter struct {
+}
+
+// Name returns the name of the filter
+func (f *WhitelistFilter) Name() string {
+	return "whitelist"
+}
+
+// Filter is exported
+func (f *WhitelistFilter) Filter(config *cluster.ContainerConfig, nodes []*node.Node, soft bool) ([]*node.Node, error) {
+	whitelists, err := parseExprs(config.Whitelists())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, whitelist := range whitelists {
+		if !soft && whitelist.isSoft {
+			continue
+		}
+		log.Debugf("matching whitelist: %s%s%s (soft=%t)", whitelist.key, OPERATORS[whitelist.operator], whitelist.value, whitelist.isSoft)
+
+		candidates := []*node.Node{}
+
+		// Handle |-separated node names in the same whitelist
+		whiteNodes := strings.Split(whitelist.value, "|")
+
+		for _, node := range nodes {
+			switch whitelist.key {
+			// Treat all keys as "node name" keys
+			default:
+				for _, whiteNode := range whiteNodes {
+					if node.Name == whiteNode {
+						candidates = append(candidates, node)
+						break
+					}
+				}
+			}
+		}
+		if len(candidates) == 0 {
+			return nil, fmt.Errorf("unable to find a node that satisfies the whitelist %s%s%s", whitelist.key, OPERATORS[whitelist.operator], whitelist.value)
+		}
+		nodes = candidates
+	}
+
+	return nodes, nil
+}
+
+// GetFilters returns a list of the whitelists found in the container config.
+func (f *WhitelistFilter) GetFilters(config *cluster.ContainerConfig) ([]string, error) {
+	allWhitelists := []string{}
+	whitelists, err := parseExprs(config.Whitelists())
+	if err != nil {
+		return nil, err
+	}
+	for _, whitelist := range whitelists {
+		allWhitelists = append(allWhitelists, fmt.Sprintf("%s%s%s (soft=%t)", whitelist.key, OPERATORS[whitelist.operator], whitelist.value, whitelist.isSoft))
+	}
+	return allWhitelists, nil
+}

--- a/scheduler/filter/whitelist_test.go
+++ b/scheduler/filter/whitelist_test.go
@@ -1,0 +1,60 @@
+package filter
+
+import (
+	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarm/scheduler/node"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhitelistFilter(t *testing.T) {
+	var (
+		f      = WhitelistFilter{}
+		nodes  = testFixtures() // Reuse the same fixtures as the constraint test
+		result []*node.Node
+		err    error
+	)
+
+	// Without a whitelist we should get all nodes back
+	result, err = f.Filter(&cluster.ContainerConfig{}, nodes, true)
+	assert.NoError(t, err)
+	assert.Equal(t, result, nodes)
+
+	// Set a multi-node whitelist that cannot be fulfilled and expect an error back.
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"whitelist:node==node-5-name|node-6-name|node-7-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
+	assert.Error(t, err)
+
+	// Set a single-node whitelist that cannot be fulfilled and expect an error back.
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"whitelist:node==node-5-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
+	assert.Error(t, err)
+
+	// Set a single-node whitelist that can be fulfilled
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"whitelist:node==node-1-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, result[0], nodes[1])
+
+	// Set a multi-node whitelist where all nodes can be fulfilled
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"whitelist:node==node-1-name|node-2-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.NotContains(t, result, nodes[0])
+	assert.NotContains(t, result, nodes[3])
+
+	// Set a multi-node whitelist where only some of the nodes can be fulfilled
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"whitelist:node==node-1-name|node-2-name|node-5-name|node-6-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.NotContains(t, result, nodes[0])
+	assert.NotContains(t, result, nodes[3])
+
+	// Make sure we only the intersection of multiple whitelists can be fulfilled
+	result, err = f.Filter(cluster.BuildContainerConfig(containertypes.Config{Env: []string{"whitelist:node==node-0-name|node-1-name|node-2-name", "whitelist:node==node-1-name|node-2-name|node-3-name"}}, containertypes.HostConfig{}, networktypes.NetworkingConfig{}), nodes, true)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.NotContains(t, result, nodes[0])
+	assert.NotContains(t, result, nodes[3])
+}


### PR DESCRIPTION
This PR adds support for a new scheduling filter that selects candidates based on a provided list of nodes, effectively implementing a "whitelist". This is meant to cover use cases where setting engine labels may not be practical.

The usage is currently implemented as `-e whitelist:node==node-1-name|node-2-name|node-3-name`, and I am definitely open to suggestions for a better UX.

A similar approach that is available today is to use a series of `constraint:name!=<name>` constraints to implement a "blacklist" of nodes. However, that method is not equivalent to a whitelist filter during rescheduling.