### PR TITLE
Add more robust detection of node OS

### DIFF
--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -79,13 +79,37 @@ func TestMatchImageOSError(t *testing.T) {
 	cases := map[string]string{
 		`image operating system "linux" cannot be used on this platform`: "linux",
 		`image operating system "" cannot be used on this platform`:      "",
-		`not a matched string`:                                           "",
+		`not a matched string`: "",
 	}
 
 	for c, e := range cases {
 		a := MatchImageOSError(c)
 		if a != e {
 			t.Fatalf("Value: %s, expected: %v, actual: %v", c, e, a)
+		}
+	}
+}
+
+func TestMatchHostConfigError(t *testing.T) {
+	cases := map[string]string{
+		// first, the real errors
+		`Invalid isolation: "lxc" - linux only supports 'default'`:                        "linux",
+		`Invalid QoS settings: linux does not support configuration of maximum bandwidth`: "linux",
+		`Invalid QoS settings: linux does not support configuration of maximum IOPs`:      "linux",
+		`Windows does not support CPU real-time period`:                                   "windows",
+		`Windows does not support CPU real-time runtime`:                                  "windows",
+		// then, some gibberish that should still match.
+		`asl;dkfh some error Invalid isolation: "marchhare" - HAL only supports blasting dave into space`: "HAL",
+		`Invalid QoS settings: someSystem does not support configuration battlebots`:                      "someSystem",
+		`Windows does not support modding the kernel yeah that's right no open source`:                    "windows",
+		// and a negative case, just to be sure.
+		`Invalid not a real error. This shouldn't trigger anything`: "",
+	}
+
+	for test, expected := range cases {
+		result := MatchHostConfigError(test)
+		if result != expected {
+			t.Fatalf("Value %s, expected %q, actual %q", test, expected, result)
 		}
 	}
 }


### PR DESCRIPTION
Here's the deal: this in the only reasonable way to do this without writing a bunch of code to, for example, pull the image manifest and inspect it directly, which is a whole rodeo i'm not interested in getting into. It's fragile and likely to break (again) later on, but whatever.