### PR TITLE
Add node filters for network and volume lists

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -332,6 +332,7 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	names := filters.Get("name")
+	nodes := filters.Get("node")
 	for _, volume := range c.cluster.Volumes() {
 		// Check if the volume matches any name filters
 		found := false
@@ -341,6 +342,7 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
+
 		if len(names) > 0 && !found {
 			// Do not include this volume in the response if it doesn't match
 			// a name filter, if any exist.
@@ -349,6 +351,17 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 
 		tmp := (*volume).Volume
 		if tmp.Driver == "local" {
+			// Check if the volume matches any node filters
+			found = false
+			for _, node := range nodes {
+				if volume.Engine.Name == node {
+					found = true
+					break
+				}
+			}
+			if len(nodes) > 0 && !found {
+				continue
+			}
 			tmp.Name = volume.Engine.Name + "/" + volume.Name
 		}
 		volumesListResponse.Volumes = append(volumesListResponse.Volumes, &tmp)

--- a/cluster/network.go
+++ b/cluster/network.go
@@ -46,7 +46,7 @@ func (networks Networks) Uniq() Networks {
 	return uniq
 }
 
-// Filter returns networks filtered by names, IDs, labels, etc.
+// Filter returns networks filtered by names, IDs, nodes, labels, etc.
 func (networks Networks) Filter(filter filters.Args) Networks {
 	includeFilter := func(network *Network) bool {
 		for _, typ := range filter.Get("type") {
@@ -64,6 +64,11 @@ func (networks Networks) Filter(filter filters.Args) Networks {
 		}
 		if filter.Include("driver") {
 			if !filter.ExactMatch("driver", network.Driver) {
+				return false
+			}
+		}
+		for _, node := range filter.Get("node") {
+			if network.Engine.Name != node {
 				return false
 			}
 		}

--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -42,6 +42,25 @@ function teardown() {
 	[ "${#lines[@]}" -eq 2 ]
 }
 
+# docker network ls --filter node returns networks that are present on a specific node
+@test "docker network ls --filter node" {
+	# docker network ls --filter type is introduced in docker 1.10, skip older version without --filter type
+	run docker --version
+	if [[ "${output}" != "Docker version 1.1"* ]]; then
+		skip
+	fi
+
+	start_docker 2
+	swarm_manage
+
+	run docker_swarm network ls --filter node=node-0
+	[ "${#lines[@]}" -eq 4 ]
+
+	run docker_swarm network ls --filter node=node-1
+	[ "${#lines[@]}" -eq 4 ]
+}
+
+
 @test "docker network inspect" {
 	# Docker 1.12 client shows "Attachable" and "Created" fields while docker daemon 1.12
 	# doesn't return them. Network inspect from Swarm is different from daemon.

--- a/test/integration/api/volume.bats
+++ b/test/integration/api/volume.bats
@@ -15,13 +15,13 @@ function teardown() {
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 1 ]
 
-	# run
-	docker_swarm run -d -v=/tmp busybox true
+	# run on node-0
+	docker_swarm run -e constraint:node==node-0 -d -v=/tmp busybox true
 
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 2 ]
 
-	docker_swarm run -d -v=/tmp busybox true
+	docker_swarm run -e constraint:node==node-0 -d -v=/tmp busybox true
 
 	run docker_swarm volume ls
 	[ "${#lines[@]}" -eq 3 ]
@@ -36,6 +36,17 @@ function teardown() {
 	[ "${#lines[@]}" -eq 3 ] 
 	[[ "${lines[1]}" == *"testsubstrvol"* ]]
 	[[ "${lines[2]}" == *"testsubstrvol"* ]]
+
+	# filter for node-specific volumes
+	# node-0 should have three volumes
+	run docker_swarm volume ls --filter node=node-0
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 4 ] 
+
+	# node-1 should have one volume
+	run docker_swarm volume ls --filter node=node-1
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 2 ] 
 }
 
 @test "docker volume inspect" {


### PR DESCRIPTION
This PR adds a `node=<hostname>` filter to the networks and volumes lists, effectively mirroring the node filter in the container list API.

Signed-off-by: Alex Mavrogiannis <alex.mavrogiannis@docker.com>