### PR TITLE
Handle event monitor errors at engine.go

### DIFF
--- a/cluster/event_monitor.go
+++ b/cluster/event_monitor.go
@@ -1,8 +1,6 @@
 package cluster
 
 import (
-	"io"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/swarm/swarmclient"
@@ -38,10 +36,6 @@ func (em *EventsMonitor) Start(ec chan error) {
 					return
 				}
 			case err := <-errStream:
-				if err == io.EOF {
-					ec <- nil
-					return
-				}
 				ec <- err
 				return
 			case <-em.stopChan:

--- a/cluster/event_monitor.go
+++ b/cluster/event_monitor.go
@@ -25,9 +25,11 @@ func NewEventsMonitor(cli swarmclient.SwarmAPIClient, handler func(msg events.Me
 // Start starts the EventsMonitor
 func (em *EventsMonitor) Start(ec chan error) {
 	em.stopChan = make(chan struct{})
-	responseStream, errStream := em.cli.Events(context.Background(), types.EventsOptions{})
+	ctx, cancel := context.WithCancel(context.Background())
+	responseStream, errStream := em.cli.Events(ctx, types.EventsOptions{})
 
 	go func() {
+		defer cancel()
 		for {
 			select {
 			case event := <-responseStream:


### PR DESCRIPTION
Fix #2581. Currently there could be multiple goroutines running `(*EventsMonitor).Start` for an engine and they introduce data race. There should be only 1 `EventsMonitor` goroutine for an engine.

`EOF` from Engine event stream is an Engine issue. Swarm needs to restart event monitor. This retry logic is in cluster/engine.go `StartMonitorEvents()`. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>