### PR TITLE
add dangling filters

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -205,6 +205,12 @@ func getImagesJSON(c *context, w http.ResponseWriter, r *http.Request) {
 			Filters: filters,
 		},
 	}
+	if opts.Filters.Include("dangling") &&
+		!(opts.Filters.ExactMatch("dangling", "false") || opts.Filters.ExactMatch("dangling", "true")) {
+		httpError(w, "Invalid filter: 'type'='dangling'", http.StatusBadRequest)
+		return
+	}
+
 	for _, image := range c.cluster.Images().Filter(opts) {
 		if len(accepteds) != 0 {
 			found := false


### PR DESCRIPTION
It's very useful to list and remove non used docker images. We  always run

```
docker images -q -a -f dangling=true
```

but when using docker swarm, we notice that there is no logic to handle dangling filter for docker images. And it also indicates that the behavior of docker api and docker swarm api for listing images are different.

[docker images api](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-images)

This is PR to fix the issue and keep the same behavior with docker engine. 
[docker/daemon/images.go](https://github.com/docker/docker/blob/master/daemon/images.go#L41)

I made a mistake to delete the original repo for pull request (2514)[https://github.com/docker/swarm/pull/2514]. So I have to use this PR.