### PR TITLE
Use engine ID + addr instead of Swarm mode ID for engine IDs

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -496,15 +496,11 @@ func (e *Engine) updateSpecs() error {
 	// Swarm/docker identifies engine by ID. Updating ID but not updating cluster
 	// index will put the cluster into inconsistent state. If this happens, the
 	// engine should be put to pending state for re-validation.
-	var infoID string
-	if info.Swarm.NodeID != "" {
-		// Use the swarm-mode node ID if it's available, since it's
-		// guaranteed to be unique, even if the daemon has a copied
-		// /etc/docker/key.json file from another machine.
-		infoID = info.Swarm.NodeID
-	} else {
-		infoID = info.ID
-	}
+	// We concatenate the engine ID and the address because sometimes engine
+	// IDs can be duplicated on different nodes (e.g. if a user has
+	// accidentally copied their /etc/docker/daemon.json file onto another
+	// node).
+	infoID := info.ID + "|" + e.Addr
 	if e.ID == "" {
 		e.ID = infoID
 	} else if e.ID != infoID {

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -55,7 +55,7 @@ var (
 func createEngine(t *testing.T, ID string, containers ...*cluster.Container) *cluster.Engine {
 	engine := cluster.NewEngine(ID, 0, engOpts)
 	engine.Name = ID
-	engine.ID = ID
+	engine.ID = ID + "|" + engine.Addr
 
 	for _, container := range containers {
 		container.Engine = engine
@@ -133,7 +133,7 @@ func TestImportImage(t *testing.T) {
 	id := "test-engine"
 	engine := cluster.NewEngine(id, 0, engOpts)
 	engine.Name = id
-	engine.ID = id
+	engine.ID = id + "|" + engine.Addr
 
 	// create mock client
 	client := mockclient.NewMockClient()
@@ -243,7 +243,7 @@ func TestTagImage(t *testing.T) {
 	id := "test-engine"
 	engine := cluster.NewEngine(id, 0, engOpts)
 	engine.Name = id
-	engine.ID = id
+	engine.ID = id + "|" + engine.Addr
 
 	// create mock client
 	client := mockclient.NewMockClient()


### PR DESCRIPTION
Signed-off-by: Wayne Song <wsong@docker.com>