### PR TITLE
skip tests on token service

### DIFF
--- a/discovery/token/token_test.go
+++ b/discovery/token/token_test.go
@@ -25,6 +25,9 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
+	// Docker hub token service is down. Skip this test.
+	t.Skip("docker hub token service is down")
+
 	d := &Discovery{token: "TEST_TOKEN", url: discoveryURL, heartbeat: 1}
 	expected := "127.0.0.1:2675"
 	expectedEntries, err := discovery.CreateEntries([]string{expected})

--- a/test/integration/discovery/token.bats
+++ b/test/integration/discovery/token.bats
@@ -5,26 +5,30 @@ load discovery_helpers
 TOKEN=""
 DISCOVERY=""
 
-function token_cleanup() {
-	[ -z "$TOKEN" ] && return
-	echo "Removing $TOKEN"
-	curl -X DELETE "https://discovery.hub.docker.com/v1/clusters/$TOKEN"
-}
+#function token_cleanup() {
+#	[ -z "$TOKEN" ] && return
+#	echo "Removing $TOKEN"
+#	curl -X DELETE "https://discovery.hub.docker.com/v1/clusters/$TOKEN"
+#}
 
-function setup() {
-	TOKEN=$(swarm create)
-	[[ "$TOKEN" =~ ^[0-9a-f]{32}$ ]]
-	DISCOVERY="token://$TOKEN"
-}
+#function setup() {
+#	TOKEN=$(swarm create)
+#	[[ "$TOKEN" =~ ^[0-9a-f]{32}$ ]]
+#	DISCOVERY="token://$TOKEN"
+#}
 
-function teardown() {
-	swarm_manage_cleanup
-	swarm_join_cleanup
-	stop_docker
-	token_cleanup
-}
+#function teardown() {
+#	swarm_manage_cleanup
+#	swarm_join_cleanup
+#	stop_docker
+#	token_cleanup
+#}
 
+# docker hub token service is down. This is not the recommended way of
+# discovery. It's not prioritized on Docker hub. Disable the test for now.
 @test "token discovery: recover engines" {
+skip
+
 	# The goal of this test is to ensure swarm can see engines that joined
 	# while the manager was stopped.
 
@@ -38,7 +42,11 @@ function teardown() {
 	retry 5 1 discovery_check_swarm_info
 }
 
+# docker hub token service is down. Since this is not the recommended way of
+# discovery. It's not prioritized on Docker hub. Disable the test for now.
 @test "token discovery: watch for changes" {
+skip
+
 	# The goal of this test is to ensure swarm can see new nodes as they join
 	# the cluster.
 


### PR DESCRIPTION
Docker hub token service is down. It fails related unit tests and integration tests. Token service is not recommended any more. We have discussed plan to deprecate this discovery service for some time. 

We want to disable the tests as first step. If it's clear nothing else depends on token service, we will deprecate it. 

close #2676.

cc @vieux @nishanttotla. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>