### PR TITLE
Fix api_version test

### DIFF
--- a/test/integration/api_version.bats
+++ b/test/integration/api_version.bats
@@ -17,15 +17,15 @@ function teardown() {
 	out=$(docker -H "${HOSTS[0]}" version)	
 
 	# Check client version
-	run bash -c "echo '$out' | grep -i version | grep -v Go | grep -v API | grep -v Minimum"
+	run bash -c "echo '$out' | egrep -i '^\s*Version'"
 	[ "$status" -eq 0 ]
 
-	[[ $(echo "${lines[0]}" | cut -d':' -f2 | tr -d '[:space:]') == $(echo "${lines[1]}" | cut -d':' -f2 | tr -d '[:space:]') ]]
+	[[ $(echo "${lines[0]}" | cut -d':' -f2 | awk -F' ' '{print $1}')  == $(echo "${lines[1]}" | cut -d':' -f2 | awk -F' ' '{print $1}') ]]
 
 	# Check API version
-	run bash -c "echo '$out' | grep -i version | grep -v Minimum | grep API"
+	run bash -c "echo '$out' | egrep -i '^\s*API version:'"
 	[ "$status" -eq 0 ]
 
-	[[ $(echo "${lines[0]}" | cut -d':' -f2 | tr -d '[:space:]') == $(echo "${lines[1]}" | cut -d':' -f2 | tr -d '[:space:]') ]]
+	[[ $(echo "${lines[0]}" | cut -d':' -f2 | awk -F' ' '{print $1}')  == $(echo "${lines[1]}" | cut -d':' -f2 | awk -F' ' '{print $1}') ]]
 
 }


### PR DESCRIPTION
In Docker 1.13, CLI output for API version is changed from `API version:  1.24` to `API version:  1.25 (minimum version 1.12)`. The API version test needs update. 

```
~$ docker version
Client:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   23cf638
 Built:        Thu Aug 18 17:52:38 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   23cf638
 Built:        Thu Aug 18 17:52:38 2016
 OS/Arch:      linux/amd64
```


```
~$ docker version
Client:
 Version:      1.13.0-rc4
 API version:  1.25
 Go version:   go1.7.3
 Git commit:   88862e7
 Built:        Sat Dec 17 01:34:17 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.13.0-rc4
 API version:  1.25 (minimum version 1.12)
 Go version:   go1.7.3
 Git commit:   88862e7
 Built:        Sat Dec 17 01:34:17 2016
 OS/Arch:      linux/amd64
 Experimental: false
```
Signed-off-by: Dong Chen <dongluo.chen@docker.com>