### PR TITLE
Use the network name instead of the ID if it was passed in during disconnects

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1036,6 +1036,13 @@ func networkDisconnect(c *context, w http.ResponseWriter, r *http.Request) {
 		httpError(w, fmt.Sprintf("No such network: %s", networkid), http.StatusNotFound)
 		return
 	}
+	// If the incoming request used the network's name instead of the ID,
+	// make the request to the daemon with the network's name as well.
+	if strings.Contains(networkid, network.Name) {
+		networkid = network.Name
+	} else {
+		networkid = network.ID
+	}
 
 	// make a copy of r.Body
 	buf, _ := ioutil.ReadAll(r.Body)
@@ -1062,7 +1069,7 @@ func networkDisconnect(c *context, w http.ResponseWriter, r *http.Request) {
 	// then try a random engine if we can't connect to that engine. We
 	// try the associated engine first because on 1.12+ clusters, the
 	// network may not be known on all nodes.
-	err := engine.NetworkDisconnect(container, network, disconnect.Force)
+	err := engine.NetworkDisconnect(container, networkid, disconnect.Force)
 	if err != nil {
 		if cluster.IsConnectionError(err) && disconnect.Force && network.Scope == "global" {
 			log.Warnf("Could not connect to engine %s: %s, trying to disconnect %s from %s on a random engine", engine.Name, err, disconnect.Container, network.Name)
@@ -1072,7 +1079,7 @@ func networkDisconnect(c *context, w http.ResponseWriter, r *http.Request) {
 				httpError(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			err = randomEngine.NetworkDisconnect(container, network, disconnect.Force)
+			err = randomEngine.NetworkDisconnect(container, networkid, disconnect.Force)
 			if err != nil {
 				httpError(w, err.Error(), http.StatusInternalServerError)
 			}

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -1400,8 +1400,8 @@ func (e *Engine) TagImage(IDOrName string, ref string, force bool) error {
 }
 
 // NetworkDisconnect disconnects a container from a network
-func (e *Engine) NetworkDisconnect(container *Container, network *Network, force bool) error {
-	err := e.apiClient.NetworkDisconnect(context.Background(), network.ID, container.ID, force)
+func (e *Engine) NetworkDisconnect(container *Container, network string, force bool) error {
+	err := e.apiClient.NetworkDisconnect(context.Background(), network, container.ID, force)
 	e.CheckConnectionErr(err)
 	if err != nil {
 		return err


### PR DESCRIPTION
If you try to disconnect a container from a network before that container was
started, it'll fail unless you use the network's name. This is because the
container isn't marked as connected to the network via ID until it's actually
started; until then, the daemon only keeps track of the network name as it
relates to the container.