### PR TITLE
Add automatic constraint logic when ContainerCreate fails because of an OSType mismatch

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1431,7 +1431,7 @@ func postBuild(c *context, w http.ResponseWriter, r *http.Request) {
 		if msg.Err != nil {
 			errorFound = true
 			errorMessage = msg.Err.Error()
-			osType := matchImageOSError(errorMessage)
+			osType := MatchImageOSError(errorMessage)
 			if osType != "" {
 				msg.Msg.Status = fmt.Sprintf("Could not build image: %s. Consider using --build-arg 'constraint:ostype==%s'", errorMessage, osType)
 			}

--- a/api/utils.go
+++ b/api/utils.go
@@ -377,11 +377,11 @@ func getImageRef(repo, tag string) string {
 	return ref
 }
 
-// This function matches a daemon error message that states that an image
+// MatchImageOSError matches a daemon error message that states that an image
 // cannot be built on a node because the image has a base image that uses the
 // wrong operating system. This function pulls out the required OS from the
 // error message.
-func matchImageOSError(errMsg string) string {
+func MatchImageOSError(errMsg string) string {
 	results := imageOSErrorPattern.FindStringSubmatch(errMsg)
 	if results == nil || len(results) < 2 {
 		return ""

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -83,7 +83,7 @@ func TestMatchImageOSError(t *testing.T) {
 	}
 
 	for c, e := range cases {
-		a := matchImageOSError(c)
+		a := MatchImageOSError(c)
 		if a != e {
 			t.Fatalf("Value: %s, expected: %v, actual: %v", c, e, a)
 		}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -58,3 +58,61 @@ func TestSelectNodesForContainer(t *testing.T) {
 	assert.Equal(t, "node-1-id", candidates[0].ID)
 
 }
+
+func TestSelectNodesForContainerHybrid(t *testing.T) {
+	var (
+		s = Scheduler{
+			strategy: &strategy.SpreadPlacementStrategy{},
+			filters:  []filter.Filter{&filter.ConstraintFilter{}},
+		}
+
+		nodes = []*node.Node{
+			{
+				ID:          "node-0-id",
+				Name:        "node-0-name",
+				Addr:        "node-0",
+				TotalMemory: 1 * 1024 * 1024 * 1024,
+				TotalCpus:   2,
+				Labels: map[string]string{
+					"ostype": "linux",
+				},
+			},
+
+			{
+				ID:          "node-1-id",
+				Name:        "node-1-name",
+				Addr:        "node-1",
+				TotalMemory: 1 * 1024 * 1024 * 1024,
+				TotalCpus:   2,
+				Labels: map[string]string{
+					"ostype": "windows",
+				},
+			},
+		}
+
+		configWin = cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{
+			Resources: containertypes.Resources{
+				Memory:    1024 * 1024 * 1024,
+				CPUShares: 2,
+			},
+		}, networktypes.NetworkingConfig{})
+		configLin = cluster.BuildContainerConfig(containertypes.Config{}, containertypes.HostConfig{
+			Resources: containertypes.Resources{
+				Memory:    1024 * 1024 * 1024,
+				CPUShares: 2,
+			},
+		}, networktypes.NetworkingConfig{})
+	)
+
+	configWin.AddConstraint("ostype==windows")
+	configLin.AddConstraint("ostype==linux")
+
+	candidates, err := s.SelectNodesForContainer(nodes, configWin)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(candidates))
+	assert.Equal(t, "node-1-id", candidates[0].ID)
+	candidates, err = s.SelectNodesForContainer(nodes, configLin)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(candidates))
+	assert.Equal(t, "node-0-id", candidates[0].ID)
+}


### PR DESCRIPTION
If the swarm contains hybrid nodes (ie: linux nodes and windows nodes), if the client does not specify an ostype constraint when creating a container, it fails randomly because there can be a mismatch between the image os and the engine os. 
This PR automatically detect OS mismatch when creating a container, and retries the operation with an ostype constraint.