### PR TITLE
Bump version to 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.2.7 (2017-06-30)
+
+#### API
+
+- Add name filter for `network ls`
+- Allow control over where volumes get created with a whitelist label
+- Immediately flush response headers for ContainerWait requests
+- Add support for network filters on containers and label filters on volumes
+- Don't throw away most of the JSONMessage content when pulling images
+- Add progress reporting during image pulls
+- Add filter to list dangling images
+- Add OSType as a label for node constraints
+- Don't fail docker pull operations when running both Linux and Windows nodes
+- Add support for some new image build options
+- Node filters for networks and volumes
+
+#### Events
+
+- Move events handling to use watch queues from `github.com/docker/swarmkit`
+- Event stream retry interval capped to 10 seconds
+
+#### Networking
+
+- Fix refresh loop after `network ls` stopped returning containers attached to networks (for newer API versions)
+
+#### Discovery
+
+- Deprecate Docker Hub discovery (token based); to be removed in an upcoming release
+
+#### Misc
+
+- Move vendoring to use `github.com/LK4D4/vndr` instead of Godeps
+- Fix several test failures
+- Parallelize engine operations
+
 ## 1.2.6 (2017-01-17)
 
 #### API
@@ -24,7 +59,7 @@
 - Remove dependency on IPv4 addresses
 - Support event top, resize, commit and so on to avoid unnecessary refreshing
 - Sequentialize event monitor to an engine to avoid data race
-- When an active engine sends EOF on event stream, restart event monitor so we don't lose events 
+- When an active engine sends EOF on event stream, restart event monitor so we don't lose events
 - When proxying a request, cancel request if user connection is broken
 
 #### MISC

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// VERSION should be updated by hand at each release
-	VERSION = "1.2.6"
+	VERSION = "1.2.7"
 
 	// GITCOMMIT will be overwritten automatically by the build system
 	GITCOMMIT = "HEAD"


### PR DESCRIPTION
Changes between the previous release and now:

```sh
$ git log --oneline --no-merges 508b331683331a0421bdc48979a0a16885ba4e7c..9f55c32a6d8a601e4cbf33a217b9f5f2c0cacfb6
53a206f Add network ls filtering by name.
c4eeb85 Enable wrongly disabled tests and delete empty tests
676bb17 Adding deprecation message for token based discovery.
82d3319 Update network containers in refresh loop.
e15a2ea Add more cases for API versions
0f4f206 Adding counter for active event listeners
beb43c3 Moving event handling for external subscribers to use github.com/docker/go-events
56fa6e2 Vendoring github.com/docker/go-events 37d35add5005832485c0225ec870121b78fcff1c
2185096 Vendoring github.com/docker/swarmkit 97727e1e18c356435819020f02f586340a8ca812
f38030d Cleaning up ROADMAP.md
b1772c6 Adding some clarifying comments for event handling
57d7dda Updating issue template
78ae04d Debugging network inspect tests for docker 1.13, 17.03
2563728 Debugging 17.03 test failures
300d421 Updating tests to match updated vendoring
d459b8d Updating types and function calls to match updated vendoring
ddccf8e Updating and adding new dependencies
b44836b Updating docker/docker vendoring to 5eca8382b03278dc42c228b3d14dec0909ce655b
045833d Allow control over where volumes get created with a whitelist label
efe5d13 Immediately flush resp headers for wait requests
c48e43e skip zookeeper node removal test
0ceeeb7 Add support for network filters on containers and label filters on volumes
3d6584e Updating integration test to use dockerd to start daemon
f5977d8 Adding ugorji/go/ package to vendor/
8f33dca The err in the else branch can not be returned in the end
2fe2f63 Updating coreos/etcd vendoring to remove Godep dependence
02f9523 Updating CONTRIBUTING.md
6230539 Running vndr to rebuild vendor/ directory
1935464 Removing /vendor and /Godeps directories
68af1e6 Adding a vendor.conf file based on Godeps.json
03a5ca7 Spelling: affinity
8b9cf93 Docker daemon may emit EOF continuously. Don't exclude it from backoff.
5711f2c event stream retry interval should be capped
d87b7a5 Don't throw away most of the JSONMessage content when pulling images
cf61120 add dangling filters
9b99958 add debug logs for discovery change
04e0711 Confirm zk running at start
9eb1abd Catch an invalid OS error and provide a build arg suggestion
3516c4e Add OSType as a label for node constraints
880a939 Include filter error in node selection message.
1bfc554 Don't fail docker pull operations when running both Linux and Windows nodes
ba501dd Add support for some new image build options
74be118 token service on docker hub is down. Skip the tests.
f95b9e5 add inspectContainer and CreateContainerExec in engine.go and called in handler.go
40ff0d9 Use engine ID + addr instead of Swarm mode ID for engine IDs
88745e1 debug start_docker failure
aae598d parallelize engine operations
14dfdd7 cluster lock should only protect cluster data access, not locking up operations.
cc16ace Node filters for networks and volumes
bc8095d fix misspell "preceding" in cluster/watchdog.go
508086b concurrent write/flush to http.ResponseWriter or http.Flusher would cause data race
2a2e4a8 put eventsHandler maps under lock protection
13b8a69 Warn instead of erroring
45a5903 Added progress reporting during image pulls
087b7f1 Use the swarm-mode node ID for the engine ID if it's available
1c86c09 fix some comments
292d9c9 fix typo in swarm/clster
7251e1a fix some typos
7e293bd remove some redundant code
2e6e4ec Fix some miispellis in cluster/engine.go
18c7bf1 rename codegangsta to urfave
100dbaf fix warnings found by go vet
cb22bbc Eliminate fmt.Sprintf and fix some typos
993439b When rescheduling containers, don't try to create them with multiple networks
d051d68 Check for AutoRemove before skipping inspect error
8389f41 add nc to validate zookeeper running status
fd53250 Gracefully handle container removal after start
36eda67 fix typo in watchdog.go
980f1a2 fix swarm version
1884844 Use the network name instead of the ID if it was passed in during disconnects
b37f0b1 fix typo
0deb85b remove result in returns of Filter() which is unused
4f6e020 fix all typos I found in this repository
993dfc3 Avoid concurrent write on http.ResponseWriter
08f0a8a fix /event response stop immediately
```

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>