### PR TITLE
Strip off node name network prefixes in endpoint configs in networking configs

### DIFF
--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripNodeNamesFromNetworkingConfig(t *testing.T) {
+	networkingConfig := network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			"testnet1":               {},
+			"nodename/testnet2":      {},
+			"nodename/test/net3":     {},
+			"foo/test/net4":          {},
+			"nodename/nodename/net5": {},
+		},
+	}
+	networkingConfig = stripNodeNamesFromNetworkingConfig(networkingConfig, []string{"nodename"})
+	assert.Contains(t, networkingConfig.EndpointsConfig, "testnet1")
+	assert.Contains(t, networkingConfig.EndpointsConfig, "testnet2")
+	assert.Contains(t, networkingConfig.EndpointsConfig, "test/net3")
+	assert.Contains(t, networkingConfig.EndpointsConfig, "foo/test/net4")
+	assert.Contains(t, networkingConfig.EndpointsConfig, "nodename/net5")
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -75,6 +75,9 @@ type Cluster interface {
 	// TotalCpus returns the number of CPUs in the cluster.
 	TotalCpus() int64
 
+	// EngineNames returns the names of all the engines in the cluster.
+	EngineNames() []string
+
 	// RegisterEventHandler registers an event handler for cluster-wide events.
 	RegisterEventHandler(h EventHandler) error
 

--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -965,6 +965,15 @@ func (c *Cluster) TotalCpus() int64 {
 	return totalCpus
 }
 
+// EngineNames returns the names of all the engines in the cluster.
+func (c *Cluster) EngineNames() []string {
+	ret := make([]string, len(c.engines))
+	for _, engine := range c.engines {
+		ret = append(ret, engine.Name)
+	}
+	return ret
+}
+
 // Info returns some info about the cluster, like nb or containers / images.
 func (c *Cluster) Info() [][2]string {
 	info := [][2]string{

--- a/test/integration/api/network.bats
+++ b/test/integration/api/network.bats
@@ -222,4 +222,6 @@ function teardown() {
 
 	run docker_swarm network inspect testn
 	[[ "${output}" != *"\"Containers\": {}"* ]]
+
+	docker_swarm run -d --net node-1/testn --network-alias=foobar --name test_container2 busybox sleep 100
 }


### PR DESCRIPTION
Previously, if you specified something like:

```
docker run --rm \
  --net=mynode/testnet
  --network-alias=foobar \
  alpine
```

Swarm classic would fail because it would try to pass an endpoint config to the
daemon with `mynode/testnet` as the network name