### PR TITLE
fix nil pointer panic bug for engine network updating containers when the container id is not in engine

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -928,6 +928,11 @@ func (e *Engine) UpdateNetworkContainers(containerID string, full bool) error {
 		if err != nil {
 			return err
 		}
+		// in case the container doesn't exist on the engine
+		if ctr == nil {
+			log.Warnf("container %s doesn't exist on the engine %s, so terminate updating network for it", containerID, e.Name)
+			return nil
+		}
 		containerMap[containerID] = ctr
 	}
 


### PR DESCRIPTION
when we are running docker legacy swarm manager as a service in a docker swarm mode cluster. The legacy swarm manager is restarted several times after the following panic:
first time:
```
time="2017-07-11T07:10:33Z" level=error msg="HTTP error: No such network: vlan12" status=404
time="2017-07-11T07:29:05Z" level=error msg="HTTP error: Error response from daemon: Container d1919815443ad868fdf8b4e251a43014f7b879817bc7197a840ff84a03d10178 is not running" status=500
time="2017-07-11T07:44:24Z" level=error msg="HTTP error: No such container 100.73.39.191" status=404
time="2017-07-11T07:49:32Z" level=error msg="HTTP error: Error response from daemon: Container d226dffdffcc8c758307bcd8f019676b14767fccd7fb69689d7bf67cdbb10048 is not running" status=500
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc0 pc=0x605d0d]

goroutine 411901 [running]:
panic(0xc2b6a0, 0xc420012040)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/docker/swarm/cluster.(*Engine).UpdateNetworkContainers(0xc420de49a0, 0xc425b72bc0, 0x40, 0x1, 0x0, 0x0)
        /go/src/github.com/docker/swarm/cluster/engine.go:995 +0x19d
github.com/docker/swarm/api.proxyNetworkConnect.func1(0xc42b66e510)
        /go/src/github.com/docker/swarm/api/handlers.go:1190 +0x61
github.com/docker/swarm/api.proxyAsync.func1(0xc423818960, 0xc427e47b70, 0xc421e48b70, 0xc4277b34a0, 0x110a240, 0xc4240c51e0, 0xc427e47b60)
        /go/src/github.com/docker/swarm/api/utils.go:113 +0x2cf
created by github.com/docker/swarm/api.proxyAsync
        /go/src/github.com/docker/swarm/api/utils.go:115 +0x3a9
time="2017-07-11T07:50:13Z" level=info msg="Initializing discovery without TLS"
```
second time
```
time="2017-08-14T08:15:14Z" level=info msg="Leader Election: Cluster leadership acquired"
time="2017-08-14T08:15:31Z" level=error msg="HTTP error: Error response from daemon: IpamDriver.RequestAddress: IP address 100.73.39.209 has been used" status=500
time="2017-08-14T08:16:07Z" level=error msg="HTTP error: container 2e9353fc35153d4ab052a75bf19a6429aec0b15249e691061e773d9ef6501644 connected to network  but the network wasn't listed in the refresh loop" status=404
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc0 pc=0x605d0d]

goroutine 9769790 [running]:
panic(0xc2b6a0, 0xc420012040)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/docker/swarm/cluster.(*Engine).UpdateNetworkContainers(0xc4245e09a0, 0xc421a14ac0, 0x40, 0x1, 0x0, 0x0)
        /go/src/github.com/docker/swarm/cluster/engine.go:995 +0x19d
github.com/docker/swarm/api.proxyNetworkConnect.func1(0xc42105de60)
        /go/src/github.com/docker/swarm/api/handlers.go:1190 +0x61
github.com/docker/swarm/api.proxyAsync.func1(0xc420bef740, 0xc425826f40, 0xc4263c0a50, 0xc4260071d0, 0x110a240, 0xc4214141a0, 0xc425826f30)
        /go/src/github.com/docker/swarm/api/utils.go:113 +0x2cf
created by github.com/docker/swarm/api.proxyAsync
        /go/src/github.com/docker/swarm/api/utils.go:115 +0x3a9
Connection closed by foreign host.ontainer process caused "process_linux.go:334: running prestart hook 0 caused \"error running hook: exit status 1, stdout: , stderr: time=\\\"2017-08-14T16:16:12+08:00\\\" level=fatal msg=\\\"dial unix /run/docker/libnetwork/43d7cf498b3e6a1ae2afa070774b09817676dbe7c50765c580f199658df41e7b.sock: connect: conDisconnected from remote 
```

For finding reason of the panics above, after reading the swarm code ,I think the reason is `ctr, err := e.refreshContainer(containerID, full)` return `nil, nil` when  the container id is not in engine, so I add a check for it, hope the bug is fixed, and sorry for my previous wrong commit  =_=!!.

Signed-off-by: Xin He <hexin@jiedaibao.com>