### PR TITLE
Switch from x/net/context -> context

### DIFF
--- a/api/mockclient/mock.go
+++ b/api/mockclient/mock.go
@@ -1,6 +1,7 @@
 package mockclient
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/net/context"
 )
 
 // MockClient is a mock API Client based on docker/api

--- a/api/mockclient/mock_test.go
+++ b/api/mockclient/mock_test.go
@@ -1,10 +1,9 @@
 package mockclient
 
 import (
+	"context"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/swarm/swarmclient"

--- a/api/nopclient/nop.go
+++ b/api/nopclient/nop.go
@@ -1,11 +1,10 @@
 package nopclient
 
 import (
+	"context"
 	"errors"
 	"io"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/api/nopclient/nop_test.go
+++ b/api/nopclient/nop_test.go
@@ -1,11 +1,11 @@
 package nopclient
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/docker/swarm/swarmclient"
-	"golang.org/x/net/context"
 )
 
 func TestNop(t *testing.T) {

--- a/cluster/engine.go
+++ b/cluster/engine.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -17,8 +18,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"

--- a/cluster/event_monitor.go
+++ b/cluster/event_monitor.go
@@ -1,10 +1,11 @@
 package cluster
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/swarm/swarmclient"
-	"golang.org/x/net/context"
 )
 
 //EventsMonitor monitors events

--- a/cluster/watchdog.go
+++ b/cluster/watchdog.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types/network"
-	"golang.org/x/net/context"
 )
 
 // Watchdog listens to cluster events and handles container rescheduling

--- a/swarmclient/interface.go
+++ b/swarmclient/interface.go
@@ -1,9 +1,10 @@
 package swarmclient
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 // SwarmAPIClient contains the subset of the docker/api interface relevant to Docker Swarm


### PR DESCRIPTION
As `context` is now a standart package, I have replaced `x/net/context` by `context`

Inspired by https://github.com/moby/moby/pull/36904. 

This is the bash script I used to replace it

```
find . -name "*.go" | grep -v vendor | while read f; do if fgrep -q "golang.org/x/net/context" $f; then echo $f && sed -i '' 's/golang.org\/x\/net\/context/context/g' $f && goimports -w $f; fi; done
``` 
(Unfortunately I had to edit the blank lines by hand.)

I also updated the `golang.org/x/net` to the latest commit and run the `vndr` tool. 