### PR TITLE
fix /event response stop immediately

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -39,7 +39,14 @@ func (eh *eventsHandler) Add(remoteAddr string, w io.Writer) {
 func (eh *eventsHandler) Wait(remoteAddr string, until int64) {
 
 	timer := time.NewTimer(0)
-	timer.Stop()
+
+	// Based on issue https://github.com/golang/go/issues/14383.
+	// If timer has already expired, `time.Stop` will return false.
+	// And we have to drain the channel manually.
+	if !timer.Stop() {
+		<-timer.C
+	}
+
 	if until > 0 {
 		dur := time.Unix(until, 0).Sub(time.Now())
 		timer = time.NewTimer(dur)


### PR DESCRIPTION
Swarm /events API may be will stop immediately at sometime.

After digging these codes I found that we should be carefully to stop a timer. A timer maybe has already expired, even the duration is zero.

We can write an example to prove it:

```go
package main

import (
	"fmt"
	"time"
)

func main() {

	for i := 0; i < 100; i++ {
		go func(c int) {
			timer := time.NewTimer(0)
			if !timer.Stop() {
				fmt.Printf("Timer stop failed at, %d\n", c)
			}
		}(i)
	}
}
```

Save as `timerTest.go` and `go run` with it:

```bash
[realityone@rEimu ~/Desktop]$ go run timerTest.go 
Timer stop failed at, 27
[realityone@rEimu ~/Desktop]$ go run timerTest.go 
Timer stop failed at, 41
[realityone@rEimu ~/Desktop]$ go run timerTest.go 
Timer stop failed at, 32
Timer stop failed at, 1
Timer stop failed at, 62
[realityone@rEimu ~/Desktop]$ go run timerTest.go 
Timer stop failed at, 13
Timer stop failed at, 57
Timer stop failed at, 83
[realityone@rEimu ~/Desktop]$ 
```

So we have to check the `timer.Stop` return value and drain the channel manually.

Signed-off-by: realityone <realityone@me.com>