### PR TITLE
fix warnings found by go vet

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -110,7 +110,7 @@ func (eh *eventsHandler) Handle(e *cluster.Event) error {
 	eh.RLock()
 
 	for key, w := range eh.ws {
-		if _, err := fmt.Fprintf(w, string(data)); err != nil {
+		if _, err := fmt.Fprint(w, string(data)); err != nil {
 			// collect them to handle later under Lock
 			failed = append(failed, key)
 			continue

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -48,7 +48,7 @@ func Run() {
 		log.SetOutput(os.Stderr)
 		level, err := log.ParseLevel(c.String("log-level"))
 		if err != nil {
-			log.Fatalf(err.Error())
+			log.Fatal(err.Error())
 		}
 		log.SetLevel(level)
 

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -502,7 +502,7 @@ func (e *Engine) updateSpecs() error {
 		e.state = statePending
 		message := fmt.Sprintf("Engine (ID: %s, Addr: %s) shows up with another ID:%s. Please remove it from cluster, it can be added back.", e.ID, e.Addr, info.ID)
 		e.lastError = message
-		return fmt.Errorf(message)
+		return errors.New(message)
 	}
 
 	// delta is an estimation of time difference between manager and engine
@@ -551,7 +551,7 @@ func (e *Engine) updateSpecs() error {
 		kv := strings.SplitN(label, "=", 2)
 		if len(kv) != 2 {
 			message := fmt.Sprintf("Engine (ID: %s, Addr: %s) contains an invalid label (%s) not formatted as \"key=value\".", e.ID, e.Addr, label)
-			return fmt.Errorf(message)
+			return errors.New(message)
 		}
 
 		// If an engine managed by Swarm contains a label with key "node",
@@ -575,7 +575,10 @@ func (e *Engine) updateSpecs() error {
 
 // RemoveImage deletes an image from the engine.
 func (e *Engine) RemoveImage(name string, force bool) ([]types.ImageDelete, error) {
-	rmOpts := types.ImageRemoveOptions{force, true}
+	rmOpts := types.ImageRemoveOptions{
+		Force:         force,
+		PruneChildren: true,
+	}
 	dels, err := e.apiClient.ImageRemove(context.Background(), name, rmOpts)
 	e.CheckConnectionErr(err)
 
@@ -673,7 +676,7 @@ func (e *Engine) refreshNetwork(ID string) error {
 
 // RefreshNetworks refreshes the list of networks on the engine.
 func (e *Engine) RefreshNetworks() error {
-	netLsOpts := types.NetworkListOptions{filters.NewArgs()}
+	netLsOpts := types.NetworkListOptions{Filters: filters.NewArgs()}
 	networks, err := e.apiClient.NetworkList(context.Background(), netLsOpts)
 	e.CheckConnectionErr(err)
 	if err != nil {


### PR DESCRIPTION
1.can't check non-constant format in call to Errorf
2.can't check non-constant format in call to Fatalf
3.can't check non-constant format in call to Fprintf
4.composite literal uses unkeyed fields

Signed-off-by: fugr <fugr2012@gmail.com>