### PR TITLE
[WIP] add mutex to protect cluster.Container

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -522,7 +522,7 @@ func getContainersJSON(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 		// Create a copy of the underlying apitypes.Container so we can
 		// make changes without messing with cluster.Container.
-		tmp := (*container).Container
+		tmp := container.Container
 
 		// Update the Status. The one we have is stale from the last `docker ps` the engine sent.
 		// `Status()` will generate a new one
@@ -939,7 +939,11 @@ func postContainersExec(c *context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// add execID to the container, so the later exec/start will work
+	container.Lock()
 	container.Info.ExecIDs = append(container.Info.ExecIDs, execCreateResp.ID)
+	container.Unlock()
+	// for temporary debugging, don't merge into code, at least not at Infof level
+	log.Infof("exec id %s is added to container %s", execCreateResp.ID, container.ID)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/api/utils.go
+++ b/api/utils.go
@@ -57,13 +57,21 @@ func getContainerFromVars(c *context, vars map[string]string) (string, *cluster.
 	}
 
 	if ID, ok := vars["execid"]; ok {
+		var containerlist []string
 		for _, container := range c.cluster.Containers() {
+			containerlist = append(containerlist, container.ID)
+			container.RLock()
 			for _, execID := range container.Info.ExecIDs {
 				if ID == execID {
+					container.RUnlock()
+					// debug info. do not merge this into master branch
+					log.Infof("execid %s found on container %s", ID, container.ID)
 					return "", container, nil
 				}
 			}
+			container.RUnlock()
 		}
+		log.Infof("all containers %s", strings.Join(containerlist, ","))
 		return "", nil, fmt.Errorf("Exec %s not found", ID)
 	}
 

--- a/cluster/container.go
+++ b/cluster/container.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -12,6 +13,7 @@ import (
 
 // Container is exported
 type Container struct {
+	sync.RWMutex
 	types.Container
 
 	Config *ContainerConfig

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -868,6 +868,7 @@ func (e *Engine) updateContainer(c types.Container, containers map[string]*Conta
 		info.State.FinishedAt = finishedAt.Add(e.DeltaDuration).Format(time.RFC3339Nano)
 
 		// Save the entire inspect back into the container.
+		log.WithFields(log.Fields{"id": info.ID}).Debugf("Update container info execid: %v", info.ExecIDs)
 		container.Info = info
 	}
 


### PR DESCRIPTION
This is related to #2664. `cluster.Container` access is not protected. 

cc @garagatyi @wsong 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>