### PR TITLE
Include filter error in node selection message.

### DIFF
--- a/scheduler/filter/expr_test.go
+++ b/scheduler/filter/expr_test.go
@@ -58,6 +58,10 @@ func TestParseExprs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, exprs[0].key, "node")
 	assert.Equal(t, exprs[0].value, "node 1")
+
+	// Doesn't allow empty value
+	_, err = parseExprs([]string{"node=="})
+	assert.Error(t, err)
 }
 
 func TestMatch(t *testing.T) {

--- a/scheduler/filter/filter.go
+++ b/scheduler/filter/filter.go
@@ -87,6 +87,11 @@ func listAllFilters(filters []Filter, config *cluster.ContainerConfig, lastFilte
 		if err == nil && len(list) > 0 {
 			allFilters = fmt.Sprintf("%s\n%v", allFilters, list)
 		}
+		if err != nil {
+			allFilters = fmt.Sprintf("%s\nerror from %s filter: %v", allFilters, filter.Name(), err)
+			// when the filter has error, no need to continue.
+			return allFilters
+		}
 		if filter.Name() == lastFilter {
 			return allFilters
 		}


### PR DESCRIPTION
If a constraint is malformed, the error is not shown to client. In the following case, constraint `node==` is malformed where the value cannot be empty. But the return message doesn't show that. 

```
# DOCKER_HOST points to swarm
$ docker run -e constraint:node== alpine
docker: Error response from daemon: Unable to find a node that satisfies the following conditions 
[available container slots].
See 'docker run --help'.
```

With this change the output would be
```
$ docker run -e constraint:node== hello-world
docker: Error response from daemon: Unable to find a node that satisfies the following conditions
[available container slots]
error from constraint filter: Value '' is invalid.
See 'docker run --help'.
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>