### PR TITLE
Use http client created in Swarm

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// Timeout for requests sent out to the engine.
-	requestTimeout = 10 * time.Second
+	requestTimeout = 30 * time.Second
 
 	// Threshold of delta duration between swarm manager and engine's systime
 	thresholdTime = 2 * time.Second
@@ -195,13 +195,13 @@ func (e *Engine) Connect(config *tls.Config) error {
 	e.url = url
 
 	// Use HTTP Client created above to create a dockerclient client
-	c, err := dockerclient.NewDockerClient(url.String(), config)
+	c := dockerclient.NewDockerClientFromHTTP(url, e.httpClient, config)
 	if err != nil {
 		return err
 	}
 
 	// Use HTTP Client used by dockerclient to create docker/api client
-	apiClient, err := engineapi.NewClient("tcp://"+e.Addr, "", c.HTTPClient, nil)
+	apiClient, err := engineapi.NewClient("tcp://"+e.Addr, "", e.httpClient, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/samalba/dockerclient/dockerclient.go
+++ b/vendor/github.com/samalba/dockerclient/dockerclient.go
@@ -55,6 +55,12 @@ func (e Error) Error() string {
 	return fmt.Sprintf("%s: %s", e.Status, e.msg)
 }
 
+// NewDockerClientFromHTTP assumes that the URL, HTTP Client, and TLS Config have been
+// appropriately set when passed. It chooses default values for other fields
+func NewDockerClientFromHTTP(u *url.URL, httpClient *http.Client, tlsConfig *tls.Config) *DockerClient {
+	return &DockerClient{u, httpClient, tlsConfig, 0, nil}
+}
+
 func NewDockerClient(daemonUrl string, tlsConfig *tls.Config) (*DockerClient, error) {
 	return NewDockerClientTimeout(daemonUrl, tlsConfig, time.Duration(defaultTimeout), nil)
 }


### PR DESCRIPTION
The changes made in https://github.com/docker/swarm/pull/2206 to address #1879 were lost recently. This PR re-introduces those changes. There was a similar effort in https://github.com/docker/swarm/pull/2555 but that has stalled.

This also prevents creating unnecessary extra http connections.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>