### PR TITLE
event stream retry interval should be capped

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -216,15 +216,13 @@ func (e *Engine) StartMonitorEvents() {
 	go func() {
 		if err := <-ec; err != nil {
 			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).WithError(err).Error("error monitoring events, will restart")
-			if !strings.Contains(err.Error(), "EOF") {
-				// failing node reconnect should use back-off strategy to avoid frequent reconnect
-				retryInterval := e.getFailureCount() + 1
-				// maximum retry interval of 10 seconds
-				if retryInterval > 10 {
-					retryInterval = 10
-				}
-				<-time.After(time.Duration(retryInterval) * time.Second)
+			// failing node reconnect should use back-off strategy to avoid frequent reconnect
+			retryInterval := e.getFailureCount() + 1
+			// maximum retry interval of 10 seconds
+			if retryInterval > 10 {
+				retryInterval = 10
 			}
+			<-time.After(time.Duration(retryInterval) * time.Second)
 			e.StartMonitorEvents()
 		}
 		close(ec)


### PR DESCRIPTION
Docker event stream may be broken from time to time. The current backoff strategy is borrowed from engine refresh interval. The default settings is a minimum of 30 seconds. This is too long and results in event loss. Set a cap of 10 seconds for the backoff. 

cc @wsong @nishanttotla.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>