### PR TITLE
Avoid false positive errors if container networkID is not set

### DIFF
--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -952,6 +952,9 @@ func (e *Engine) UpdateNetworkContainers(containerID string, full bool) error {
 			continue
 		}
 		for _, n := range c.NetworkSettings.Networks {
+			if n.NetworkID == "" {
+				continue
+			}
 			engineNetwork, ok := e.networks[n.NetworkID]
 			if !ok {
 				// it shouldn't be the case that a network which a container is connected to wasn't


### PR DESCRIPTION
Set the Swarm logs to Debug
Create a container and make sure NOT to start it.
Wait a bit and watch the swarm logs, you will see the logs polluted with the following error message.
example:

time="2017-12-13T16:25:19Z" level=debug msg="Engine refresh succeeded, but network containers update failed: container 2fe39a5a292c8f62b4fabe5800890926899ce938115ba344abf3232250ff5b03 connected to network but the network wasn't listed in the refresh loop" id="QARB:VEOA:SKKF:3KXB:5OEH:DPJT:3VYN:Y2GJ:QFVN:E2EN:BUPP:626C|10.10.53.68:12376" name=ucpworker-1

Signed-off-by: Dani Louca <dani.louca@docker.com>