### PR TITLE
Support more filters in network list operations

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -277,7 +277,7 @@ func getNetworks(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := []*apitypes.NetworkResource{}
-	networks := c.cluster.Networks().Filter(filters.Get("name"), filters.Get("id"), types)
+	networks := c.cluster.Networks().Filter(filters)
 	for _, network := range networks {
 		tmp := (*network).NetworkResource
 		if tmp.Scope == "local" {


### PR DESCRIPTION
This is necessary when doing `docker stack rm` in Docker 1.13+ engines, because
the CLI client deletes networks by doing a network list call with a label
filter and then deleting everything that gets returned. If you do this against
Swarm, then you wind up deleting all of your networks.

Signed-off-by: Wayne Song <wsong@docker.com>