### PR TITLE
Remove dependency on IPv4 addresses

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -178,7 +178,7 @@ func (e *Engine) Connect(config *tls.Config) error {
 		return err
 	}
 
-	addr, err := net.ResolveIPAddr("ip4", host)
+	addr, err := net.ResolveIPAddr("ip", host)
 	if err != nil {
 		return err
 	}

--- a/scheduler/filter/port.go
+++ b/scheduler/filter/port.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/swarm/cluster"
@@ -151,5 +152,6 @@ func (p *PortFilter) GetFilters(config *cluster.ContainerConfig) ([]string, erro
 }
 
 func bindsAllInterfaces(binding nat.PortBinding) bool {
-	return binding.HostIP == "0.0.0.0" || binding.HostIP == ""
+	ip := net.ParseIP(binding.HostIP)
+	return binding.HostIP == "" || (ip != nil && ip.IsUnspecified())
 }


### PR DESCRIPTION
Fix #2503. 

`Connect()` in cluster/engine.go only resolves to IPv4 address. We should remove dependency on IP address family. 

```
addr, err := net.ResolveIPAddr("ip4", host)
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>