### PR TITLE
Set timeouts in HTTP clients for connecting to engines

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -185,7 +185,7 @@ func (e *Engine) Connect(config *tls.Config) error {
 	e.IP = addr.IP.String()
 
 	// create the HTTP Client and URL
-	httpClient, url, err := NewHTTPClientTimeout("tcp://"+e.Addr, config, time.Duration(requestTimeout), nil)
+	httpClient, url, err := NewHTTPClientTimeout("tcp://"+e.Addr, config, time.Duration(requestTimeout))
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (e *Engine) Connect(config *tls.Config) error {
 	}
 
 	// Use HTTP Client used by dockerclient to create docker/api client
-	apiClient, err := engineapi.NewClient("tcp://"+e.Addr, "", c.HTTPClient, nil)
+	apiClient, err := engineapi.NewClient("tcp://"+e.Addr, "", e.httpClient, nil)
 	if err != nil {
 		return err
 	}

--- a/cluster/httpclient.go
+++ b/cluster/httpclient.go
@@ -2,46 +2,13 @@ package cluster
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
 	"net/url"
 	"time"
 )
 
-type tcpFunc func(*net.TCPConn, time.Duration) error
-
-func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration, setUserTimeout tcpFunc) *http.Client {
-	httpTransport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-
-	switch u.Scheme {
-	default:
-		httpTransport.Dial = func(proto, addr string) (net.Conn, error) {
-			conn, err := net.DialTimeout(proto, addr, timeout)
-			if tcpConn, ok := conn.(*net.TCPConn); ok && setUserTimeout != nil {
-				// Sender can break TCP connection if the remote side doesn't
-				// acknowledge packets within timeout
-				setUserTimeout(tcpConn, timeout)
-			}
-			return conn, err
-		}
-	case "unix":
-		socketPath := u.Path
-		unixDial := func(proto, addr string) (net.Conn, error) {
-			return net.DialTimeout("unix", socketPath, timeout)
-		}
-		httpTransport.Dial = unixDial
-		// Override the main URL object so the HTTP lib won't complain
-		u.Scheme = "http"
-		u.Host = "unix.sock"
-		u.Path = ""
-	}
-	return &http.Client{Transport: httpTransport}
-}
-
 // NewHTTPClientTimeout is used to create the HTTP Client and URL
-func NewHTTPClientTimeout(daemonURL string, tlsConfig *tls.Config, timeout time.Duration, setUserTimeout tcpFunc) (*http.Client, *url.URL, error) {
+func NewHTTPClientTimeout(daemonURL string, tlsConfig *tls.Config, timeout time.Duration) (*http.Client, *url.URL, error) {
 	u, err := url.Parse(daemonURL)
 	if err != nil {
 		return nil, nil, err
@@ -53,6 +20,11 @@ func NewHTTPClientTimeout(daemonURL string, tlsConfig *tls.Config, timeout time.
 			u.Scheme = "https"
 		}
 	}
-	httpClient := newHTTPClient(u, tlsConfig, timeout, setUserTimeout)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: timeout,
+	}
 	return httpClient, u, nil
 }


### PR DESCRIPTION
Previously, we were only using the timeouts in the Dial function of the HTTP
clients we use to connect to Docker engines. This means that if we can
successfully connect to a server but it hangs when it's processing a request,
we will never disconnect from that engine. This can result in the Swarm manager
using up all its file descriptors on an engine that can process HTTP requests
but which cannot return responses.