### PR TITLE
Debugging 17.03 test failures

### DIFF
--- a/test/integration/api/search.bats
+++ b/test/integration/api/search.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 	local version="new"
 	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* ]]; then
+	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* || "${output}" == "Docker version 17.03"* ]]; then
 			version="old"
 	fi
 


### PR DESCRIPTION
We now have 17.03 tests in the CI, but it seems like a graph driver issue is causing them to fail. Using this PR to track and fix those failures.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>