### PR TITLE
[DO NOT MERGE] add docker group to temporary fix CI failure on docker master

### DIFF
--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -209,6 +209,7 @@ function start_docker() {
 				rm /var/run/docker.pid ; \
 				rm /var/run/docker/libcontainerd/docker-containerd.pid ; \ 
 				rm /var/run/docker/libcontainerd/docker-containerd.sock ; \
+				addgroup docker ; \
 				hostname node-$i && \
 				docker daemon -H 127.0.0.1:$port \
 					-H=unix:///var/run/docker.sock \


### PR DESCRIPTION
Fix #2646. When docker/docker fixes it in master https://github.com/docker/docker/issues/31788, this should be reverted. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>