### PR TITLE
Fix bug: ports of pending containers are not filtered when scheduling

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -41,8 +41,9 @@ func (p *pendingContainer) ToContainer() *cluster.Container {
 		Config: p.Config,
 		Info: types.ContainerJSON{
 			ContainerJSONBase: &types.ContainerJSONBase{
-				HostConfig: &containertypes.HostConfig{},
+				HostConfig: &p.Config.HostConfig,
 			},
+			Config: &p.Config.Config,
 		},
 		Engine: p.Engine,
 	}


### PR DESCRIPTION
The port filter uses Info structure to identify the ports used by containers(Info.HostConfig.PortBindings, Info.NetworkSettings and Info.Config.ExposedPorts), but pending containers are initialized with empty Info. 

Signed-off-by: jimmycmh <menghui.chen@alibaba-inc.com>