### PR TITLE
Change 'volume ls' name format to enginename/volumename for non-local drivers

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -366,20 +366,18 @@ func getVolumes(c *context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		tmp := (*volume).Volume
-		if tmp.Driver == "local" {
-			// Check if the volume matches any node filters
-			found = false
-			for _, node := range nodes {
-				if volume.Engine.Name == node {
-					found = true
-					break
-				}
+		// Check if the volume matches any node filters
+		found = false
+		for _, node := range nodes {
+			if volume.Engine.Name == node {
+				found = true
+				break
 			}
-			if len(nodes) > 0 && !found {
-				continue
-			}
-			tmp.Name = volume.Engine.Name + "/" + volume.Name
 		}
+		if len(nodes) > 0 && !found {
+			continue
+		}
+		tmp.Name = volume.Engine.Name + "/" + volume.Name
 		volumesListResponse.Volumes = append(volumesListResponse.Volumes, &tmp)
 	}
 


### PR DESCRIPTION
I am not sure why existing code limited the engine/volume naming convention to `local` drivers only. The same should apply to volume plugins, otherwise, there will be no way to tell which engine the non-local volume belongs to (ofcourse, unless you filter per specific node)

In case I am missing some design cases, ping @vieux who committed the original fix.
ping @nishanttotla @wsong as if this got accepted, it will make #2831 implementation of dangling much cleaner. 

Signed-off-by: Dani Louca <dani.louca@docker.com>