### PR TITLE
Add --tlsminversion flag

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -25,7 +25,7 @@ var (
 				flStrategy, flFilter,
 				flHosts,
 				flLeaderElection, flLeaderTTL, flManageAdvertise,
-				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify,
+				flTLS, flTLSCaCert, flTLSCert, flTLSKey, flTLSVerify, flTLSMinVersion,
 				flRefreshIntervalMin, flRefreshIntervalMax, flFailureRetry, flRefreshRetry,
 				flHeartBeat,
 				flEnableCors,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -110,6 +110,10 @@ var (
 		Name:  "tlsverify",
 		Usage: "use TLS and verify the remote",
 	}
+	flTLSMinVersion = cli.StringFlag{
+		Name:  "tlsminversion",
+		Usage: "set the minimum TLS version to serve",
+	}
 	flStrategy = cli.StringFlag{
 		Name:  "strategy",
 		Usage: "placement strategy to use [" + strings.Join(strategy.List(), ", ") + "]",


### PR DESCRIPTION
Adds a --tlsminversion flag which allows the user to set the minimum TLS version that swarm will use.

There is no automated test for this right now because I don't know how to use `bats` and there isn't even a test for the other TLS flags right now. 