### PR TITLE
disable network inspect test for docker 1.12

### DIFF
--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -43,6 +43,13 @@ function teardown() {
 }
 
 @test "docker network inspect" {
+	# Docker 1.12 client shows "Attachable" and "Created" fields while docker daemon 1.12
+	# doesn't return them. Network inspect from Swarm is different from daemon.
+	run docker --version
+	if [[ "${output}" == "Docker version 1.12"* ]]; then
+		skip
+	fi
+
 	start_docker_with_busybox 2
 	swarm_manage
 

--- a/test/integration/mesos/api/network.bats
+++ b/test/integration/mesos/api/network.bats
@@ -20,6 +20,13 @@ function teardown() {
 }
 
 @test "mesos - docker network inspect" {
+	# Docker 1.12 client shows "Attachable" and "Created" fields while docker daemon 1.12
+	# doesn't return them. Network inspect from Swarm is different from daemon.
+	run docker --version
+	if [[ "${output}" == "Docker version 1.12"* ]]; then
+		skip
+	fi
+
 	start_docker_with_busybox 2
 	start_mesos
 	swarm_manage


### PR DESCRIPTION
In Docker 1.12, docker client would accept `Attachable` and `Created` fields from network inspect, but docker daemon doesn't send out these fields. Swarm doesn't differentiate request client version (it'd get into maintenance nightmare). So `network inspect` from Swarm and from daemon would have difference. There is not much value to fix it in Docker or Swarm. 

```
# ======= docker swarm version =======
# time="2016-12-05T22:32:10Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/version" 
# Client: Version: 1.12.3 API version: 1.24 Go version: go1.6.3 Git commit: 6b644ec Built: Wed Oct 26 23:26:11 2016 OS/Arch: linux/amd64 Server: Version: swarm/1.2.5 API version: 1.22 Go version: go1.7.1 Git commit: HEAD Built: <unknown> OS/Arch: linux/amd64 Experimental: true

# ======= docker_swarm network inspect node-0/bridge =======
# time="2016-12-05T22:32:10Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/networks/node-0/bridge" 
# [ { "Name": "bridge", "Id": "003bed68452df39de04682314103d054bd6a5a87957977225736c9a48413993f", "Created": "0001-01-01T00:00:00Z", "Scope": "local", "Driver": "bridge", "EnableIPv6": false, "IPAM": { "Driver": "default", "Options": null, "Config": [ { "Subnet": "172.18.0.0/16", "Gateway": "172.18.0.1" } ] }, "Internal": false, "Attachable": false, "Containers": { "269e32a6525dec428a71a2e1238eb12ee3c05fa49658901f68da7f135de60266": { "Name": "grave_meninsky", "EndpointID": "20619d0f4de1b48552dc611363f6c2f5022d11c47c2ff5414b597fed3848d209", "MacAddress": "02:42:ac:12:00:02", "IPv4Address": "172.18.0.2/16", "IPv6Address": "" } }, "Options": { "com.docker.network.bridge.default_bridge": "true", "com.docker.network.bridge.enable_icc": "true", "com.docker.network.bridge.enable_ip_masquerade": "true", "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0", "com.docker.network.bridge.name": "docker0", "com.docker.network.driver.mtu": "1500" }, "Labels": {} } ]

# ======= docker -H 127.0.0.1:5757 network inspect bridge =======
# [ { "Name": "bridge", "Id": "003bed68452df39de04682314103d054bd6a5a87957977225736c9a48413993f", "Scope": "local", "Driver": "bridge", "EnableIPv6": false, "IPAM": { "Driver": "default", "Options": null, "Config": [ { "Subnet": "172.18.0.0/16", "Gateway": "172.18.0.1" } ] }, "Internal": false, "Containers": { "269e32a6525dec428a71a2e1238eb12ee3c05fa49658901f68da7f135de60266": { "Name": "grave_meninsky", "EndpointID": "20619d0f4de1b48552dc611363f6c2f5022d11c47c2ff5414b597fed3848d209", "MacAddress": "02:42:ac:12:00:02", "IPv4Address": "172.18.0.2/16", "IPv6Address": "" } }, "Options": { "com.docker.network.bridge.default_bridge": "true", "com.docker.network.bridge.enable_icc": "true", "com.docker.network.bridge.enable_ip_masquerade": "true", "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0", "com.docker.network.bridge.name": "docker0", "com.docker.network.driver.mtu": "1500" }, "Labels": {} } ]
# time="2016-12-05T22:32:10Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/networks/node-0/bridge" 

# 5d4
# <         "Created": "0001-01-01T00:00:00Z",
# 20d18
# <         "Attachable": false,
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>