### PR TITLE
add nc command to validate zookeeper running status

### DIFF
--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -4,7 +4,7 @@
 FROM dockerswarm/dind:1.9.0
 
 # Install dependencies.
-RUN apt-get update && apt-get install -y --no-install-recommends git file parallel \
+RUN apt-get update && apt-get install -y --no-install-recommends git file parallel netcat \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install golang


### PR DESCRIPTION
There is race condition in test that docker nodes try to join before zookeeper starts. See #2575. Add `nc` to validate zookeeper running with following command.

```
$ echo ruok | nc 127.0.0.1 5111
imok
```

cc @vieux.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>