### PR TITLE
data race from concurrent write/flush 

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -117,7 +117,7 @@ func (eh *eventsHandler) Handle(e *cluster.Event) error {
 
 	var failed []string
 
-	eh.RLock()
+	eh.Lock()
 
 	for key, w := range eh.ws {
 		if _, err := fmt.Fprint(w, string(data)); err != nil {
@@ -130,8 +130,6 @@ func (eh *eventsHandler) Handle(e *cluster.Event) error {
 			f.Flush()
 		}
 	}
-	eh.RUnlock()
-	eh.Lock()
 	if len(failed) > 0 {
 		for _, key := range failed {
 			if ch, ok := eh.cs[key]; ok {


### PR DESCRIPTION
Concurrent write/flush to http.ResponseWriter or http.Flusher would cause data race. This change sequentializes event processing. Normally this shouldn't be a performance bottleneck. If there are too many events, we could change this to batch processing, flush when there are no more events, or a small timer (20 milliseconds) expires. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>