### PR TITLE
Adding Drew Erny to maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16,6 +16,7 @@
 			"chanwit",
 			"dani-docker",
 			"dongluochen",
+                        "dperny",
 			"jimmyxian",
 			"mhbauer",
 			"vieux",
@@ -87,6 +88,11 @@
 	Name = "Dongluo Chen"
 	Email = "dong@docker.com"
 	GitHub = "dongluochen"
+
+        [people.dperny]
+        Name = "Drew Erny"
+        Email = "drew.erny@docker.com"
+        GitHub = "dperny"
 
 	[people.mhbauer]
 	Name = "Morgan Bauer"


### PR DESCRIPTION
Drew has been the rock star maintainer of swarmkit, adding him to help maintaining swarm.
Welcome Drew!
cc: @dperny @thaJeztah 
Signed-off-by: Dani Louca <dani.louca@docker.com>