### PR TITLE
Add network ls filtering by name

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -92,9 +92,19 @@ func (networks Networks) Filter(filter filters.Args) Networks {
 				}
 			}
 		}
+		// substring match based on name filter
+		for _, idOrName := range append(names, ids...) {
+			if networkList := networks.matchByName(idOrName, filter); len(networkList) != 0 {
+				for _, network := range networkList.Uniq() {
+					if includeFilter(network) {
+						out = append(out, network)
+					}
+				}
+			}
+		}
 	}
 
-	return out
+	return out.Uniq()
 }
 
 // RemoveDuplicateEndpoints returns a copy of input network
@@ -123,6 +133,17 @@ func (network *Network) RemoveDuplicateEndpoints() *Network {
 		netCopy.Containers[index] = network.Containers[index]
 	}
 	return &netCopy
+}
+
+// matchByName checks if any networks match by substring
+func (networks Networks) matchByName(IDOrName string, filter filters.Args) Networks {
+	candidates := Networks{}
+	for _, network := range networks {
+		if filter.Match("name", network.Name) {
+			candidates = append(candidates, network)
+		}
+	}
+	return candidates
 }
 
 // Get returns a network using its ID or Name

--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -18,7 +18,7 @@ function teardown() {
 @test "docker network ls --filter type" {
 	# docker network ls --filter type is introduced in docker 1.10, skip older version without --filter type
 	run docker --version
-	if [[ "${output}" != "Docker version 1.1"* ]]; then
+	if [[ "${output}" == "Docker version 1.9"* ]]; then
 		skip
 	fi
 
@@ -46,7 +46,7 @@ function teardown() {
 @test "docker network ls --filter node" {
 	# docker network ls --filter type is introduced in docker 1.10, skip older version without --filter type
 	run docker --version
-	if [[ "${output}" != "Docker version 1.1"* ]]; then
+	if [[ "${output}" == "Docker version 1.9"* ]]; then
 		skip
 	fi
 
@@ -60,6 +60,27 @@ function teardown() {
 	[ "${#lines[@]}" -eq 4 ]
 }
 
+# docker network ls --filter name returns networks that match with a provided name
+@test "docker network ls --filter name" {
+	# don't bother running this for older versions
+	run docker --version
+	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* ]]; then
+			skip
+	fi
+
+	start_docker 2
+	swarm_manage
+
+	run docker_swarm network create networknameone
+	run docker_swarm network create networknametwo
+
+	run docker_swarm network ls
+	echo $output
+
+	run docker_swarm network ls --filter name=networkname
+	echo $output
+	[ "${#lines[@]}" -eq 3 ]
+}
 
 @test "docker network inspect" {
 	# Docker 1.12 client shows "Attachable" and "Created" fields while docker daemon 1.12


### PR DESCRIPTION
Turns out that network filter tests were wrongly disabled for master
branch. This is also fixed here.

(This PR is currently rebased on top of https://github.com/docker/swarm/pull/2734 to make sure vendoring issues don't affect this PR)

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>