### PR TITLE
Moving event handling for external subscribers to use go-events

### DIFF
--- a/api/events_test.go
+++ b/api/events_test.go
@@ -41,10 +41,10 @@ func TestHandle(t *testing.T) {
 	event.Message.From = "from"
 	event.Message.Time = 0
 	event.Actor.Attributes = make(map[string]string)
-	event.Actor.Attributes["nodevent.name"] = event.Engine.Name
-	event.Actor.Attributes["nodevent.id"] = event.Engine.ID
-	event.Actor.Attributes["nodevent.addr"] = event.Engine.Addr
-	event.Actor.Attributes["nodevent.ip"] = event.Engine.IP
+	event.Actor.Attributes["node.name"] = event.Engine.Name
+	event.Actor.Attributes["node.id"] = event.Engine.ID
+	event.Actor.Attributes["node.addr"] = event.Engine.Addr
+	event.Actor.Attributes["node.ip"] = event.Engine.IP
 
 	assert.NoError(t, eh.Handle(event))
 

--- a/api/primary.go
+++ b/api/primary.go
@@ -3,18 +3,26 @@ package api
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"net/http/pprof"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm/cluster"
+	"github.com/docker/swarmkit/watch"
 	"github.com/gorilla/mux"
+)
+
+const (
+	defaultEventQueueLimit   = 10000
+	defaultEventQueueTimeout = 10 * time.Second
 )
 
 // Primary router context, used by handlers.
 type context struct {
 	cluster       cluster.Cluster
 	eventsHandler *eventsHandler
+	watchQueue    *watch.Queue
 	statusHandler StatusHandler
 	debug         bool
 	tlsConfig     *tls.Config
@@ -122,16 +130,22 @@ func NewPrimary(cluster cluster.Cluster, tlsConfig *tls.Config, status StatusHan
 	// The new eventsHandler is initialized with no writers or channels.
 	// This is in api/events.go
 	eventsHandler := newEventsHandler()
+	// eventsQueue uses the watch package from SwarmKit, which is based on
+	// the go-events package. See https://github.com/docker/swarm/issues/2718
+	// for context
+	eventsQueue := watch.NewQueue(watch.WithTimeout(defaultEventQueueTimeout), watch.WithLimit(defaultEventQueueLimit), watch.WithCloseOutChan())
+	// need to add this queue to the cluster
 	// This just calls c.eventHandlers.RegisterEventHandler(eventsHandler) internally.
 	// Eventually, eventsHandler is added to the Cluster struct's EventHandlers map, if it
 	// doesn't already exist there. The Cluster struct implements the cluster.EventHandler
 	// interface, as does eventsHandler. So calling the Handle function for a Cluster object
 	// will eventually call the Handle function for eventsHandler.
-	cluster.RegisterEventHandler(eventsHandler)
+	cluster.RegisterEventHandler(eventsHandler, eventsQueue)
 
 	context := &context{
 		cluster:       cluster,
 		eventsHandler: eventsHandler,
+		watchQueue:    eventsQueue,
 		statusHandler: status,
 		tlsConfig:     tlsConfig,
 	}

--- a/api/primary.go
+++ b/api/primary.go
@@ -23,6 +23,7 @@ type context struct {
 	cluster       cluster.Cluster
 	eventsHandler *eventsHandler
 	watchQueue    *watch.Queue
+	listenerCount *uint64
 	statusHandler StatusHandler
 	debug         bool
 	tlsConfig     *tls.Config
@@ -134,6 +135,7 @@ func NewPrimary(cluster cluster.Cluster, tlsConfig *tls.Config, status StatusHan
 	// the go-events package. See https://github.com/docker/swarm/issues/2718
 	// for context
 	eventsQueue := watch.NewQueue(watch.WithTimeout(defaultEventQueueTimeout), watch.WithLimit(defaultEventQueueLimit), watch.WithCloseOutChan())
+	listenerCount := uint64(0)
 	// need to add this queue to the cluster
 	// This just calls c.eventHandlers.RegisterEventHandler(eventsHandler) internally.
 	// Eventually, eventsHandler is added to the Cluster struct's EventHandlers map, if it
@@ -146,6 +148,7 @@ func NewPrimary(cluster cluster.Cluster, tlsConfig *tls.Config, status StatusHan
 		cluster:       cluster,
 		eventsHandler: eventsHandler,
 		watchQueue:    eventsQueue,
+		listenerCount: &listenerCount,
 		statusHandler: status,
 		tlsConfig:     tlsConfig,
 	}

--- a/cli/manage.go
+++ b/cli/manage.go
@@ -179,6 +179,8 @@ func run(cl cluster.Cluster, candidate *leadership.Candidate, server *api.Server
 			} else {
 				log.Info("Leader Election: Cluster leadership lost")
 				cl.UnregisterEventHandler(watchdog)
+				// TODO(nishanttotla): perhaps EventHandler for subscription events should
+				// also be unregistered here
 				server.SetHandler(replica)
 			}
 
@@ -335,6 +337,7 @@ func manage(c *cli.Context) {
 		server.SetHandler(api.NewPrimary(cl, tlsConfig, &statusHandler{cl, nil, nil}, c.GlobalBool("debug"), c.Bool("cors")))
 		cluster.NewWatchdog(cl)
 	}
+	defer cl.CloseWatchQueue()
 
 	log.Fatal(server.ListenAndServe())
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/swarmkit/watch"
 	"github.com/samalba/dockerclient"
 )
 
@@ -77,10 +78,13 @@ type Cluster interface {
 	TotalCpus() int64
 
 	// RegisterEventHandler registers an event handler for cluster-wide events.
-	RegisterEventHandler(h EventHandler) error
+	RegisterEventHandler(h EventHandler, q *watch.Queue) error
 
 	// UnregisterEventHandler unregisters an event handler.
 	UnregisterEventHandler(h EventHandler)
+
+	// CloseWatchQueue closes the watchQueue when the manager shuts down.
+	CloseWatchQueue()
 
 	// FIXME: remove this method
 	// RANDOMENGINE returns a random engine.

--- a/cluster/mesos/cluster.go
+++ b/cluster/mesos/cluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/swarm/cluster/mesos/task"
 	"github.com/docker/swarm/scheduler"
 	"github.com/docker/swarm/scheduler/node"
+	"github.com/docker/swarmkit/watch"
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/mesos-go/mesosproto"
 	mesosscheduler "github.com/mesos/mesos-go/scheduler"
@@ -34,6 +35,7 @@ type Cluster struct {
 
 	dockerEnginePort    string
 	eventHandlers       *cluster.EventHandlers
+	watchQueue          *watch.Queue
 	master              string
 	agents              map[string]*agent
 	scheduler           *Scheduler
@@ -168,18 +170,31 @@ func NewCluster(scheduler *scheduler.Scheduler, TLSConfig *tls.Config, master st
 
 // Handle callbacks for the events
 func (c *Cluster) Handle(e *cluster.Event) error {
+	// publish event to the watchQueue for external subscribers
+	c.watchQueue.Publish(e)
+	// call Handle for other eventHandlers
 	c.eventHandlers.Handle(e)
 	return nil
 }
 
 // RegisterEventHandler registers an event handler.
-func (c *Cluster) RegisterEventHandler(h cluster.EventHandler) error {
+func (c *Cluster) RegisterEventHandler(h cluster.EventHandler, q *watch.Queue) error {
+	// only set if watchQueue hasn't been set already. This is to avoid issues because
+	// the watchdog code still uses the old event handler.
+	if q != nil && c.watchQueue == nil {
+		c.watchQueue = q
+	}
 	return c.eventHandlers.RegisterEventHandler(h)
 }
 
 // UnregisterEventHandler unregisters a previously registered event handler.
 func (c *Cluster) UnregisterEventHandler(h cluster.EventHandler) {
 	c.eventHandlers.UnregisterEventHandler(h)
+}
+
+// CloseWatchQueue closes the watchQueue when the manager shuts down.
+func (c *Cluster) CloseWatchQueue() {
+	c.watchQueue.Close()
 }
 
 // StartContainer starts a container

--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -187,6 +187,6 @@ func NewWatchdog(cluster Cluster) *Watchdog {
 	w := &Watchdog{
 		cluster: cluster,
 	}
-	cluster.RegisterEventHandler(w)
+	cluster.RegisterEventHandler(w, nil)
 	return w
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,13 +1,13 @@
-github.com/Microsoft/go-winio v0.4.2
-github.com/Sirupsen/logrus 3ec0642a7fb6488f65b06f9040adc67e3990296a
-github.com/urfave/cli c31a7975863e7810c92e2e288a9ab074f9a88f29
-
 # coreos/etcd depends on the dependencies listed below it.
 # Their import versions should be the same as that required
 # by the corresponding version of coreos/etcd
 github.com/coreos/etcd 6081a29c13c380f1e7d85240f7927e422b0cfa51
 github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
 
+github.com/Microsoft/go-winio v0.4.2
+github.com/Sirupsen/logrus 3ec0642a7fb6488f65b06f9040adc67e3990296a
+github.com/urfave/cli c31a7975863e7810c92e2e288a9ab074f9a88f29
+github.com/docker/swarmkit 97727e1e18c356435819020f02f586340a8ca812
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/docker/docker 5eca8382b03278dc42c228b3d14dec0909ce655b

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,6 +8,7 @@ github.com/Microsoft/go-winio v0.4.2
 github.com/Sirupsen/logrus 3ec0642a7fb6488f65b06f9040adc67e3990296a
 github.com/urfave/cli c31a7975863e7810c92e2e288a9ab074f9a88f29
 github.com/docker/swarmkit 97727e1e18c356435819020f02f586340a8ca812
+github.com/docker/go-events 37d35add5005832485c0225ec870121b78fcff1c
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/docker/docker 5eca8382b03278dc42c228b3d14dec0909ce655b

--- a/vendor/github.com/docker/go-events/LICENSE
+++ b/vendor/github.com/docker/go-events/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/docker/go-events/README.md
+++ b/vendor/github.com/docker/go-events/README.md
@@ -1,0 +1,117 @@
+# Docker Events Package
+
+[![GoDoc](https://godoc.org/github.com/docker/go-events?status.svg)](https://godoc.org/github.com/docker/go-events)
+[![Circle CI](https://circleci.com/gh/docker/go-events.svg?style=shield)](https://circleci.com/gh/docker/go-events)
+
+The Docker `events` package implements a composable event distribution package
+for Go.
+
+Originally created to implement the [notifications in Docker Registry
+2](https://github.com/docker/distribution/blob/master/docs/notifications.md),
+we've found the pattern to be useful in other applications. This package is
+most of the same code with slightly updated interfaces. Much of the internals
+have been made available.
+
+## Usage
+
+The `events` package centers around a `Sink` type.  Events are written with
+calls to `Sink.Write(event Event)`. Sinks can be wired up in various
+configurations to achieve interesting behavior.
+
+The canonical example is that employed by the
+[docker/distribution/notifications](https://godoc.org/github.com/docker/distribution/notifications)
+package. Let's say we have a type `httpSink` where we'd like to queue
+notifications. As a rule, it should send a single http request and return an
+error if it fails:
+
+```go
+func (h *httpSink) Write(event Event) error {
+	p, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	body := bytes.NewReader(p)
+	resp, err := h.client.Post(h.url, "application/json", body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	
+	if resp.Status != 200 {
+		return errors.New("unexpected status")
+	}
+
+	return nil
+}
+
+// implement (*httpSink).Close()
+```
+
+With just that, we can start using components from this package. One can call
+`(*httpSink).Write` to send events as the body of a post request to a
+configured URL.
+
+### Retries
+
+HTTP can be unreliable. The first feature we'd like is to have some retry:
+
+```go
+hs := newHTTPSink(/*...*/)
+retry := NewRetryingSink(hs, NewBreaker(5, time.Second))
+```
+
+We now have a sink that will retry events against the `httpSink` until they
+succeed. The retry will backoff for one second after 5 consecutive failures
+using the breaker strategy.
+
+### Queues
+
+This isn't quite enough. We we want a sink that doesn't block while we are
+waiting for events to be sent. Let's add a `Queue`:
+
+```go
+queue := NewQueue(retry)
+```
+
+Now, we have an unbounded queue that will work through all events sent with
+`(*Queue).Write`. Events can be added asynchronously to the queue without
+blocking the current execution path. This is ideal for use in an http request.
+
+### Broadcast
+
+It usually turns out that you want to send to more than one listener. We can
+use `Broadcaster` to support this:
+
+```go
+var broadcast = NewBroadcaster() // make it available somewhere in your application.
+broadcast.Add(queue) // add your queue!
+broadcast.Add(queue2) // and another!
+```
+
+With the above, we can now call `broadcast.Write` in our http handlers and have
+all the events distributed to each queue. Because the events are queued, not
+listener blocks another.
+
+### Extending
+
+For the most part, the above is sufficient for a lot of applications. However,
+extending the above functionality can be done implementing your own `Sink`. The
+behavior and semantics of the sink can be completely dependent on the
+application requirements. The interface is provided below for reference:
+
+```go
+type Sink {
+	Write(Event) error
+	Close() error
+}
+```
+
+Application behavior can be controlled by how `Write` behaves. The examples
+above are designed to queue the message and return as quickly as possible.
+Other implementations may block until the event is committed to durable
+storage.
+
+## Copyright and license
+
+Copyright © 2016 Docker, Inc. go-events is licensed under the Apache License,
+Version 2.0. See [LICENSE](LICENSE) for the full license text.

--- a/vendor/github.com/docker/go-events/broadcast.go
+++ b/vendor/github.com/docker/go-events/broadcast.go
@@ -1,0 +1,178 @@
+package events
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// Broadcaster sends events to multiple, reliable Sinks. The goal of this
+// component is to dispatch events to configured endpoints. Reliability can be
+// provided by wrapping incoming sinks.
+type Broadcaster struct {
+	sinks   []Sink
+	events  chan Event
+	adds    chan configureRequest
+	removes chan configureRequest
+
+	shutdown chan struct{}
+	closed   chan struct{}
+	once     sync.Once
+}
+
+// NewBroadcaster appends one or more sinks to the list of sinks. The
+// broadcaster behavior will be affected by the properties of the sink.
+// Generally, the sink should accept all messages and deal with reliability on
+// its own. Use of EventQueue and RetryingSink should be used here.
+func NewBroadcaster(sinks ...Sink) *Broadcaster {
+	b := Broadcaster{
+		sinks:    sinks,
+		events:   make(chan Event),
+		adds:     make(chan configureRequest),
+		removes:  make(chan configureRequest),
+		shutdown: make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+
+	// Start the broadcaster
+	go b.run()
+
+	return &b
+}
+
+// Write accepts an event to be dispatched to all sinks. This method will never
+// fail and should never block (hopefully!). The caller cedes the memory to the
+// broadcaster and should not modify it after calling write.
+func (b *Broadcaster) Write(event Event) error {
+	select {
+	case b.events <- event:
+	case <-b.closed:
+		return ErrSinkClosed
+	}
+	return nil
+}
+
+// Add the sink to the broadcaster.
+//
+// The provided sink must be comparable with equality. Typically, this just
+// works with a regular pointer type.
+func (b *Broadcaster) Add(sink Sink) error {
+	return b.configure(b.adds, sink)
+}
+
+// Remove the provided sink.
+func (b *Broadcaster) Remove(sink Sink) error {
+	return b.configure(b.removes, sink)
+}
+
+type configureRequest struct {
+	sink     Sink
+	response chan error
+}
+
+func (b *Broadcaster) configure(ch chan configureRequest, sink Sink) error {
+	response := make(chan error, 1)
+
+	for {
+		select {
+		case ch <- configureRequest{
+			sink:     sink,
+			response: response}:
+			ch = nil
+		case err := <-response:
+			return err
+		case <-b.closed:
+			return ErrSinkClosed
+		}
+	}
+}
+
+// Close the broadcaster, ensuring that all messages are flushed to the
+// underlying sink before returning.
+func (b *Broadcaster) Close() error {
+	b.once.Do(func() {
+		close(b.shutdown)
+	})
+
+	<-b.closed
+	return nil
+}
+
+// run is the main broadcast loop, started when the broadcaster is created.
+// Under normal conditions, it waits for events on the event channel. After
+// Close is called, this goroutine will exit.
+func (b *Broadcaster) run() {
+	defer close(b.closed)
+	remove := func(target Sink) {
+		for i, sink := range b.sinks {
+			if sink == target {
+				b.sinks = append(b.sinks[:i], b.sinks[i+1:]...)
+				break
+			}
+		}
+	}
+
+	for {
+		select {
+		case event := <-b.events:
+			for _, sink := range b.sinks {
+				if err := sink.Write(event); err != nil {
+					if err == ErrSinkClosed {
+						// remove closed sinks
+						remove(sink)
+						continue
+					}
+					logrus.WithField("event", event).WithField("events.sink", sink).WithError(err).
+						Errorf("broadcaster: dropping event")
+				}
+			}
+		case request := <-b.adds:
+			// while we have to iterate for add/remove, common iteration for
+			// send is faster against slice.
+
+			var found bool
+			for _, sink := range b.sinks {
+				if request.sink == sink {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				b.sinks = append(b.sinks, request.sink)
+			}
+			// b.sinks[request.sink] = struct{}{}
+			request.response <- nil
+		case request := <-b.removes:
+			remove(request.sink)
+			request.response <- nil
+		case <-b.shutdown:
+			// close all the underlying sinks
+			for _, sink := range b.sinks {
+				if err := sink.Close(); err != nil && err != ErrSinkClosed {
+					logrus.WithField("events.sink", sink).WithError(err).
+						Errorf("broadcaster: closing sink failed")
+				}
+			}
+			return
+		}
+	}
+}
+
+func (b *Broadcaster) String() string {
+	// Serialize copy of this broadcaster without the sync.Once, to avoid
+	// a data race.
+
+	b2 := map[string]interface{}{
+		"sinks":   b.sinks,
+		"events":  b.events,
+		"adds":    b.adds,
+		"removes": b.removes,
+
+		"shutdown": b.shutdown,
+		"closed":   b.closed,
+	}
+
+	return fmt.Sprint(b2)
+}

--- a/vendor/github.com/docker/go-events/channel.go
+++ b/vendor/github.com/docker/go-events/channel.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Channel provides a sink that can be listened on. The writer and channel
+// listener must operate in separate goroutines.
+//
+// Consumers should listen on Channel.C until Closed is closed.
+type Channel struct {
+	C chan Event
+
+	closed chan struct{}
+	once   sync.Once
+}
+
+// NewChannel returns a channel. If buffer is zero, the channel is
+// unbuffered.
+func NewChannel(buffer int) *Channel {
+	return &Channel{
+		C:      make(chan Event, buffer),
+		closed: make(chan struct{}),
+	}
+}
+
+// Done returns a channel that will always proceed once the sink is closed.
+func (ch *Channel) Done() chan struct{} {
+	return ch.closed
+}
+
+// Write the event to the channel. Must be called in a separate goroutine from
+// the listener.
+func (ch *Channel) Write(event Event) error {
+	select {
+	case ch.C <- event:
+		return nil
+	case <-ch.closed:
+		return ErrSinkClosed
+	}
+}
+
+// Close the channel sink.
+func (ch *Channel) Close() error {
+	ch.once.Do(func() {
+		close(ch.closed)
+	})
+
+	return nil
+}
+
+func (ch *Channel) String() string {
+	// Serialize a copy of the Channel that doesn't contain the sync.Once,
+	// to avoid a data race.
+	ch2 := map[string]interface{}{
+		"C":      ch.C,
+		"closed": ch.closed,
+	}
+	return fmt.Sprint(ch2)
+}

--- a/vendor/github.com/docker/go-events/errors.go
+++ b/vendor/github.com/docker/go-events/errors.go
@@ -1,0 +1,10 @@
+package events
+
+import "fmt"
+
+var (
+	// ErrSinkClosed is returned if a write is issued to a sink that has been
+	// closed. If encountered, the error should be considered terminal and
+	// retries will not be successful.
+	ErrSinkClosed = fmt.Errorf("events: sink closed")
+)

--- a/vendor/github.com/docker/go-events/event.go
+++ b/vendor/github.com/docker/go-events/event.go
@@ -1,0 +1,15 @@
+package events
+
+// Event marks items that can be sent as events.
+type Event interface{}
+
+// Sink accepts and sends events.
+type Sink interface {
+	// Write an event to the Sink. If no error is returned, the caller will
+	// assume that all events have been committed to the sink. If an error is
+	// received, the caller may retry sending the event.
+	Write(event Event) error
+
+	// Close the sink, possibly waiting for pending events to flush.
+	Close() error
+}

--- a/vendor/github.com/docker/go-events/filter.go
+++ b/vendor/github.com/docker/go-events/filter.go
@@ -1,0 +1,52 @@
+package events
+
+// Matcher matches events.
+type Matcher interface {
+	Match(event Event) bool
+}
+
+// MatcherFunc implements matcher with just a function.
+type MatcherFunc func(event Event) bool
+
+// Match calls the wrapped function.
+func (fn MatcherFunc) Match(event Event) bool {
+	return fn(event)
+}
+
+// Filter provides an event sink that sends only events that are accepted by a
+// Matcher. No methods on filter are goroutine safe.
+type Filter struct {
+	dst     Sink
+	matcher Matcher
+	closed  bool
+}
+
+// NewFilter returns a new filter that will send to events to dst that return
+// true for Matcher.
+func NewFilter(dst Sink, matcher Matcher) Sink {
+	return &Filter{dst: dst, matcher: matcher}
+}
+
+// Write an event to the filter.
+func (f *Filter) Write(event Event) error {
+	if f.closed {
+		return ErrSinkClosed
+	}
+
+	if f.matcher.Match(event) {
+		return f.dst.Write(event)
+	}
+
+	return nil
+}
+
+// Close the filter and allow no more events to pass through.
+func (f *Filter) Close() error {
+	// TODO(stevvooe): Not all sinks should have Close.
+	if f.closed {
+		return nil
+	}
+
+	f.closed = true
+	return f.dst.Close()
+}

--- a/vendor/github.com/docker/go-events/queue.go
+++ b/vendor/github.com/docker/go-events/queue.go
@@ -1,0 +1,111 @@
+package events
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// Queue accepts all messages into a queue for asynchronous consumption
+// by a sink. It is unbounded and thread safe but the sink must be reliable or
+// events will be dropped.
+type Queue struct {
+	dst    Sink
+	events *list.List
+	cond   *sync.Cond
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewQueue returns a queue to the provided Sink dst.
+func NewQueue(dst Sink) *Queue {
+	eq := Queue{
+		dst:    dst,
+		events: list.New(),
+	}
+
+	eq.cond = sync.NewCond(&eq.mu)
+	go eq.run()
+	return &eq
+}
+
+// Write accepts the events into the queue, only failing if the queue has
+// beend closed.
+func (eq *Queue) Write(event Event) error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if eq.closed {
+		return ErrSinkClosed
+	}
+
+	eq.events.PushBack(event)
+	eq.cond.Signal() // signal waiters
+
+	return nil
+}
+
+// Close shutsdown the event queue, flushing
+func (eq *Queue) Close() error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if eq.closed {
+		return nil
+	}
+
+	// set closed flag
+	eq.closed = true
+	eq.cond.Signal() // signal flushes queue
+	eq.cond.Wait()   // wait for signal from last flush
+	return eq.dst.Close()
+}
+
+// run is the main goroutine to flush events to the target sink.
+func (eq *Queue) run() {
+	for {
+		event := eq.next()
+
+		if event == nil {
+			return // nil block means event queue is closed.
+		}
+
+		if err := eq.dst.Write(event); err != nil {
+			// TODO(aaronl): Dropping events could be bad depending
+			// on the application. We should have a way of
+			// communicating this condition. However, logging
+			// at a log level above debug may not be appropriate.
+			// Eventually, go-events should not use logrus at all,
+			// and should bubble up conditions like this through
+			// error values.
+			logrus.WithFields(logrus.Fields{
+				"event": event,
+				"sink":  eq.dst,
+			}).WithError(err).Debug("eventqueue: dropped event")
+		}
+	}
+}
+
+// next encompasses the critical section of the run loop. When the queue is
+// empty, it will block on the condition. If new data arrives, it will wake
+// and return a block. When closed, a nil slice will be returned.
+func (eq *Queue) next() Event {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	for eq.events.Len() < 1 {
+		if eq.closed {
+			eq.cond.Broadcast()
+			return nil
+		}
+
+		eq.cond.Wait()
+	}
+
+	front := eq.events.Front()
+	block := front.Value.(Event)
+	eq.events.Remove(front)
+
+	return block
+}

--- a/vendor/github.com/docker/go-events/retry.go
+++ b/vendor/github.com/docker/go-events/retry.go
@@ -1,0 +1,260 @@
+package events
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// RetryingSink retries the write until success or an ErrSinkClosed is
+// returned. Underlying sink must have p > 0 of succeeding or the sink will
+// block. Retry is configured with a RetryStrategy.  Concurrent calls to a
+// retrying sink are serialized through the sink, meaning that if one is
+// in-flight, another will not proceed.
+type RetryingSink struct {
+	sink     Sink
+	strategy RetryStrategy
+	closed   chan struct{}
+	once     sync.Once
+}
+
+// NewRetryingSink returns a sink that will retry writes to a sink, backing
+// off on failure. Parameters threshold and backoff adjust the behavior of the
+// circuit breaker.
+func NewRetryingSink(sink Sink, strategy RetryStrategy) *RetryingSink {
+	rs := &RetryingSink{
+		sink:     sink,
+		strategy: strategy,
+		closed:   make(chan struct{}),
+	}
+
+	return rs
+}
+
+// Write attempts to flush the events to the downstream sink until it succeeds
+// or the sink is closed.
+func (rs *RetryingSink) Write(event Event) error {
+	logger := logrus.WithField("event", event)
+
+retry:
+	select {
+	case <-rs.closed:
+		return ErrSinkClosed
+	default:
+	}
+
+	if backoff := rs.strategy.Proceed(event); backoff > 0 {
+		select {
+		case <-time.After(backoff):
+			// TODO(stevvooe): This branch holds up the next try. Before, we
+			// would simply break to the "retry" label and then possibly wait
+			// again. However, this requires all retry strategies to have a
+			// large probability of probing the sync for success, rather than
+			// just backing off and sending the request.
+		case <-rs.closed:
+			return ErrSinkClosed
+		}
+	}
+
+	if err := rs.sink.Write(event); err != nil {
+		if err == ErrSinkClosed {
+			// terminal!
+			return err
+		}
+
+		logger := logger.WithError(err) // shadow!!
+
+		if rs.strategy.Failure(event, err) {
+			logger.Errorf("retryingsink: dropped event")
+			return nil
+		}
+
+		logger.Errorf("retryingsink: error writing event, retrying")
+		goto retry
+	}
+
+	rs.strategy.Success(event)
+	return nil
+}
+
+// Close closes the sink and the underlying sink.
+func (rs *RetryingSink) Close() error {
+	rs.once.Do(func() {
+		close(rs.closed)
+	})
+
+	return nil
+}
+
+func (rs *RetryingSink) String() string {
+	// Serialize a copy of the RetryingSink without the sync.Once, to avoid
+	// a data race.
+	rs2 := map[string]interface{}{
+		"sink":     rs.sink,
+		"strategy": rs.strategy,
+		"closed":   rs.closed,
+	}
+	return fmt.Sprint(rs2)
+}
+
+// RetryStrategy defines a strategy for retrying event sink writes.
+//
+// All methods should be goroutine safe.
+type RetryStrategy interface {
+	// Proceed is called before every event send. If proceed returns a
+	// positive, non-zero integer, the retryer will back off by the provided
+	// duration.
+	//
+	// An event is provided, by may be ignored.
+	Proceed(event Event) time.Duration
+
+	// Failure reports a failure to the strategy. If this method returns true,
+	// the event should be dropped.
+	Failure(event Event, err error) bool
+
+	// Success should be called when an event is sent successfully.
+	Success(event Event)
+}
+
+// Breaker implements a circuit breaker retry strategy.
+//
+// The current implementation never drops events.
+type Breaker struct {
+	threshold int
+	recent    int
+	last      time.Time
+	backoff   time.Duration // time after which we retry after failure.
+	mu        sync.Mutex
+}
+
+var _ RetryStrategy = &Breaker{}
+
+// NewBreaker returns a breaker that will backoff after the threshold has been
+// tripped. A Breaker is thread safe and may be shared by many goroutines.
+func NewBreaker(threshold int, backoff time.Duration) *Breaker {
+	return &Breaker{
+		threshold: threshold,
+		backoff:   backoff,
+	}
+}
+
+// Proceed checks the failures against the threshold.
+func (b *Breaker) Proceed(event Event) time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.recent < b.threshold {
+		return 0
+	}
+
+	return b.last.Add(b.backoff).Sub(time.Now())
+}
+
+// Success resets the breaker.
+func (b *Breaker) Success(event Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.recent = 0
+	b.last = time.Time{}
+}
+
+// Failure records the failure and latest failure time.
+func (b *Breaker) Failure(event Event, err error) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.recent++
+	b.last = time.Now().UTC()
+	return false // never drop events.
+}
+
+var (
+	// DefaultExponentialBackoffConfig provides a default configuration for
+	// exponential backoff.
+	DefaultExponentialBackoffConfig = ExponentialBackoffConfig{
+		Base:   time.Second,
+		Factor: time.Second,
+		Max:    20 * time.Second,
+	}
+)
+
+// ExponentialBackoffConfig configures backoff parameters.
+//
+// Note that these parameters operate on the upper bound for choosing a random
+// value. For example, at Base=1s, a random value in [0,1s) will be chosen for
+// the backoff value.
+type ExponentialBackoffConfig struct {
+	// Base is the minimum bound for backing off after failure.
+	Base time.Duration
+
+	// Factor sets the amount of time by which the backoff grows with each
+	// failure.
+	Factor time.Duration
+
+	// Max is the absolute maxiumum bound for a single backoff.
+	Max time.Duration
+}
+
+// ExponentialBackoff implements random backoff with exponentially increasing
+// bounds as the number consecutive failures increase.
+type ExponentialBackoff struct {
+	config   ExponentialBackoffConfig
+	failures uint64 // consecutive failure counter.
+}
+
+// NewExponentialBackoff returns an exponential backoff strategy with the
+// desired config. If config is nil, the default is returned.
+func NewExponentialBackoff(config ExponentialBackoffConfig) *ExponentialBackoff {
+	return &ExponentialBackoff{
+		config: config,
+	}
+}
+
+// Proceed returns the next randomly bound exponential backoff time.
+func (b *ExponentialBackoff) Proceed(event Event) time.Duration {
+	return b.backoff(atomic.LoadUint64(&b.failures))
+}
+
+// Success resets the failures counter.
+func (b *ExponentialBackoff) Success(event Event) {
+	atomic.StoreUint64(&b.failures, 0)
+}
+
+// Failure increments the failure counter.
+func (b *ExponentialBackoff) Failure(event Event, err error) bool {
+	atomic.AddUint64(&b.failures, 1)
+	return false
+}
+
+// backoff calculates the amount of time to wait based on the number of
+// consecutive failures.
+func (b *ExponentialBackoff) backoff(failures uint64) time.Duration {
+	if failures <= 0 {
+		// proceed normally when there are no failures.
+		return 0
+	}
+
+	factor := b.config.Factor
+	if factor <= 0 {
+		factor = DefaultExponentialBackoffConfig.Factor
+	}
+
+	backoff := b.config.Base + factor*time.Duration(1<<(failures-1))
+
+	max := b.config.Max
+	if max <= 0 {
+		max = DefaultExponentialBackoffConfig.Max
+	}
+
+	if backoff > max || backoff < 0 {
+		backoff = max
+	}
+
+	// Choose a uniformly distributed value from [0, backoff).
+	return time.Duration(rand.Int63n(int64(backoff)))
+}

--- a/vendor/github.com/docker/swarmkit/LICENSE
+++ b/vendor/github.com/docker/swarmkit/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/docker/swarmkit/README.md
+++ b/vendor/github.com/docker/swarmkit/README.md
@@ -1,0 +1,327 @@
+# [SwarmKit](https://github.com/docker/swarmkit)
+
+[![GoDoc](https://godoc.org/github.com/docker/swarmkit?status.svg)](https://godoc.org/github.com/docker/swarmkit)
+[![Circle CI](https://circleci.com/gh/docker/swarmkit.svg?style=shield&circle-token=a7bf494e28963703a59de71cf19b73ad546058a7)](https://circleci.com/gh/docker/swarmkit)
+[![codecov.io](https://codecov.io/github/docker/swarmkit/coverage.svg?branch=master&token=LqD1dzTjsN)](https://codecov.io/github/docker/swarmkit?branch=master)
+[![Badge Badge](http://doyouevenbadge.com/github.com/docker/swarmkit)](http://doyouevenbadge.com/report/github.com/docker/swarmkit)
+
+*SwarmKit* is a toolkit for orchestrating distributed systems at any scale. It includes primitives for node discovery, raft-based consensus, task scheduling and more.
+
+Its main benefits are:
+
+-   **Distributed**: *SwarmKit* uses the [Raft Consensus Algorithm](https://raft.github.io/) in order to coordinate and does not rely on a single point of failure to perform decisions.
+-   **Secure**: Node communication and membership within a *Swarm* are secure out of the box. *SwarmKit* uses mutual TLS for node *authentication*, *role authorization* and *transport encryption*, automating both certificate issuance and rotation.
+-   **Simple**: *SwarmKit* is operationally simple and minimizes infrastructure dependencies. It does not need an external database to operate.
+
+## Overview
+
+Machines running *SwarmKit* can be grouped together in order to form a *Swarm*, coordinating tasks with each other.
+Once a machine joins, it becomes a *Swarm Node*. Nodes can either be *worker* nodes or *manager* nodes.
+
+-   **Worker Nodes** are responsible for running Tasks using an *Executor*. *SwarmKit* comes with a default *Docker Container Executor* that can be easily swapped out.
+-   **Manager Nodes** on the other hand accept specifications from the user and are responsible for reconciling the desired state with the actual cluster state.
+
+An operator can dynamically update a Node's role by promoting a Worker to Manager or demoting a Manager to Worker.
+
+*Tasks* are organized in *Services*. A service is a higher level abstraction that allows the user to declare the desired state of a group of tasks.
+Services define what type of task should be created as well as how to execute them (e.g. run this many replicas at all times) and how to update them (e.g. rolling updates).
+
+## Features
+
+Some of *SwarmKit*'s main features are:
+
+-   **Orchestration**
+
+    -   **Desired State Reconciliation**: *SwarmKit* constantly compares the desired state against the current cluster state and reconciles the two if necessary. For instance, if a node fails, *SwarmKit* reschedules its tasks onto a different node.
+
+    -   **Service Types**: There are different types of services. The project currently ships with two of them out of the box
+
+        -   **Replicated Services** are scaled to the desired number of replicas.
+        -   **Global Services** run one task on every available node in the cluster.
+
+    -   **Configurable Updates**: At any time, you can change the value of one or more fields for a service. After you make the update, *SwarmKit* reconciles the desired state by ensuring all tasks are using the desired settings. By default, it performs a lockstep update - that is, update all tasks at the same time. This can be configured through different knobs:
+
+        -   **Parallelism** defines how many updates can be performed at the same time.
+        -   **Delay** sets the minimum delay between updates. *SwarmKit* will start by shutting down the previous task, bring up a new one, wait for it to transition to the *RUNNING* state *then* wait for the additional configured delay. Finally, it will move onto other tasks.
+
+    -   **Restart Policies**: The orchestration layer monitors tasks and reacts to failures based on the specified policy. The operator can define restart conditions, delays and limits (maximum number of attempts in a given time window). *SwarmKit* can decide to restart a task on a different machine. This means that faulty nodes will gradually be drained of their tasks.
+
+-   **Scheduling**
+
+    -   **Resource Awareness**: *SwarmKit* is aware of resources available on nodes and will place tasks accordingly.
+    -   **Constraints**: Operators can limit the set of nodes where a task can be scheduled by defining constraint expressions. Multiple constraints find nodes that satisfy every expression, i.e., an `AND` match. Constraints can match node attributes in the following table. Note that `engine.labels` are collected from Docker Engine with information like operating system, drivers, etc. `node.labels` are added by cluster administrators for operational purpose. For example, some nodes have security compliant labels to run tasks with compliant requirements.
+
+        | node attribute | matches | example |
+        |:------------- |:-------------| :-------------|
+        | node.id | node's ID | `node.id == 2ivku8v2gvtg4`|
+        | node.hostname | node's hostname | `node.hostname != node-2`|
+        | node.ip | node's IP address | `node.ip != 172.19.17.0/24`|
+        | node.role |  node's manager or worker role | `node.role == manager`|
+        | node.platform.os |  node's operating system | `node.platform.os == linux`|
+        | node.platform.arch |  node's architecture | `node.platform.arch == x86_64`|
+        | node.labels | node's labels added by cluster admins | `node.labels.security == high`|
+        | engine.labels | Docker Engine's labels | `engine.labels.operatingsystem == ubuntu 14.04`|
+
+    -   **Strategies**: The project currently ships with a *spread strategy* which will attempt to schedule tasks on the least loaded
+    nodes, provided they meet the constraints and resource requirements.
+
+-   **Cluster Management**
+
+    -   **State Store**: Manager nodes maintain a strongly consistent, replicated (Raft based) and extremely fast (in-memory reads) view of the cluster which allows them to make quick scheduling decisions while tolerating failures.
+    -   **Topology Management**: Node roles (*Worker* / *Manager*) can be dynamically changed through API/CLI calls.
+    -   **Node Management**: An operator can alter the desired availability of a node: Setting it to *Paused* will prevent any further tasks from being scheduled to it while *Drained* will have the same effect while also re-scheduling its tasks somewhere else (mostly for maintenance scenarios).
+
+-   **Security**
+
+    -   **Mutual TLS**: All nodes communicate with each other using mutual *TLS*. Swarm managers act as a *Root Certificate Authority*, issuing certificates to new nodes.
+    -   **Token-based Join**: All nodes require a cryptographic token to join the swarm, which defines that node's role. Tokens can be rotated as often as desired without affecting already-joined nodes.
+    -   **Certificate Rotation**: TLS Certificates are rotated and reloaded transparently on every node, allowing a user to set how frequently rotation should happen (the current default is 3 months, the minimum is 30 minutes).
+
+## Build
+
+Requirements:
+
+-   Go 1.6 or higher
+-   A [working golang](https://golang.org/doc/code.html) environment
+-   [Protobuf 3.x or higher](https://developers.google.com/protocol-buffers/docs/downloads) to regenerate protocol buffer files (e.g. using `make generate`)
+
+*SwarmKit* is built in Go and leverages a standard project structure to work well with Go tooling.
+If you are new to Go, please see [BUILDING.md](BUILDING.md) for a more detailed guide.
+
+Once you have *SwarmKit* checked out in your `$GOPATH`, the `Makefile` can be used for common tasks.
+
+From the project root directory, run the following to build `swarmd` and `swarmctl`:
+
+```sh
+$ make binaries
+```
+
+## Test
+
+Before running tests for the first time, setup the tooling:
+
+```sh
+$ make setup
+```
+
+Then run:
+
+```sh
+$ make all
+```
+
+## Usage Examples
+
+### Setting up a Swarm
+
+These instructions assume that `swarmd` and `swarmctl` are in your PATH.
+
+(Before starting, make sure `/tmp/node-N` don't exist)
+
+Initialize the first node:
+
+```sh
+$ swarmd -d /tmp/node-1 --listen-control-api /tmp/node-1/swarm.sock --hostname node-1
+```
+
+Before joining cluster, the token should be fetched:
+
+```  
+$ export SWARM_SOCKET=/tmp/node-1/swarm.sock  
+$ swarmctl cluster inspect default  
+ID          : 87d2ecpg12dfonxp3g562fru1
+Name        : default
+Orchestration settings:
+  Task history entries: 5
+Dispatcher settings:
+  Dispatcher heartbeat period: 5s
+Certificate Authority settings:
+  Certificate Validity Duration: 2160h0m0s
+  Join Tokens:
+    Worker: SWMTKN-1-3vi7ajem0jed8guusgvyl98nfg18ibg4pclify6wzac6ucrhg3-0117z3s2ytr6egmmnlr6gd37n
+    Manager: SWMTKN-1-3vi7ajem0jed8guusgvyl98nfg18ibg4pclify6wzac6ucrhg3-d1ohk84br3ph0njyexw0wdagx
+```
+
+In two additional terminals, join two nodes. From the example below, replace `127.0.0.1:4242`
+with the address of the first node, and use the `<Worker Token>` acquired above.
+In this example, the `<Worker Token>` is `SWMTKN-1-3vi7ajem0jed8guusgvyl98nfg18ibg4pclify6wzac6ucrhg3-0117z3s2ytr6egmmnlr6gd37n`.
+If the joining nodes run on the same host as `node-1`, select a different remote
+listening port, e.g., `--listen-remote-api 127.0.0.1:4343`.
+
+```sh
+$ swarmd -d /tmp/node-2 --hostname node-2 --join-addr 127.0.0.1:4242 --join-token <Worker Token>
+$ swarmd -d /tmp/node-3 --hostname node-3 --join-addr 127.0.0.1:4242 --join-token <Worker Token>
+```
+
+In a fourth terminal, use `swarmctl` to explore and control the cluster. Before
+running `swarmctl`, set the `SWARM_SOCKET` environment variable to the path of the
+manager socket that was specified in `--listen-control-api` when starting the
+manager.
+
+To list nodes:
+
+```
+$ export SWARM_SOCKET=/tmp/node-1/swarm.sock
+$ swarmctl node ls
+ID                         Name    Membership  Status  Availability  Manager Status
+--                         ----    ----------  ------  ------------  --------------
+3x12fpoi36eujbdkgdnbvbi6r  node-2  ACCEPTED    READY   ACTIVE
+4spl3tyipofoa2iwqgabsdcve  node-1  ACCEPTED    READY   ACTIVE        REACHABLE *
+dknwk1uqxhnyyujq66ho0h54t  node-3  ACCEPTED    READY   ACTIVE
+
+
+```
+
+### Creating Services
+
+Start a *redis* service:
+
+```
+$ swarmctl service create --name redis --image redis:3.0.5
+08ecg7vc7cbf9k57qs722n2le
+```
+
+List the running services:
+
+```
+$ swarmctl service ls
+ID                         Name   Image        Replicas
+--                         ----   -----        --------
+08ecg7vc7cbf9k57qs722n2le  redis  redis:3.0.5  1/1
+```
+
+Inspect the service:
+
+```
+$ swarmctl service inspect redis
+ID                : 08ecg7vc7cbf9k57qs722n2le
+Name              : redis
+Replicas          : 1/1
+Template
+ Container
+  Image           : redis:3.0.5
+
+Task ID                      Service    Slot    Image          Desired State    Last State                Node
+-------                      -------    ----    -----          -------------    ----------                ----
+0xk1ir8wr85lbs8sqg0ug03vr    redis      1       redis:3.0.5    RUNNING          RUNNING 1 minutes ago    node-1
+```
+
+### Updating Services
+
+You can update any attribute of a service.
+
+For example, you can scale the service by changing the instance count:
+
+```
+$ swarmctl service update redis --replicas 6
+08ecg7vc7cbf9k57qs722n2le
+
+$ swarmctl service inspect redis
+ID                : 08ecg7vc7cbf9k57qs722n2le
+Name              : redis
+Replicas          : 6/6
+Template
+ Container
+  Image           : redis:3.0.5
+
+Task ID                      Service    Slot    Image          Desired State    Last State                Node
+-------                      -------    ----    -----          -------------    ----------                ----
+0xk1ir8wr85lbs8sqg0ug03vr    redis      1       redis:3.0.5    RUNNING          RUNNING 3 minutes ago    node-1
+25m48y9fevrnh77til1d09vqq    redis      2       redis:3.0.5    RUNNING          RUNNING 28 seconds ago    node-3
+42vwc8z93c884anjgpkiatnx6    redis      3       redis:3.0.5    RUNNING          RUNNING 28 seconds ago    node-2
+d41f3wnf9dex3mk6jfqp4tdjw    redis      4       redis:3.0.5    RUNNING          RUNNING 28 seconds ago    node-2
+66lefnooz63met6yfrsk6myvg    redis      5       redis:3.0.5    RUNNING          RUNNING 28 seconds ago    node-1
+3a2sawtoyk19wqhmtuiq7z9pt    redis      6       redis:3.0.5    RUNNING          RUNNING 28 seconds ago    node-3
+```
+
+Changing *replicas* from *1* to *6* forced *SwarmKit* to create *5* additional Tasks in order to
+comply with the desired state.
+
+Every other field can be changed as well, such as image, args, env, ...
+
+Let's change the image from *redis:3.0.5* to *redis:3.0.6* (e.g. upgrade):
+
+```
+$ swarmctl service update redis --image redis:3.0.6
+08ecg7vc7cbf9k57qs722n2le
+
+$ swarmctl service inspect redis
+ID                   : 08ecg7vc7cbf9k57qs722n2le
+Name                 : redis
+Replicas             : 6/6
+Update Status
+ State               : COMPLETED
+ Started             : 3 minutes ago
+ Completed           : 1 minute ago
+ Message             : update completed
+Template
+ Container
+  Image              : redis:3.0.6
+
+Task ID                      Service    Slot    Image          Desired State    Last State              Node
+-------                      -------    ----    -----          -------------    ----------              ----
+0udsjss61lmwz52pke5hd107g    redis      1       redis:3.0.6    RUNNING          RUNNING 1 minute ago    node-3
+b8o394v840thk10tamfqlwztb    redis      2       redis:3.0.6    RUNNING          RUNNING 1 minute ago    node-1
+efw7j66xqpoj3cn3zjkdrwff7    redis      3       redis:3.0.6    RUNNING          RUNNING 1 minute ago    node-3
+8ajeipzvxucs3776e4z8gemey    redis      4       redis:3.0.6    RUNNING          RUNNING 1 minute ago    node-2
+f05f2lbqzk9fh4kstwpulygvu    redis      5       redis:3.0.6    RUNNING          RUNNING 1 minute ago    node-2
+7sbpoy82deq7hu3q9cnucfin6    redis      6       redis:3.0.6    RUNNING          RUNNING 1 minute ago    node-1
+```
+
+By default, all tasks are updated at the same time.
+
+This behavior can be changed by defining update options.
+
+For instance, in order to update tasks 2 at a time and wait at least 10 seconds between updates:
+
+```
+$ swarmctl service update redis --image redis:3.0.7 --update-parallelism 2 --update-delay 10s
+$ watch -n1 "swarmctl service inspect redis"  # watch the update
+```
+
+This will update 2 tasks, wait for them to become *RUNNING*, then wait an additional 10 seconds before moving to other tasks.
+
+Update options can be set at service creation and updated later on. If an update command doesn't specify update options, the last set of options will be used.
+
+### Node Management
+
+*SwarmKit* monitors node health. In the case of node failures, it re-schedules tasks to other nodes.
+
+An operator can manually define the *Availability* of a node and can *Pause* and *Drain* nodes.
+
+Let's put `node-1` into maintenance mode:
+
+```
+$ swarmctl node drain node-1
+
+$ swarmctl node ls
+ID                         Name    Membership  Status  Availability  Manager Status
+--                         ----    ----------  ------  ------------  --------------
+3x12fpoi36eujbdkgdnbvbi6r  node-2  ACCEPTED    READY   ACTIVE
+4spl3tyipofoa2iwqgabsdcve  node-1  ACCEPTED    READY   DRAIN         REACHABLE *
+dknwk1uqxhnyyujq66ho0h54t  node-3  ACCEPTED    READY   ACTIVE
+
+$ swarmctl service inspect redis
+ID                   : 08ecg7vc7cbf9k57qs722n2le
+Name                 : redis
+Replicas             : 6/6
+Update Status
+ State               : COMPLETED
+ Started             : 2 minutes ago
+ Completed           : 1 minute ago
+ Message             : update completed
+Template
+ Container
+  Image              : redis:3.0.7
+
+Task ID                      Service    Slot    Image          Desired State    Last State                Node
+-------                      -------    ----    -----          -------------    ----------                ----
+8uy2fy8dqbwmlvw5iya802tj0    redis      1       redis:3.0.7    RUNNING          RUNNING 23 seconds ago    node-2
+7h9lgvidypcr7q1k3lfgohb42    redis      2       redis:3.0.7    RUNNING          RUNNING 2 minutes ago     node-3
+ae4dl0chk3gtwm1100t5yeged    redis      3       redis:3.0.7    RUNNING          RUNNING 23 seconds ago    node-3
+9fz7fxbg0igypstwliyameobs    redis      4       redis:3.0.7    RUNNING          RUNNING 2 minutes ago     node-3
+drzndxnjz3c8iujdewzaplgr6    redis      5       redis:3.0.7    RUNNING          RUNNING 23 seconds ago    node-2
+7rcgciqhs4239quraw7evttyf    redis      6       redis:3.0.7    RUNNING          RUNNING 2 minutes ago     node-2
+```
+
+As you can see, every Task running on `node-1` was rebalanced to either `node-2` or `node-3` by the reconciliation loop.

--- a/vendor/github.com/docker/swarmkit/vendor.conf
+++ b/vendor/github.com/docker/swarmkit/vendor.conf
@@ -1,0 +1,65 @@
+# grpc and protobuf
+google.golang.org/grpc v1.3.0
+github.com/gogo/protobuf v0.4
+github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
+github.com/matttproud/golang_protobuf_extensions v1.0.0
+google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+
+# metrics
+github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
+
+# etcd/raft
+github.com/coreos/etcd ea5389a79f40206170582c1ea076191b8622cb8e https://github.com/aaronlehmann/etcd # for https://github.com/coreos/etcd/pull/7830
+github.com/coreos/go-systemd v12
+github.com/coreos/pkg v3
+github.com/prometheus/client_golang 52437c81da6b127a9925d17eb3a382a2e5fd395e
+github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+github.com/prometheus/common ebdfc6da46522d58825777cf1f90490a5b1ef1d8
+github.com/prometheus/procfs abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
+
+github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
+github.com/docker/docker 77c9728847358a3ed3581d828fb0753017e1afd3
+github.com/docker/go-connections 34b5052da6b11e27f5f2e357b38b571ddddd3928
+github.com/docker/go-events 37d35add5005832485c0225ec870121b78fcff1c
+github.com/docker/go-units 954fed01cc617c55d838fa2230073f2cb17386c8
+github.com/docker/libkv 9fd56606e928ff1f309808f5d5a0b7a2ef73f9a8
+github.com/docker/libnetwork 37e20af882e13dd01ade3658b7aabdae3412118b
+github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
+github.com/opencontainers/runc b6b70e53451794e8333e9b602cc096b47a20bd0f
+github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
+github.com/opencontainers/image-spec f03dbe35d449c54915d235f1a3cf8f585a24babe
+
+# containerd executor
+github.com/containerd/containerd 7fc91b05917e93d474fab9465547d44eacd10ce3
+github.com/containerd/continuity f4ad4294c92f596c9241947c416d1297f9faf3ea
+github.com/containerd/fifo 69b99525e472735860a5269b75af1970142b3062
+github.com/opencontainers/runtime-spec v1.0.0-rc5
+github.com/nightlyone/lockfile 1d49c987357a327b5b03aa84cbddd582c328615d
+golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
+
+github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+github.com/Microsoft/go-winio f778f05015353be65d242f3fedc18695756153bb
+github.com/Sirupsen/logrus v0.11.0
+github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+github.com/boltdb/bolt e72f08ddb5a52992c0a44c7dda9316c7333938b2
+github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
+github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
+github.com/google/certificate-transparency 0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341
+github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
+github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
+github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+github.com/phayes/permbits f7e3ac5e859d0b919c5068d581cc4c5d4f4f9bc5
+github.com/pivotal-golang/clock 3fd3c1944c59d9742e1cd333672181cd1a6f9fa0
+github.com/pkg/errors 01fa4104b9c248c8945d14d9f128454d5b28d595
+github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
+github.com/rcrowley/go-metrics 51425a2415d21afadfd55cd93432c0bc69e9598d
+github.com/spf13/cobra 8e91712f174ced10270cf66615e0a9127e7c4de5
+github.com/spf13/pflag 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
+github.com/stretchr/testify v1.1.4
+golang.org/x/crypto 3fbbcd23f1cb824e69491a5930cfeff09b12f4d2
+golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
+golang.org/x/sys 5eaf0df67e70d6997a9fe0ed24383fa1b01638d3
+golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
+golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb

--- a/vendor/github.com/docker/swarmkit/watch/queue/queue.go
+++ b/vendor/github.com/docker/swarmkit/watch/queue/queue.go
@@ -1,0 +1,158 @@
+package queue
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/go-events"
+)
+
+// ErrQueueFull is returned by a Write operation when that Write causes the
+// queue to reach its size limit.
+var ErrQueueFull = fmt.Errorf("queue closed due to size limit")
+
+// LimitQueue accepts all messages into a queue for asynchronous consumption by
+// a sink until an upper limit of messages is reached. When that limit is
+// reached, the entire Queue is Closed. It is thread safe but the
+// sink must be reliable or events will be dropped.
+// If a size of 0 is provided, the LimitQueue is considered limitless.
+type LimitQueue struct {
+	dst        events.Sink
+	events     *list.List
+	limit      uint64
+	cond       *sync.Cond
+	mu         sync.Mutex
+	closed     bool
+	full       chan struct{}
+	fullClosed bool
+}
+
+// NewLimitQueue returns a queue to the provided Sink dst.
+func NewLimitQueue(dst events.Sink, limit uint64) *LimitQueue {
+	eq := LimitQueue{
+		dst:    dst,
+		events: list.New(),
+		limit:  limit,
+		full:   make(chan struct{}),
+	}
+
+	eq.cond = sync.NewCond(&eq.mu)
+	go eq.run()
+	return &eq
+}
+
+// Write accepts the events into the queue, only failing if the queue has
+// been closed or has reached its size limit.
+func (eq *LimitQueue) Write(event events.Event) error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if eq.closed {
+		return events.ErrSinkClosed
+	}
+
+	if eq.limit > 0 && uint64(eq.events.Len()) >= eq.limit {
+		// If the limit has been reached, don't write the event to the queue,
+		// and close the Full channel. This notifies listeners that the queue
+		// is now full, but the sink is still permitted to consume events. It's
+		// the responsibility of the listener to decide whether they want to
+		// live with dropped events or whether they want to Close() the
+		// LimitQueue
+		if !eq.fullClosed {
+			eq.fullClosed = true
+			close(eq.full)
+		}
+		return ErrQueueFull
+	}
+
+	eq.events.PushBack(event)
+	eq.cond.Signal() // signal waiters
+
+	return nil
+}
+
+// Full returns a channel that is closed when the queue becomes full for the
+// first time.
+func (eq *LimitQueue) Full() chan struct{} {
+	return eq.full
+}
+
+// Close shuts down the event queue, flushing all events
+func (eq *LimitQueue) Close() error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if eq.closed {
+		return nil
+	}
+
+	// set the closed flag
+	eq.closed = true
+	eq.cond.Signal() // signal flushes queue
+	eq.cond.Wait()   // wait for signal from last flush
+	return eq.dst.Close()
+}
+
+// run is the main goroutine to flush events to the target sink.
+func (eq *LimitQueue) run() {
+	for {
+		event := eq.next()
+
+		if event == nil {
+			return // nil block means event queue is closed.
+		}
+
+		if err := eq.dst.Write(event); err != nil {
+			// TODO(aaronl): Dropping events could be bad depending
+			// on the application. We should have a way of
+			// communicating this condition. However, logging
+			// at a log level above debug may not be appropriate.
+			// Eventually, go-events should not use logrus at all,
+			// and should bubble up conditions like this through
+			// error values.
+			logrus.WithFields(logrus.Fields{
+				"event": event,
+				"sink":  eq.dst,
+			}).WithError(err).Debug("eventqueue: dropped event")
+		}
+	}
+}
+
+// Len returns the number of items that are currently stored in the queue and
+// not consumed by its sink.
+func (eq *LimitQueue) Len() int {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+	return eq.events.Len()
+}
+
+func (eq *LimitQueue) String() string {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+	return fmt.Sprintf("%v", eq.events)
+}
+
+// next encompasses the critical section of the run loop. When the queue is
+// empty, it will block on the condition. If new data arrives, it will wake
+// and return a block. When closed, a nil slice will be returned.
+func (eq *LimitQueue) next() events.Event {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	for eq.events.Len() < 1 {
+		if eq.closed {
+			eq.cond.Broadcast()
+			return nil
+		}
+
+		eq.cond.Wait()
+	}
+
+	front := eq.events.Front()
+	block := front.Value.(events.Event)
+	eq.events.Remove(front)
+
+	return block
+}

--- a/vendor/github.com/docker/swarmkit/watch/sinks.go
+++ b/vendor/github.com/docker/swarmkit/watch/sinks.go
@@ -1,0 +1,95 @@
+package watch
+
+import (
+	"fmt"
+	"time"
+
+	events "github.com/docker/go-events"
+)
+
+// ErrSinkTimeout is returned from the Write method when a sink times out.
+var ErrSinkTimeout = fmt.Errorf("timeout exceeded, tearing down sink")
+
+// timeoutSink is a sink that wraps another sink with a timeout. If the
+// embedded sink fails to complete a Write operation within the specified
+// timeout, the Write operation of the timeoutSink fails.
+type timeoutSink struct {
+	timeout time.Duration
+	sink    events.Sink
+}
+
+func (s timeoutSink) Write(event events.Event) error {
+	errChan := make(chan error)
+	go func(c chan<- error) {
+		c <- s.sink.Write(event)
+	}(errChan)
+
+	timer := time.NewTimer(s.timeout)
+	select {
+	case err := <-errChan:
+		timer.Stop()
+		return err
+	case <-timer.C:
+		s.sink.Close()
+		return ErrSinkTimeout
+	}
+}
+
+func (s timeoutSink) Close() error {
+	return s.sink.Close()
+}
+
+// dropErrClosed is a sink that suppresses ErrSinkClosed from Write, to avoid
+// debug log messages that may be confusing. It is possible that the queue
+// will try to write an event to its destination channel while the queue is
+// being removed from the broadcaster. Since the channel is closed before the
+// queue, there is a narrow window when this is possible. In some event-based
+// dropping events when a sink is removed from a broadcaster is a problem, but
+// for the usage in this watch package that's the expected behavior.
+type dropErrClosed struct {
+	sink events.Sink
+}
+
+func (s dropErrClosed) Write(event events.Event) error {
+	err := s.sink.Write(event)
+	if err == events.ErrSinkClosed {
+		return nil
+	}
+	return err
+}
+
+func (s dropErrClosed) Close() error {
+	return s.sink.Close()
+}
+
+// dropErrClosedChanGen is a ChannelSinkGenerator for dropErrClosed sinks wrapping
+// unbuffered channels.
+type dropErrClosedChanGen struct{}
+
+func (s *dropErrClosedChanGen) NewChannelSink() (events.Sink, *events.Channel) {
+	ch := events.NewChannel(0)
+	return dropErrClosed{sink: ch}, ch
+}
+
+// TimeoutDropErrChanGen is a ChannelSinkGenerator that creates a channel,
+// wrapped by the dropErrClosed sink and a timeout.
+type TimeoutDropErrChanGen struct {
+	timeout time.Duration
+}
+
+// NewChannelSink creates a new sink chain of timeoutSink->dropErrClosed->Channel
+func (s *TimeoutDropErrChanGen) NewChannelSink() (events.Sink, *events.Channel) {
+	ch := events.NewChannel(0)
+	return timeoutSink{
+		timeout: s.timeout,
+		sink: dropErrClosed{
+			sink: ch,
+		},
+	}, ch
+}
+
+// NewTimeoutDropErrSinkGen returns a generator of timeoutSinks wrapping dropErrClosed
+// sinks, wrapping unbuffered channel sinks.
+func NewTimeoutDropErrSinkGen(timeout time.Duration) ChannelSinkGenerator {
+	return &TimeoutDropErrChanGen{timeout: timeout}
+}

--- a/vendor/github.com/docker/swarmkit/watch/watch.go
+++ b/vendor/github.com/docker/swarmkit/watch/watch.go
@@ -1,0 +1,197 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/docker/go-events"
+	"github.com/docker/swarmkit/watch/queue"
+)
+
+// ChannelSinkGenerator is a constructor of sinks that eventually lead to a
+// channel.
+type ChannelSinkGenerator interface {
+	NewChannelSink() (events.Sink, *events.Channel)
+}
+
+// Queue is the structure used to publish events and watch for them.
+type Queue struct {
+	sinkGen ChannelSinkGenerator
+	// limit is the max number of items to be held in memory for a watcher
+	limit       uint64
+	mu          sync.Mutex
+	broadcast   *events.Broadcaster
+	cancelFuncs map[events.Sink]func()
+
+	// closeOutChan indicates whether the watchers' channels should be closed
+	// when a watcher queue reaches its limit or when the Close method of the
+	// sink is called.
+	closeOutChan bool
+}
+
+// NewQueue creates a new publish/subscribe queue which supports watchers.
+// The channels that it will create for subscriptions will have the buffer
+// size specified by buffer.
+func NewQueue(options ...func(*Queue) error) *Queue {
+	// Create a queue with the default values
+	q := &Queue{
+		sinkGen:      &dropErrClosedChanGen{},
+		broadcast:    events.NewBroadcaster(),
+		cancelFuncs:  make(map[events.Sink]func()),
+		limit:        0,
+		closeOutChan: false,
+	}
+
+	for _, option := range options {
+		err := option(q)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to apply options to queue: %s", err))
+		}
+	}
+
+	return q
+}
+
+// WithTimeout returns a functional option for a queue that sets a write timeout
+func WithTimeout(timeout time.Duration) func(*Queue) error {
+	return func(q *Queue) error {
+		q.sinkGen = NewTimeoutDropErrSinkGen(timeout)
+		return nil
+	}
+}
+
+// WithCloseOutChan returns a functional option for a queue whose watcher
+// channel is closed when no more events are expected to be sent to the watcher.
+func WithCloseOutChan() func(*Queue) error {
+	return func(q *Queue) error {
+		q.closeOutChan = true
+		return nil
+	}
+}
+
+// WithLimit returns a functional option for a queue with a max size limit.
+func WithLimit(limit uint64) func(*Queue) error {
+	return func(q *Queue) error {
+		q.limit = limit
+		return nil
+	}
+}
+
+// Watch returns a channel which will receive all items published to the
+// queue from this point, until cancel is called.
+func (q *Queue) Watch() (eventq chan events.Event, cancel func()) {
+	return q.CallbackWatch(nil)
+}
+
+// WatchContext returns a channel where all items published to the queue will
+// be received. The channel will be closed when the provided context is
+// cancelled.
+func (q *Queue) WatchContext(ctx context.Context) (eventq chan events.Event) {
+	return q.CallbackWatchContext(ctx, nil)
+}
+
+// CallbackWatch returns a channel which will receive all events published to
+// the queue from this point that pass the check in the provided callback
+// function. The returned cancel function will stop the flow of events and
+// close the channel.
+func (q *Queue) CallbackWatch(matcher events.Matcher) (eventq chan events.Event, cancel func()) {
+	chanSink, ch := q.sinkGen.NewChannelSink()
+	lq := queue.NewLimitQueue(chanSink, q.limit)
+	sink := events.Sink(lq)
+
+	if matcher != nil {
+		sink = events.NewFilter(sink, matcher)
+	}
+
+	q.broadcast.Add(sink)
+
+	cancelFunc := func() {
+		q.broadcast.Remove(sink)
+		ch.Close()
+		sink.Close()
+	}
+
+	externalCancelFunc := func() {
+		q.mu.Lock()
+		cancelFunc := q.cancelFuncs[sink]
+		delete(q.cancelFuncs, sink)
+		q.mu.Unlock()
+
+		if cancelFunc != nil {
+			cancelFunc()
+		}
+	}
+
+	q.mu.Lock()
+	q.cancelFuncs[sink] = cancelFunc
+	q.mu.Unlock()
+
+	// If the output channel shouldn't be closed and the queue is limitless,
+	// there's no need for an additional goroutine.
+	if !q.closeOutChan && q.limit == 0 {
+		return ch.C, externalCancelFunc
+	}
+
+	outChan := make(chan events.Event)
+	go func() {
+		for {
+			select {
+			case <-ch.Done():
+				// Close the output channel if the ChannelSink is Done for any
+				// reason. This can happen if the cancelFunc is called
+				// externally or if it has been closed by a wrapper sink, such
+				// as the TimeoutSink.
+				if q.closeOutChan {
+					close(outChan)
+				}
+				externalCancelFunc()
+				return
+			case <-lq.Full():
+				// Close the output channel and tear down the Queue if the
+				// LimitQueue becomes full.
+				if q.closeOutChan {
+					close(outChan)
+				}
+				externalCancelFunc()
+				return
+			case event := <-ch.C:
+				outChan <- event
+			}
+		}
+	}()
+
+	return outChan, externalCancelFunc
+}
+
+// CallbackWatchContext returns a channel where all items published to the queue will
+// be received. The channel will be closed when the provided context is
+// cancelled.
+func (q *Queue) CallbackWatchContext(ctx context.Context, matcher events.Matcher) (eventq chan events.Event) {
+	c, cancel := q.CallbackWatch(matcher)
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+	return c
+}
+
+// Publish adds an item to the queue.
+func (q *Queue) Publish(item events.Event) {
+	q.broadcast.Write(item)
+}
+
+// Close closes the queue and frees the associated resources.
+func (q *Queue) Close() error {
+	// Make sure all watchers have been closed to avoid a deadlock when
+	// closing the broadcaster.
+	q.mu.Lock()
+	for _, cancelFunc := range q.cancelFuncs {
+		cancelFunc()
+	}
+	q.cancelFuncs = make(map[events.Sink]func())
+	q.mu.Unlock()
+
+	return q.broadcast.Close()
+}


### PR DESCRIPTION
Fix https://github.com/docker/swarm/issues/2718

This PR starts to move event handling for external subscribers (API users) to use the battle-tested github.com/docker/go-events repo instead of `cluster.EventHandlers` defined internally in Swarm. To be more precise, it uses the `Queue` abstraction defined in the `watch` package in github.com/docker/swarmkit.

For now, event listening by the watchdog (for rescheduling) continues to be done by the old code.