### PR TITLE
fix swarm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/github.com/docker/swarm
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
 	git \
-	&& GOARCH=$GOARCH GOOS=$GOOS CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags '-w -X "github.com/docker/swarm/version.GITCOMMIT=`git rev-parse --short HEAD`" -X "github.com/docker/swarm/version.BUILDTIME=`date -u`"'  \
+	&& GOARCH=$GOARCH GOOS=$GOOS CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-w -X github.com/docker/swarm/version.GITCOMMIT=$(git rev-parse --short HEAD) -X github.com/docker/swarm/version.BUILDTIME=$(date -u +%FT%T%z)"  \
 	&& apk del .build-deps
 
 ENV SWARM_HOST :2375


### PR DESCRIPTION
Fix #2597.

```
swarm$ docker build .
...
Successfully built a6c95b047c5d

swarm$ docker run a6c95b047c5d --version
swarm version 1.2.6 (27bd3a1)
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>