### PR TITLE
Remove cases for unsupported Docker versions in integration tests

### DIFF
--- a/test/integration/api/info.bats
+++ b/test/integration/api/info.bats
@@ -18,12 +18,6 @@ function teardown() {
 }
 
 @test "docker info - details" {
-	# details in docker info were introduced in docker 1.10, skip older version without
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 2
 	swarm_manage
 

--- a/test/integration/api/inspect.bats
+++ b/test/integration/api/inspect.bats
@@ -9,11 +9,6 @@ function teardown() {
 
 @test "docker inspect" {
 	local version="new"
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-			version="old"
-	fi
-
 	start_docker_with_busybox 2
 	swarm_manage
 	# run container
@@ -32,13 +27,8 @@ function teardown() {
 	# the specific information of swarm node
 	[[ "${output}" == *'"Node": {'* ]]
 	[[ "${output}" == *'"Name": "node-'* ]]
-	if [[ "${version}" == "old" ]]; then
-		[[ "${output}" == *'"Hostname": "hostname"'* ]]
-		[[ "${output}" == *'"Domainname": "test"'* ]]
-	else
-		[[ "${output}" == *'"Hostname": "hostname.test"'* ]]
-		[[ "${output}" == *'"Domainname": ""'* ]]
-	fi
+	[[ "${output}" == *'"Hostname": "hostname.test"'* ]]
+	[[ "${output}" == *'"Domainname": ""'* ]]
 }
 
 @test "docker inspect --format" {

--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -16,12 +16,6 @@ function teardown() {
 }
 
 @test "docker network ls --filter type" {
-	# docker network ls --filter type is introduced in docker 1.10, skip older version without --filter type
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* ]]; then
-		skip
-	fi
-
 	start_docker 2
 	swarm_manage
 
@@ -44,12 +38,6 @@ function teardown() {
 
 # docker network ls --filter node returns networks that are present on a specific node
 @test "docker network ls --filter node" {
-	# docker network ls --filter type is introduced in docker 1.10, skip older version without --filter type
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* ]]; then
-		skip
-	fi
-
 	start_docker 2
 	swarm_manage
 
@@ -64,7 +52,7 @@ function teardown() {
 @test "docker network ls --filter name" {
 	# don't bother running this for older versions
 	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* ]]; then
+	if [[ "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* ]]; then
 			skip
 	fi
 

--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -171,12 +171,6 @@ function teardown() {
 }
 
 @test "docker network connect --ip" {
-	# docker network connect --ip is introduced in docker 1.10, skip older version without --ip
-	run docker network connect --help
-	if [[ "${output}" != *"--ip"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 1
 	swarm_manage
 
@@ -198,12 +192,6 @@ function teardown() {
 }
 
 @test "docker network connect --alias" {
-	# docker network connect --alias is introduced in docker 1.10, skip older version without --alias
-	run docker network connect --help
-	if [[ "${output}" != *"--alias"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 1
 	swarm_manage
 

--- a/test/integration/api/ps.bats
+++ b/test/integration/api/ps.bats
@@ -141,10 +141,6 @@ function teardown() {
 }
 
 @test "docker ps --filter volume" {
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-		skip
-	fi
 	start_docker_with_busybox 2
 	swarm_manage
 
@@ -160,10 +156,6 @@ function teardown() {
 }
 
 @test "docker ps --filter network" {
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-		skip
-	fi
 	start_docker_with_busybox 2
 	swarm_manage
 

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -117,12 +117,6 @@ function teardown() {
 	# stop-signal
 	[[ "${output}" == *"\"StopSignal\": \"SIGKILL\""* ]]
 
-	# following options are introduced in docker 1.10, skip older version
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* ]]; then
-		skip
-	fi
-
 	docker_swarm run -d --name test_container2 \
 			 --oom-score-adj=350 \
 			 --tmpfs=/tempfs:rw \

--- a/test/integration/api/run.bats
+++ b/test/integration/api/run.bats
@@ -142,13 +142,6 @@ function teardown() {
 }
 
 @test "docker run --ip" {
-	# docker run --ip is introduced in docker 1.10, skip older version without --ip
-	# look for --ip6 because --ip will match --ipc
-	run docker run --help
-	if [[ "${output}" != *"--ip6"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 1
 	swarm_manage
 
@@ -160,13 +153,6 @@ function teardown() {
 }
 
 @test "docker run --network-alias" {
-	# docker run --net-alias was introduced in docker 1.10, and later renamed to
-	# --network-alias. Only run tests for the latter.
-	run docker run --help
-	if [[ "${output}" != *"--network-alias"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 1
 	swarm_manage
 

--- a/test/integration/api/search.bats
+++ b/test/integration/api/search.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 	local version="new"
 	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* || "${output}" == "Docker version 17.03"* ]]; then
+	if [[ "${output}" == "Docker version 1.12"* || "${output}" == "Docker version 1.13"* || "${output}" == "Docker version 17.03"* ]]; then
 			version="old"
 	fi
 

--- a/test/integration/api/update.bats
+++ b/test/integration/api/update.bats
@@ -8,12 +8,6 @@ function teardown() {
 }
 
 @test "docker update" {
-	# docker update is introduced in docker 1.10, skip older version without update command
-	run docker help update
-	if [[ "${output}" != *"Usage:	docker update"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 1
 	swarm_manage
 	docker_swarm run -d --name test_container \

--- a/test/integration/api/volume.bats
+++ b/test/integration/api/volume.bats
@@ -126,7 +126,7 @@ function teardown() {
 
 @test "docker volume ls --filter label" {
 	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* ]]; then
+	if [[ "${output}" == "Docker version 1.12"* ]]; then
 		skip
 	fi
 	start_docker_with_busybox 2
@@ -163,7 +163,7 @@ function teardown() {
 
 @test "docker volume create with whitelist" {
 	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* || "${output}" == "Docker version 1.11"* || "${output}" == "Docker version 1.12"* ]]; then
+	if [[ "${output}" == "Docker version 1.12"* ]]; then
 		skip
 	fi
 

--- a/test/integration/compose/up.bats
+++ b/test/integration/compose/up.bats
@@ -55,12 +55,6 @@ function teardown() {
 }
 
 @test "docker-compose up - check bridge network" {
-	# docker network connect --ip is introduced in docker 1.10, skip older version without --ip
-	run docker network connect --help
-	if [[ "${output}" != *"--ip"* ]]; then
-		skip
-	fi
-
 	start_docker_with_busybox 2
 	swarm_manage
 	FILE=$TESTDATA/compose/simple_v2.yml

--- a/test/integration/mesos/api/inspect.bats
+++ b/test/integration/mesos/api/inspect.bats
@@ -10,12 +10,6 @@ function teardown() {
 }
 
 @test "mesos - docker inspect" {
-	local version="new"
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-			version="old"
-	fi
-
 	start_docker_with_busybox 2
 	start_mesos
 	swarm_manage --cluster-driver mesos-experimental 127.0.0.1:$MESOS_MASTER_PORT
@@ -28,7 +22,7 @@ function teardown() {
 	[ "${#lines[@]}" -eq 2 ]
 	[[ "${lines[1]}" == *"test_container"* ]]
 
-	# inspect and verify 
+	# inspect and verify
 	run docker_swarm inspect test_container
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"NetworkSettings"* ]]
@@ -36,12 +30,7 @@ function teardown() {
 	# the specific information of swarm node
 	[[ "${output}" == *'"Node": {'* ]]
 	[[ "${output}" == *'"Name": "node-'* ]]
-	if [[ "${version}" == "old" ]]; then
-		[[ "${output}" == *'"Hostname": "hostname"'* ]]
-		[[ "${output}" == *'"Domainname": "test"'* ]]
-	else
-		[[ "${output}" == *'"Hostname": "hostname.test"'* ]]
-		[[ "${output}" == *'"Domainname": ""'* ]]
-	fi
+	[[ "${output}" == *'"Hostname": "hostname.test"'* ]]
+	[[ "${output}" == *'"Domainname": ""'* ]]
 }
 

--- a/test/integration/nodemanagement/nodehealth.bats
+++ b/test/integration/nodemanagement/nodehealth.bats
@@ -8,13 +8,6 @@ function teardown() {
 }
 
 @test "scheduler avoids failing node" {
-	# Docker issue #14203 in runC causing this test to fail.
-	# Issue fixed after Docker 1.10
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-		skip
-	fi
-
 	# Start 1 engine and register it in the file.
 	start_docker 2
 	# Start swarm and check it can reach the node
@@ -40,13 +33,6 @@ function teardown() {
 }
 
 @test "refresh loop detects failure" {
-	# Docker issue #14203 in runC causing this test to fail.
-	# Issue fixed after Docker 1.10
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-		skip
-	fi
-
 	# Start 1 engine and register it in the file.
 	start_docker 2
 	# Start swarm and check it can reach the node
@@ -70,13 +56,6 @@ function teardown() {
 }
 
 @test "scheduler retry" {
-	# Docker issue #14203 in runC causing this test to fail.
-	# Issue fixed after Docker 1.10
-	run docker --version
-	if [[ "${output}" == "Docker version 1.9"* || "${output}" == "Docker version 1.10"* ]]; then
-		skip
-	fi
-
 	# Start 1 engine and register it in the file.
 	start_docker 2
 	# Start swarm and check it can reach the node


### PR DESCRIPTION
The CI now only runs version 1.12+, so these cases are no longer needed.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>