### PR TITLE
Fix nodemanagement/connection.bats

### DIFF
--- a/test/integration/nodemanagement/connection.bats
+++ b/test/integration/nodemanagement/connection.bats
@@ -23,13 +23,13 @@ function teardown() {
 	# run most common container operations
 	for((i=0; i<30; i++)); do
 		# test postContainerCreate
-		docker_swarm run --name="hello$i" hello-world
+		run docker_swarm run --name="hello$i" hello-world
 		# test getContainerJSON
-		docker_swarm inspect "hello$i"
+		run docker_swarm inspect "hello$i"
 		# test proxyContainer
-		docker_swarm logs "hello$i"
+		run docker_swarm logs "hello$i"
 		# test proxyContainerAndForceRefresh
-		docker_swarm stop "hello$i"
+		run docker_swarm rm -f "hello$i"
 	done
 
 	# get connection count


### PR DESCRIPTION
The test on master has following error where connection to a daemon is stuck. I cannot reproduce it with a real test cluster. I suspect `dind` has some side effects here. Adding `run` in commands seems to resolve it. 

```
# time="2016-12-02T19:24:26Z" level=debug msg="HTTP request received" method=GET uri="/v1.24/events?filters=%7B%22container%22%3A%7B%22b6cd9fab2ac305689cc1ad697e129e126ef419f26405312e4506853a8adea605%22%3Atrue%7D%2C%22type%22%3A%7B%22container%22%3Atrue%7D%7D" 
# time="2016-12-02T19:24:26Z" level=error msg="error getting events from daemon: EOF" 
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>