### PR TITLE
Avoid concurrent write on http.ResponseWriter

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -846,14 +846,12 @@ func getEvents(c *context, w http.ResponseWriter, r *http.Request) {
 		until = u
 	}
 
-	c.eventsHandler.Add(r.RemoteAddr, w)
-
 	w.Header().Set("Content-Type", "application/json")
-
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}
 
+	c.eventsHandler.Add(r.RemoteAddr, w)
 	c.eventsHandler.Wait(r.RemoteAddr, until)
 }
 


### PR DESCRIPTION
Fix #2598. 

`api.getEvents()` should finish writing HTTP header to http.ResponseWriter before adding it to `c.eventsHandler`. Otherwise race on writing may occur. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>