### PR TITLE
Archive this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Classic Swarm: a Docker-native clustering system
 
+**Classic Swarm has been archived and is no longer actively developed. You may want to
+use the Swarm mode built into the Docker Engine instead, or another orchestration system.**
+
 [![GoDoc](https://godoc.org/github.com/docker/swarm?status.png)](https://godoc.org/github.com/docker/swarm)
 [![Build Status](https://travis-ci.org/docker/swarm.svg?branch=master)](https://travis-ci.org/docker/swarm)
 [![Go Report Card](https://goreportcard.com/badge/github.com/docker/swarm)](https://goreportcard.com/report/github.com/docker/swarm)


### PR DESCRIPTION
Classic Swarm has not been actively developed for several years, so
archive it to make it clear that there will be no further updates.

The majority of people coming to this repository for the last few years
have been looking for Docker Swarm, aka Swarmkit, built into the Docker
Engine, not the confusingly named Classic Swarm that predates this.

We are not aware of active usage of this project, and we have not had
contributions or bug fixes, but the code remains open and free to use
and modify. If you fork this code, note that "Docker" remains a trademark,
so do not call your releases "Docker Swarm". You can call it Swarm or
Classic Swarm, although these names are confusing to users.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>