### PR TITLE
Immediately flush response headers for ContainerWait requests

### DIFF
--- a/api/primary.go
+++ b/api/primary.go
@@ -72,7 +72,7 @@ var routes = map[string]map[string]handler{
 		"/containers/{name:.*}/start":         postContainersStart,
 		"/containers/{name:.*}/stop":          proxyContainerAndForceRefresh,
 		"/containers/{name:.*}/update":        proxyContainerAndForceRefresh,
-		"/containers/{name:.*}/wait":          proxyContainerAndForceRefresh,
+		"/containers/{name:.*}/wait":          postContainersWait,
 		"/containers/{name:.*}/resize":        proxyContainer,
 		"/containers/{name:.*}/attach":        proxyHijack,
 		"/containers/{name:.*}/copy":          proxyContainer,


### PR DESCRIPTION
Some Docker API endpoints (specifically the latest updates to the `ContainerWait` API in Docker API v1.30) require that response headers are immediately flushed to the client in order to have correct behavior.

Fixes an issue where `docker run ...` hangs on the latest version of Docker CLI (v17.06.0-ce-rc1).