### PR TITLE
Add better OS detection

### DIFF
--- a/api/mockclient/mock.go
+++ b/api/mockclient/mock.go
@@ -457,3 +457,8 @@ func (client *MockClient) VolumesPrune(ctx context.Context, pruneFilter filters.
 	args := client.Mock.Called(ctx, pruneFilter)
 	return args.Get(0).(types.VolumesPruneReport), args.Error(1)
 }
+
+func (client *MockClient) DistributionInspect(ctx context.Context, image, authConfig string) (registry.DistributionInspect, error) {
+	args := client.Mock.Called(ctx, image, authConfig)
+	return args.Get(0).(registry.DistributionInspect), args.Error(1)
+}

--- a/api/nopclient/nop.go
+++ b/api/nopclient/nop.go
@@ -395,3 +395,7 @@ func (client *NopClient) VolumeRemove(ctx context.Context, volumeID string, forc
 func (client *NopClient) VolumesPrune(ctx context.Context, pruneFilter filters.Args) (types.VolumesPruneReport, error) {
 	return types.VolumesPruneReport{}, errNoEngine
 }
+
+func (client *NopClient) DistributionInspect(_ context.Context, _, _ string) (registry.DistributionInspect, error) {
+	return registry.DistributionInspect{}, nil
+}

--- a/swarmclient/interface.go
+++ b/swarmclient/interface.go
@@ -1,9 +1,9 @@
 package swarmclient
 
 import (
+	"context"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"context"
 )
 
 // SwarmAPIClient contains the subset of the docker/api interface relevant to Docker Swarm
@@ -13,6 +13,7 @@ type SwarmAPIClient interface {
 	client.NetworkAPIClient
 	client.SystemAPIClient
 	client.VolumeAPIClient
+	client.DistributionAPIClient
 	ClientVersion() string
 	NegotiateAPIVersion(ctx context.Context)
 	ServerVersion(ctx context.Context) (types.Version, error)


### PR DESCRIPTION
Adds better detection of the OS type of the engine by getting the supported platforms defined in the manifest and creating an ostype constraint using them.

This is #2959 done the right way.