### PR TITLE
Drop support for old TLS

### DIFF
--- a/cli/manage.go
+++ b/cli/manage.go
@@ -76,7 +76,7 @@ func loadTLSConfig(ca, cert, key string, verify bool) (*tls.Config, error) {
 
 	config := &tls.Config{
 		Certificates: []tls.Certificate{c},
-		MinVersion:   tls.VersionTLS10,
+		MinVersion:   tls.VersionTLS12,
 	}
 
 	if verify {


### PR DESCRIPTION
Sets the min version of the swarm TLS config to TLSv1.2. No options, just always 1.2.

Supersedes #2811. 

/cc @nishanttotla 