### PR TITLE
Gracefully handle container removal after start

### DIFF
--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -186,7 +186,7 @@ func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *dockerclient.HostConfig) error {
 	// if the container was started less than a second ago in detach mode, do not start it
 	if time.Now().Unix()-container.Created > 1 || container.Config.Labels[cluster.SwarmLabelNamespace+".mesos.detach"] != "true" {
-		return container.Engine.StartContainer(container.ID, hostConfig)
+		return container.Engine.StartContainer(container, hostConfig)
 	}
 	return nil
 }

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -141,7 +141,7 @@ func (c *Cluster) generateUniqueID() string {
 
 // StartContainer starts a container
 func (c *Cluster) StartContainer(container *cluster.Container, hostConfig *dockerclient.HostConfig) error {
-	return container.Engine.StartContainer(container.ID, hostConfig)
+	return container.Engine.StartContainer(container, hostConfig)
 }
 
 // CreateContainer aka schedule a brand new container into the cluster.

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -26,6 +26,15 @@ function teardown() {
 	[[ "${output}" == *"cannot specify 64-byte hexadecimal strings"* ]]
 }
 
+@test "docker run with autoremove" {
+	start_docker_with_busybox 2
+	swarm_manage
+
+	# run with --rm
+	docker_swarm run --rm busybox echo hello
+	[ "$status" -eq 0 ]
+}
+
 @test "docker run with image digest" {
 	start_docker 2
 	swarm_manage


### PR DESCRIPTION
When a client uses the v1.25 API version to create a container with the `--rm` flag, the removal of the container is expected to occur server-side, rather than client-side. If a short-lived container is used, then the handler of the `ContainerStart` operation may hit a `Container Not Found` error while attempting to refresh containers.

A very easy repro for this is the following:
```
$ docker run --rm busybox echo hello
docker: Error response from daemon: Error: No such container: 72d5403456de362e8a15fdd6b25f2a17e39559b75119776985075cd
```

In this PR, I suggest a silent cache cleanup as a workaround for this issue.
Some potential enhancements could be:
- Use the `engineapi/types/container/host_config` field which includes the AutoRemove field and detect its use
- Also check if the version is 1.25 or higher.

However, I think that this proposal also accounts for a race condition that is present in older versions where one swarm client could issue a `ContainerStart` while a sideband daemon client would perform a `ContainerRemove` on that container immediately after it's started. Since the time interval is pretty thin, that's very unlikely to happen without some network-originating service interruptions

Signed-off-by: Alex Mavrogiannis <alex.mavrogiannis@docker.com>