### PR TITLE
Don't throw away most of the JSONMessage content when pulling images

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -25,19 +25,6 @@ func httpError(w http.ResponseWriter, err string, status int) {
 	http.Error(w, err, status)
 }
 
-func sendJSONMessage(w io.Writer, id, status string) {
-	message := struct {
-		ID       string      `json:"id,omitempty"`
-		Status   string      `json:"status,omitempty"`
-		Progress interface{} `json:"progressDetail,omitempty"`
-	}{
-		id,
-		status,
-		struct{}{}, // this is required by the docker cli to have a proper display
-	}
-	json.NewEncoder(w).Encode(message)
-}
-
 func sendErrorJSONMessage(w io.Writer, errorCode int, errorMessage string) {
 	error := struct {
 		Code    int    `json:"code,omitempty"`

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -56,21 +56,15 @@ type Cluster interface {
 
 	// Pull images
 	// `callback` can be called multiple time
-	//  `where` is where it is being pulled
-	//  `status` is the current status, like "", "in progress" or "downloaded".
-	Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error))
+	Pull(name string, authConfig *types.AuthConfig, callback func(msg JSONMessageWrapper))
 
 	// Import image
 	// `callback` can be called multiple time
-	// `where` is where it is being imported
-	// `status` is the current status, like "", "in progress" or "imported".
-	Import(source string, ref string, tag string, imageReader io.Reader, callback func(where, status string, err error))
+	Import(source string, ref string, tag string, imageReader io.Reader, callback func(msg JSONMessageWrapper))
 
 	// Load images
 	// `callback` can be called multiple time
-	// `what` is what is being loaded
-	// `status` is the current status, like "", "in progress" or "loaded".
-	Load(imageReader io.Reader, callback func(what, status string, err error))
+	Load(imageReader io.Reader, callback func(msg JSONMessageWrapper))
 
 	// Info returns some info about the cluster, like nb of containers / images.
 	// It is pretty open, so the implementation decides what to return.
@@ -96,7 +90,7 @@ type Cluster interface {
 	RenameContainer(container *Container, newName string) error
 
 	// BuildImage builds an image.
-	BuildImage(io.Reader, *types.ImageBuildOptions, func(what, status string, err error)) error
+	BuildImage(io.Reader, *types.ImageBuildOptions, func(msg JSONMessageWrapper)) error
 
 	// TagImage tags an image.
 	TagImage(IDOrName string, ref string, force bool) error

--- a/cluster/jsonmessage.go
+++ b/cluster/jsonmessage.go
@@ -33,3 +33,12 @@ type JSONMessage struct {
 	// Aux contains out-of-band data, such as digests for push signing.
 	Aux *json.RawMessage `json:"aux,omitempty"`
 }
+
+// JSONMessageWrapper is used in callback functions for API calls that send back
+// JSONMessages; this allows us to pass info around within Swarm classic.
+type JSONMessageWrapper struct {
+	Msg        JSONMessage
+	EngineName string
+	Err        error
+	Success    bool
+}

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -367,17 +367,17 @@ func (c *Cluster) RemoveImage(image *cluster.Image) ([]types.ImageDelete, error)
 }
 
 // Pull pulls images on the cluster nodes
-func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error)) {
+func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(msg cluster.JSONMessageWrapper)) {
 
 }
 
 // Load images
-func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string, err error)) {
+func (c *Cluster) Load(imageReader io.Reader, callback func(msg cluster.JSONMessageWrapper)) {
 
 }
 
 // Import image
-func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
+func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(msg cluster.JSONMessageWrapper)) {
 
 }
 
@@ -649,7 +649,7 @@ func (c *Cluster) RANDOMENGINE() (*cluster.Engine, error) {
 }
 
 // BuildImage builds an image
-func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuildOptions, callback func(what, status string, err error)) error {
+func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuildOptions, callback func(msg cluster.JSONMessageWrapper)) error {
 	c.scheduler.Lock()
 
 	// get an engine
@@ -672,15 +672,24 @@ func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuil
 	var engineCallback func(msg cluster.JSONMessage)
 	if callback != nil {
 		engineCallback = func(msg cluster.JSONMessage) {
-			callback(engine.Name, msg.Status, nil)
+			callback(cluster.JSONMessageWrapper{
+				EngineName: engine.Name,
+				Msg:        msg,
+			})
 		}
 	}
 	err = engine.BuildImage(buildContext, buildImage, engineCallback)
 	if callback != nil {
 		if err != nil {
-			callback(engine.Name, "", err)
+			callback(cluster.JSONMessageWrapper{
+				EngineName: engine.Name,
+				Err:        err,
+			})
 		} else {
-			callback(engine.Name, "built", nil)
+			callback(cluster.JSONMessageWrapper{
+				EngineName: engine.Name,
+				Success:    true,
+			})
 		}
 	}
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -619,7 +619,7 @@ func (c *Cluster) RemoveVolumes(name string) (bool, error) {
 }
 
 // Pull is exported.
-func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(where, status string, err error)) {
+func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(msg cluster.JSONMessageWrapper)) {
 	var wg sync.WaitGroup
 
 	for _, e := range c.listActiveEngines() {
@@ -629,21 +629,32 @@ func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(
 			defer wg.Done()
 
 			if callback != nil {
-				callback(engine.Name, "", nil)
+				callback(cluster.JSONMessageWrapper{
+					EngineName: engine.Name,
+				})
 			}
 
 			var engineCallback func(msg cluster.JSONMessage)
 			if callback != nil {
 				engineCallback = func(msg cluster.JSONMessage) {
-					callback(engine.Name, msg.Status, nil)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Msg:        msg,
+					})
 				}
 			}
 			err := engine.Pull(name, authConfig, engineCallback)
 			if callback != nil {
 				if err != nil {
-					callback(engine.Name, "", err)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Err:        err,
+					})
 				} else {
-					callback(engine.Name, "downloaded", nil)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Success:    true,
+					})
 				}
 			}
 		}(e)
@@ -653,7 +664,7 @@ func (c *Cluster) Pull(name string, authConfig *types.AuthConfig, callback func(
 }
 
 // Load loads image.
-func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string, err error)) {
+func (c *Cluster) Load(imageReader io.Reader, callback func(msg cluster.JSONMessageWrapper)) {
 	var wg sync.WaitGroup
 
 	pipeWriters := []*io.PipeWriter{}
@@ -671,13 +682,19 @@ func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string
 			var engineCallback func(msg cluster.JSONMessage)
 			if callback != nil {
 				engineCallback = func(msg cluster.JSONMessage) {
-					callback(engine.Name, msg.Status, nil)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Msg:        msg,
+					})
 				}
 			}
 			err := engine.Load(reader, engineCallback)
 			if callback != nil {
 				if err != nil {
-					callback(engine.Name, "", err)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Err:        err,
+					})
 				}
 			}
 		}(pipeReader, e)
@@ -705,7 +722,7 @@ func (c *Cluster) Load(imageReader io.Reader, callback func(where, status string
 }
 
 // Import imports image.
-func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(what, status string, err error)) {
+func (c *Cluster) Import(source string, ref string, tag string, imageReader io.Reader, callback func(msg cluster.JSONMessageWrapper)) {
 	var wg sync.WaitGroup
 	pipeWriters := []*io.PipeWriter{}
 
@@ -723,15 +740,24 @@ func (c *Cluster) Import(source string, ref string, tag string, imageReader io.R
 			var engineCallback func(msg cluster.JSONMessage)
 			if callback != nil {
 				engineCallback = func(msg cluster.JSONMessage) {
-					callback(engine.Name, msg.Status, nil)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Msg:        msg,
+					})
 				}
 			}
 			err := engine.Import(source, ref, tag, reader, engineCallback)
 			if callback != nil {
 				if err != nil {
-					callback(engine.Name, "", err)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Err:        err,
+					})
 				} else {
-					callback(engine.Name, "Import success", nil)
+					callback(cluster.JSONMessageWrapper{
+						EngineName: engine.Name,
+						Success:    true,
+					})
 				}
 			}
 
@@ -977,7 +1003,7 @@ func (c *Cluster) RenameContainer(container *cluster.Container, newName string) 
 }
 
 // BuildImage builds an image
-func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuildOptions, callback func(what, status string, err error)) error {
+func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuildOptions, callback func(msg cluster.JSONMessageWrapper)) error {
 	c.scheduler.Lock()
 
 	// get an engine
@@ -996,15 +1022,24 @@ func (c *Cluster) BuildImage(buildContext io.Reader, buildImage *types.ImageBuil
 	var engineCallback func(msg cluster.JSONMessage)
 	if callback != nil {
 		engineCallback = func(msg cluster.JSONMessage) {
-			callback(engine.Name, msg.Status, nil)
+			callback(cluster.JSONMessageWrapper{
+				EngineName: engine.Name,
+				Msg:        msg,
+			})
 		}
 	}
 	err = engine.BuildImage(buildContext, buildImage, engineCallback)
 	if callback != nil {
 		if err != nil {
-			callback(engine.Name, "", err)
+			callback(cluster.JSONMessageWrapper{
+				EngineName: engine.Name,
+				Err:        err,
+			})
 		} else {
-			callback(engine.Name, "built", nil)
+			callback(cluster.JSONMessageWrapper{
+				EngineName: engine.Name,
+				Success:    true,
+			})
 		}
 	}
 

--- a/cluster/swarm/cluster_test.go
+++ b/cluster/swarm/cluster_test.go
@@ -158,9 +158,9 @@ func TestImportImage(t *testing.T) {
 	readCloser := nopCloser{bytes.NewBufferString("")}
 	apiClient.On("ImageImport", mock.Anything, mock.AnythingOfType("types.ImageImportSource"), mock.Anything, mock.AnythingOfType("types.ImageImportOptions")).Return(readCloser, nil).Once()
 
-	callback := func(what, status string, err error) {
+	callback := func(msg cluster.JSONMessageWrapper) {
 		// import success
-		assert.Nil(t, err)
+		assert.Nil(t, msg.Err)
 	}
 	c.Import("-", "testImageOK", "latest", bytes.NewReader(nil), callback)
 
@@ -169,9 +169,9 @@ func TestImportImage(t *testing.T) {
 	err := fmt.Errorf("Import error")
 	apiClient.On("ImageImport", mock.Anything, mock.AnythingOfType("types.ImageImportSource"), mock.Anything, mock.AnythingOfType("types.ImageImportOptions")).Return(readCloser, err).Once()
 
-	callback = func(what, status string, err error) {
+	callback = func(msg cluster.JSONMessageWrapper) {
 		// import error
-		assert.NotNil(t, err)
+		assert.NotNil(t, msg.Err)
 	}
 	c.Import("-", "testImageError", "latest", bytes.NewReader(nil), callback)
 }
@@ -210,18 +210,18 @@ func TestLoadImage(t *testing.T) {
 	// load success
 	readCloser := nopCloser{bytes.NewBufferString("")}
 	apiClient.On("ImageLoad", mock.Anything, mock.AnythingOfType("*io.PipeReader"), false).Return(types.ImageLoadResponse{Body: readCloser}, nil).Once()
-	callback := func(what, status string, err error) {
+	callback := func(msg cluster.JSONMessageWrapper) {
 		//if load OK, err will be nil
-		assert.Nil(t, err)
+		assert.Nil(t, msg.Err)
 	}
 	c.Load(bytes.NewReader(nil), callback)
 
 	// load error
 	err := fmt.Errorf("Load error")
 	apiClient.On("ImageLoad", mock.Anything, mock.AnythingOfType("*io.PipeReader"), false).Return(types.ImageLoadResponse{}, err).Once()
-	callback = func(what, status string, err error) {
+	callback = func(msg cluster.JSONMessageWrapper) {
 		// load error, err is not nil
-		assert.NotNil(t, err)
+		assert.NotNil(t, msg.Err)
 	}
 	c.Load(bytes.NewReader(nil), callback)
 }


### PR DESCRIPTION
Previously, we were basically crafting our own JSONMessage objects, but we
should be using the ones the engines pass back to us so that we preserve
progress information and so on.

Signed-off-by: Wayne Song <wsong@docker.com>