### PR TITLE
Add support for the name filter when listing volumes

### DIFF
--- a/test/integration/api/volume.bats
+++ b/test/integration/api/volume.bats
@@ -25,6 +25,17 @@ function teardown() {
 
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 3 ]
+
+	# create a named volume on all nodes to test --filter
+	docker_swarm volume create --name=testsubstrvol
+
+	# filter for a named volume using a name substring
+	run docker_swarm volume ls --filter name=substr
+	[ "$status" -eq 0 ]
+	# expect 3 lines: the header and one volume per node
+	[ "${#lines[@]}" -eq 3 ] 
+	[[ "${lines[1]}" == *"testsubstrvol"* ]]
+	[[ "${lines[2]}" == *"testsubstrvol"* ]]
 }
 
 @test "docker volume inspect" {


### PR DESCRIPTION
This PR enables the `name` filter in the `/volumes` API endpoint. The implementation works in accordance to that of the daemon itself:
- Volumes are matched if any substring of the volume name matches the filter
- When multiple `name` filters are provided, each result must match at least one of them. 

Signed-off-by: Alex Mavrogiannis <alex.mavrogiannis@docker.com>