### PR TITLE
Address concurrency issue

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -315,9 +315,11 @@ func (e *Engine) HealthIndicator() int64 {
 }
 
 // setState sets engine state
-func (e *Engine) setState(state engineState) {
-	e.Lock()
-	defer e.Unlock()
+func (e *Engine) setState(state engineState, lockSet bool) {
+	if !lockSet {
+		e.Lock()
+		defer e.Unlock()
+	}
 	e.state = state
 }
 
@@ -354,9 +356,11 @@ func (e *Engine) ValidationComplete() {
 }
 
 // setErrMsg sets error message for the engine
-func (e *Engine) setErrMsg(errMsg string) {
-	e.Lock()
-	defer e.Unlock()
+func (e *Engine) setErrMsg(errMsg string, lockSet bool) {
+	if !lockSet {
+		e.Lock()
+		defer e.Unlock()
+	}
 	e.lastError = strings.TrimSpace(errMsg)
 	e.updatedAt = time.Now()
 }
@@ -370,7 +374,7 @@ func (e *Engine) ErrMsg() string {
 
 // HandleIDConflict handles ID duplicate with existing engine
 func (e *Engine) HandleIDConflict(otherAddr string) {
-	e.setErrMsg(fmt.Sprintf("ID duplicated. %s shared by this node %s and another node %s", e.ID, e.Addr, otherAddr))
+	e.setErrMsg(fmt.Sprintf("ID duplicated. %s shared by this node %s and another node %s", e.ID, e.Addr, otherAddr), false)
 }
 
 // Status returns the health status of the Engine: Healthy or Unhealthy
@@ -381,9 +385,11 @@ func (e *Engine) Status() string {
 }
 
 // incFailureCount increases engine's failure count, and sets engine as unhealthy if threshold is crossed
-func (e *Engine) incFailureCount() {
-	e.Lock()
-	defer e.Unlock()
+func (e *Engine) incFailureCount(lockSet bool) {
+	if !lockSet {
+		e.Lock()
+		defer e.Unlock()
+	}
 	e.failureCount++
 	if e.state == stateHealthy && e.failureCount >= e.opts.FailureRetry {
 		e.state = stateUnhealthy
@@ -406,23 +412,29 @@ func (e *Engine) UpdatedAt() time.Time {
 	return e.updatedAt
 }
 
-func (e *Engine) resetFailureCount() {
-	e.Lock()
-	defer e.Unlock()
+func (e *Engine) resetFailureCount(lockSet bool) {
+	if !lockSet {
+		e.Lock()
+		defer e.Unlock()
+	}
 	e.failureCount = 0
 }
 
-// CheckConnectionErr checks error from client response and adjusts engine healthy indicators
 func (e *Engine) CheckConnectionErr(err error) {
+	e.checkConnectionErr(err, false)
+}
+
+// CheckConnectionErr checks error from client response and adjusts engine healthy indicators
+func (e *Engine) checkConnectionErr(err error, lockSet bool) {
 	if err == nil {
-		e.setErrMsg("")
+		e.setErrMsg("", lockSet)
 		// If current state is unhealthy, change it to healthy
 		if e.state == stateUnhealthy {
 			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Infof("Engine came back to life after %d retries. Hooray!", e.getFailureCount())
 			e.emitEvent("engine_reconnect")
-			e.setState(stateHealthy)
+			e.setState(stateHealthy, lockSet)
 		}
-		e.resetFailureCount()
+		e.resetFailureCount(lockSet)
 		return
 	}
 
@@ -432,9 +444,9 @@ func (e *Engine) CheckConnectionErr(err error) {
 		// in engine marked as unhealthy. If this causes unnecessary failure, engine
 		// can track last error time. Only increase failure count if last error is
 		// not too recent, e.g., last error is at least 1 seconds ago.
-		e.incFailureCount()
+		e.incFailureCount(lockSet)
 		// update engine error message
-		e.setErrMsg(err.Error())
+		e.setErrMsg(err.Error(), lockSet)
 		return
 	}
 	// other errors may be ambiguous.
@@ -724,6 +736,8 @@ func (e *Engine) refreshVolume(IDOrName string) error {
 // true, each container will be inspected.
 // FIXME: unexport this method after mesos scheduler stops using it directly
 func (e *Engine) RefreshContainers(full bool) error {
+	e.Lock()
+	defer e.Unlock()
 	opts := types.ContainerListOptions{
 		All:  true,
 		Size: false,
@@ -731,14 +745,14 @@ func (e *Engine) RefreshContainers(full bool) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), requestTimeout)
 	defer cancel()
 	containers, err := e.apiClient.ContainerList(ctx, opts)
-	e.CheckConnectionErr(err)
+	e.checkConnectionErr(err, true)
 	if err != nil {
 		return err
 	}
 
 	merged := make(map[string]*Container)
 	for _, c := range containers {
-		mergedUpdate, err := e.updateContainer(c, merged, full)
+		mergedUpdate, err := e.updateContainer(c, merged, full, true)
 		if err != nil {
 			log.WithFields(log.Fields{"name": e.Name, "id": e.ID}).Errorf("Unable to update state of container %q: %v", c.ID, err)
 		} else {
@@ -746,8 +760,6 @@ func (e *Engine) RefreshContainers(full bool) error {
 		}
 	}
 
-	e.Lock()
-	defer e.Unlock()
 	e.containers = merged
 
 	return nil
@@ -784,17 +796,19 @@ func (e *Engine) refreshContainer(ID string, full bool) (*Container, error) {
 		return nil, nil
 	}
 
-	_, err = e.updateContainer(containers[0], e.containers, full)
+	_, err = e.updateContainer(containers[0], e.containers, full, false)
 	e.RLock()
 	container := e.containers[containers[0].ID]
 	e.RUnlock()
 	return container, err
 }
 
-func (e *Engine) updateContainer(c types.Container, containers map[string]*Container, full bool) (map[string]*Container, error) {
+func (e *Engine) updateContainer(c types.Container, containers map[string]*Container, full bool, lockSet bool) (map[string]*Container, error) {
 	var container *Container
 
-	e.RLock()
+	if !lockSet {
+		e.RLock()
+	}
 	if current, exists := e.containers[c.ID]; exists {
 		// The container is already known.
 		container = current
@@ -814,14 +828,16 @@ func (e *Engine) updateContainer(c types.Container, containers map[string]*Conta
 	// Trade-off: If updateContainer() is called concurrently for the same
 	// container, we will end up doing a full refresh twice and the original
 	// container (containers[container.Id]) will get replaced.
-	e.RUnlock()
+	if !lockSet {
+		e.RUnlock()
+	}
 
 	c.Created = time.Unix(c.Created, 0).Add(e.DeltaDuration).Unix()
 
 	// Update ContainerInfo.
 	if full {
 		info, err := e.apiClient.ContainerInspect(context.Background(), c.ID)
-		e.CheckConnectionErr(err)
+		e.checkConnectionErr(err, lockSet)
 		if err != nil {
 			return nil, err
 		}
@@ -848,10 +864,14 @@ func (e *Engine) updateContainer(c types.Container, containers map[string]*Conta
 	}
 
 	// Update its internal state.
-	e.Lock()
+	if !lockSet {
+		e.Lock()
+	}
 	container.Container = c
 	containers[container.ID] = container
-	e.Unlock()
+	if !lockSet {
+		e.Unlock()
+	}
 
 	return containers, nil
 }

--- a/cluster/engine_test.go
+++ b/cluster/engine_test.go
@@ -58,9 +58,9 @@ func (nopCloser) Close() error {
 func TestSetEngineState(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.True(t, engine.state == statePending)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	assert.True(t, engine.state == stateUnhealthy)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, false)
 	assert.True(t, engine.state == stateHealthy)
 }
 
@@ -68,13 +68,13 @@ func TestErrMsg(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.True(t, len(engine.ErrMsg()) == 0)
 	message := "cannot connect"
-	engine.setErrMsg(message)
+	engine.setErrMsg(message, false)
 	assert.True(t, engine.ErrMsg() == message)
 }
 
 func TestCheckConnectionErr(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, false)
 	assert.True(t, engine.failureCount == 0)
 	err := engineapi.ErrorConnectionFailed("")
 	engine.CheckConnectionErr(err)
@@ -97,14 +97,14 @@ func TestCheckConnectionErr(t *testing.T) {
 
 func TestEngineFailureCount(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, false)
 	for i := 0; i < engine.opts.FailureRetry; i++ {
 		assert.True(t, engine.IsHealthy())
-		engine.incFailureCount()
+		engine.incFailureCount(false)
 	}
 	assert.False(t, engine.IsHealthy())
 	assert.True(t, engine.failureCount == engine.opts.FailureRetry)
-	engine.resetFailureCount()
+	engine.resetFailureCount(false)
 	assert.True(t, engine.failureCount == 0)
 }
 
@@ -112,11 +112,11 @@ func TestHealthIndicator(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
 	assert.True(t, engine.state == statePending)
 	assert.True(t, engine.HealthIndicator() == 0)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	assert.True(t, engine.HealthIndicator() == 0)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, false)
 	assert.True(t, engine.HealthIndicator() == 100)
-	engine.incFailureCount()
+	engine.incFailureCount(false)
 	assert.True(t, engine.HealthIndicator() == (int64)(100-100/engine.opts.FailureRetry))
 }
 
@@ -155,7 +155,7 @@ func TestOutdatedEngine(t *testing.T) {
 
 func TestEngineCpusMemory(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	assert.False(t, engine.isConnected())
 
 	apiClient := engineapimock.NewMockClient()
@@ -184,7 +184,7 @@ func TestEngineCpusMemory(t *testing.T) {
 
 func TestEngineSpecs(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	assert.False(t, engine.isConnected())
 
 	apiClient := engineapimock.NewMockClient()
@@ -224,7 +224,7 @@ func TestEngineSpecs(t *testing.T) {
 
 func TestEngineState(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	assert.False(t, engine.isConnected())
 
 	apiClient := engineapimock.NewMockClient()
@@ -360,7 +360,7 @@ func TestCreateContainer(t *testing.T) {
 		readCloser = nopCloser{bytes.NewBufferString("")}
 	)
 
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	apiClient.On("Info", mock.Anything).Return(mockInfo, nil)
 	apiClient.On("ServerVersion", mock.Anything).Return(mockVersion, nil)
 	apiClient.On("NetworkList", mock.Anything,
@@ -526,7 +526,7 @@ func TestCreateContainer(t *testing.T) {
 
 func TestImages(t *testing.T) {
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, false)
 	engine.images = []*Image{
 		{types.ImageSummary{ID: "a"}, engine},
 		{types.ImageSummary{ID: "b"}, engine},
@@ -564,7 +564,7 @@ func TestUsedCpus(t *testing.T) {
 	)
 
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateHealthy)
+	engine.setState(stateHealthy, false)
 	apiClient := engineapimock.NewMockClient()
 
 	for _, hn := range hostNcpu {
@@ -651,7 +651,7 @@ func TestContainerRemovedDuringRefresh(t *testing.T) {
 	)
 
 	engine := NewEngine("test", 0, engOpts)
-	engine.setState(stateUnhealthy)
+	engine.setState(stateUnhealthy, false)
 	assert.False(t, engine.isConnected())
 
 	// A container is removed before it can be inspected.


### PR DESCRIPTION
RefreshContainers is not thread safe and can overwrite _e.containers_ map with a dated list of containers. 
The issue can be observed during high concurrent API calls to **create** and **start** containers.
The **start** container call fails with "container ID not found".

In details: 
(Pre-req: RefreshContainers_ and _CreateContainer_ are both updating the same engine). 
Flow:
- _RefreshContainers_ is first called (issue happens with argument True or False, see below for more details) 
- Right after _RefreshContainers_ gets the list of Containers from the engine, _CreateContainer_ generates container **A** on the same worker engine and adds it to the containers map
- At this point, the list of containers _RefreshContainers_ has is missing **A** and before it returns, it overwrites the map with its "dated" list; 
- result, Container A is missing/removed from the list

Eventually, on the next _RefreshContainers_ the list of containers recover any missing container.

Ideally, refreshing the list of containers should be a "stop the world" operation, especially that the time of execution of this call is relatively slow. 
There are 2 areas that can cause the delay and the container list to be inconsistent:

1- When **full** is false and while getting the ContainerList . 
This represents the majority of what I have seen and can be mitigated with the current PR

& 2- When **full** is true and while iterating and inspecting each container in updateContainer.
Wrapping a mutex lock here, can be costly, without refactoring, not sure what is the best way to address it.

Repro:

-Run a script (ex: python) that calls container create/start API in a multithreaded fashion against a cluster ex: 3 managers 2 workers
-Some of the start calls fails with container not found (the failure is very random as it has to be tied to   _RefreshContainers_ running at the same time.

You can also start your swarm with **refresh-on-node-filter** and give the worker name as its value, next run containers/json api with filters node=<your_worker_name> multiple times in parallel with the above script

**N.B.: See later comments, solution changed to address all concurrency issue related to _RefreshContainers_**

Signed-off-by: Dani Louca <dani.louca@docker.com>