### PR TITLE
Supports image load on hybrid cluster

### DIFF
--- a/cluster/swarm/utils.go
+++ b/cluster/swarm/utils.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"regexp"
 	"strings"
 )
 
@@ -32,4 +33,14 @@ func convertMapToKVStrings(values map[string]*string) []string {
 		i++
 	}
 	return result
+}
+
+var imageEngineOSErrorPattern = regexp.MustCompile(`cannot load (.+) image on (.+)`)
+
+func isErrorLoadImageOsMismatch(err string) (match bool, imageOs, engineOs string) {
+	matches := imageEngineOSErrorPattern.FindStringSubmatch(err)
+	if len(matches) != 3 {
+		return false, "", ""
+	}
+	return true, matches[1], matches[2]
 }

--- a/cluster/swarm/utils_test.go
+++ b/cluster/swarm/utils_test.go
@@ -35,3 +35,34 @@ func TestConvertMapToKVStrings(t *testing.T) {
 	expected := []string{"HELLO=WORLD", "a=b=c=d", "e=", "f="}
 	assert.Equal(t, expected, result)
 }
+
+func TestImageLoadErrorParsing(t *testing.T) {
+	cases := []struct {
+		text     string
+		match    bool
+		imageOS  string
+		engineOS string
+	}{
+		{
+			text: "no match",
+		},
+		{
+			text:     "Failed to load image: cannot load linux image on windows",
+			match:    true,
+			imageOS:  "linux",
+			engineOS: "windows",
+		},
+		{
+			text:     "Failed to load image: cannot load windows image on linux",
+			match:    true,
+			imageOS:  "windows",
+			engineOS: "linux",
+		},
+	}
+	for _, c := range cases {
+		m, i, e := isErrorLoadImageOsMismatch(c.text)
+		assert.Equal(t, c.match, m)
+		assert.Equal(t, c.imageOS, i)
+		assert.Equal(t, c.engineOS, e)
+	}
+}


### PR DESCRIPTION
On hybrid clusters (with linux and windows nodes), `docker load` always fail because a linux node cannot load a windows image and vice-versa.

This fix the issue by parsing errors in the engine output, and ignoring OS mismatch errors